### PR TITLE
use &str instead of &String everywhere

### DIFF
--- a/src/bin/add/args.rs
+++ b/src/bin/add/args.rs
@@ -81,7 +81,7 @@ macro_rules! toml_table {
     ($key:expr => $value:expr) => {
         {
             let mut dep = BTreeMap::new();
-            dep.insert(String::from($key), toml::Value::String($value.clone()));
+            dep.insert(String::from($key), toml::Value::String($value.to_owned()));
             toml::Value::Table(dep)
         }
     }
@@ -104,18 +104,18 @@ fn parse_crate_name_with_version(name: &str) -> Result<Dependency, Box<Error>> {
 }
 
 /// Parse (and validate) a version requirement to the correct TOML data.
-fn parse_semver(version: &String) -> Result<toml::Value, Box<Error>> {
+fn parse_semver(version: &str) -> Result<toml::Value, Box<Error>> {
     try!(semver::VersionReq::parse(version));
-    Ok(toml::Value::String(version.clone()))
+    Ok(toml::Value::String(version.to_owned()))
 }
 
 /// Parse a git source to the correct TOML data.
-fn parse_git(repo: &String) -> Result<toml::Value, Box<Error>> {
+fn parse_git(repo: &str) -> Result<toml::Value, Box<Error>> {
     Ok(toml_table!("git" => repo))
 }
 
 /// Parse a path to the correct TOML data.
-fn parse_path(path: &String) -> Result<toml::Value, Box<Error>> {
+fn parse_path(path: &str) -> Result<toml::Value, Box<Error>> {
     Ok(toml_table!("path" => path))
 }
 

--- a/src/bin/add/args.rs
+++ b/src/bin/add/args.rs
@@ -48,11 +48,11 @@ impl Args {
         }
 
         let version = if let Some(ref version) = self.flag_ver {
-            parse_semver(&version)
+            parse_semver(version.clone())
         } else if let Some(ref repo) = self.flag_git {
-            parse_git(&repo)
+            parse_git(repo.clone())
         } else if let Some(ref path) = self.flag_path {
-            parse_path(&path)
+            parse_path(path.clone())
         } else {
             Ok(toml::Value::String(String::from("*")))
         };
@@ -81,7 +81,7 @@ macro_rules! toml_table {
     ($key:expr => $value:expr) => {
         {
             let mut dep = BTreeMap::new();
-            dep.insert(String::from($key), toml::Value::String($value.to_owned()));
+            dep.insert(String::from($key), toml::Value::String($value));
             toml::Value::Table(dep)
         }
     }
@@ -98,24 +98,24 @@ fn parse_crate_name_with_version(name: &str) -> Result<Dependency, Box<Error>> {
 
     let xs: Vec<&str> = name.splitn(2, "@").collect();
     let (name, version) = (xs[0], xs[1]);
-    let version = try!(parse_semver(&version.to_owned()));
+    let version = try!(parse_semver(version.to_owned()));
 
-    Ok((String::from(name), version))
+    Ok((name.to_owned(), version))
 }
 
 /// Parse (and validate) a version requirement to the correct TOML data.
-fn parse_semver(version: &str) -> Result<toml::Value, Box<Error>> {
-    try!(semver::VersionReq::parse(version));
-    Ok(toml::Value::String(version.to_owned()))
+fn parse_semver(version: String) -> Result<toml::Value, Box<Error>> {
+    try!(semver::VersionReq::parse(&version));
+    Ok(toml::Value::String(version))
 }
 
 /// Parse a git source to the correct TOML data.
-fn parse_git(repo: &str) -> Result<toml::Value, Box<Error>> {
+fn parse_git(repo: String) -> Result<toml::Value, Box<Error>> {
     Ok(toml_table!("git" => repo))
 }
 
 /// Parse a path to the correct TOML data.
-fn parse_path(path: &str) -> Result<toml::Value, Box<Error>> {
+fn parse_path(path: String) -> Result<toml::Value, Box<Error>> {
     Ok(toml_table!("path" => path))
 }
 

--- a/src/bin/add/main.rs
+++ b/src/bin/add/main.rs
@@ -42,13 +42,13 @@ Add a dependency to a Cargo.toml manifest file.
 ";
 
 fn handle_add(args: &Args) -> Result<(), Box<Error>> {
-    let mut manifest = try!(Manifest::open(&args.flag_manifest_path.as_ref().map(|s| &**s)));
+    let mut manifest = try!(Manifest::open(&args.flag_manifest_path.as_ref().map(|s| &s[..])));
     let dep = try!(args.parse_dependency());
 
     manifest.insert_into_table(&args.get_section(), &dep)
             .map_err(From::from)
             .and_then(|_| {
-                let mut file = try!(Manifest::find_file(&args.flag_manifest_path.as_ref().map(|s| &**s)));
+                let mut file = try!(Manifest::find_file(&args.flag_manifest_path.as_ref().map(|s| &s[..])));
                 manifest.write_to_file(&mut file)
             })
             .or_else(|err| {

--- a/src/bin/add/main.rs
+++ b/src/bin/add/main.rs
@@ -42,13 +42,13 @@ Add a dependency to a Cargo.toml manifest file.
 ";
 
 fn handle_add(args: &Args) -> Result<(), Box<Error>> {
-    let mut manifest = try!(Manifest::open(&args.flag_manifest_path.as_ref()));
+    let mut manifest = try!(Manifest::open(&args.flag_manifest_path.as_ref().map(|s| &**s)));
     let dep = try!(args.parse_dependency());
 
     manifest.insert_into_table(&args.get_section(), &dep)
             .map_err(From::from)
             .and_then(|_| {
-                let mut file = try!(Manifest::find_file(&args.flag_manifest_path.as_ref()));
+                let mut file = try!(Manifest::find_file(&args.flag_manifest_path.as_ref().map(|s| &**s)));
                 manifest.write_to_file(&mut file)
             })
             .or_else(|err| {

--- a/src/bin/list/list.rs
+++ b/src/bin/list/list.rs
@@ -8,8 +8,7 @@ use list_error::ListError;
 
 /// List the dependencies for manifest section
 #[allow(deprecated)] // connect -> join
-pub fn list_section(manifest: &Manifest, section: &str) -> Result<String, Box<Error>> {
-    let section = String::from(section);
+pub fn list_section(manifest: &Manifest, section: String) -> Result<String, Box<Error>> {
     let mut output = vec![];
 
     let list = try!(manifest.data
@@ -21,7 +20,7 @@ pub fn list_section(manifest: &Manifest, section: &str) -> Result<String, Box<Er
 
     for (name, val) in list {
         let version = match *val {
-            toml::Value::String(ref version) => version.to_owned(),
+            toml::Value::String(ref version) => version.clone(),
             toml::Value::Table(_) => {
                 let v = try!(val.lookup("version")
                                 .and_then(|field| field.as_str())
@@ -59,7 +58,7 @@ lorem-ipsum = "0.4.2""#;
     fn basic_listing() {
         let manifile: Manifest = DEFAULT_CARGO_TOML.parse().unwrap();
 
-        assert_eq!(list_section(&manifile, "dependencies").unwrap(),
+        assert_eq!(list_section(&manifile, "dependencies".to_owned()).unwrap(),
                    "\
 foo-bar     0.1
 lorem-ipsum 0.4.2");
@@ -70,6 +69,6 @@ lorem-ipsum 0.4.2");
     fn unknown_section() {
         let manifile: Manifest = DEFAULT_CARGO_TOML.parse().unwrap();
 
-        list_section(&manifile, "lol-dependencies").unwrap();
+        list_section(&manifile, "lol-dependencies".to_owned()).unwrap();
     }
 }

--- a/src/bin/list/main.rs
+++ b/src/bin/list/main.rs
@@ -65,11 +65,11 @@ impl Args {
 
 fn handle_list(args: &Args) -> Result<(), Box<Error>> {
     let listing = if args.flag_tree {
-        let manifest = try!(Manifest::open_lock_file(&args.flag_manifest_path.as_ref().map(|s| &**s)));
+        let manifest = try!(Manifest::open_lock_file(&args.flag_manifest_path.as_ref().map(|s| &s[..])));
         list_tree(&manifest)
     } else {
-        let manifest = try!(Manifest::open(&args.flag_manifest_path.as_ref().map(|s| &**s)));
-        list_section(&manifest, &args.get_section())
+        let manifest = try!(Manifest::open(&args.flag_manifest_path.as_ref().map(|s| &s[..])));
+        list_section(&manifest, args.get_section())
     };
 
     listing.map(|listing| println!("{}", listing)).or_else(|err| {

--- a/src/bin/list/main.rs
+++ b/src/bin/list/main.rs
@@ -65,10 +65,10 @@ impl Args {
 
 fn handle_list(args: &Args) -> Result<(), Box<Error>> {
     let listing = if args.flag_tree {
-        let manifest = try!(Manifest::open_lock_file(&args.flag_manifest_path.as_ref()));
+        let manifest = try!(Manifest::open_lock_file(&args.flag_manifest_path.as_ref().map(|s| &**s)));
         list_tree(&manifest)
     } else {
-        let manifest = try!(Manifest::open(&args.flag_manifest_path.as_ref()));
+        let manifest = try!(Manifest::open(&args.flag_manifest_path.as_ref().map(|s| &**s)));
         list_section(&manifest, &args.get_section())
     };
 

--- a/src/bin/list/tree.rs
+++ b/src/bin/list/tree.rs
@@ -140,8 +140,7 @@ mod test {
 
     #[test]
     fn basic_tree() {
-        let manifile = Manifest::open_lock_file(&Some(&"tests/fixtures/tree/Cargo.lock"
-                                                           .to_owned()))
+        let manifile = Manifest::open_lock_file(&Some("tests/fixtures/tree/Cargo.lock"))
                            .unwrap();
 
         assert_eq!(parse_lock_file(&manifile).unwrap(),

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -42,7 +42,7 @@ pub struct Manifest {
 /// If a manifest is specified, return that one. If a path is specified, perform a manifest search
 /// starting from there. If nothing is specified, start searching from the current directory
 /// (`cwd`).
-fn find(specified: &Option<&String>, file: CargoFile) -> Result<PathBuf, Box<Error>> {
+fn find(specified: &Option<&str>, file: CargoFile) -> Result<PathBuf, Box<Error>> {
     let file_path = specified.map(PathBuf::from);
 
     if let Some(path) = file_path {
@@ -75,7 +75,7 @@ impl Manifest {
     ///
     /// Starts at the given path an goes into its parent directories until the manifest file is
     /// found. If no path is given, the process's working directory is used as a starting point.
-    pub fn find_file(path: &Option<&String>) -> Result<File, Box<Error>> {
+    pub fn find_file(path: &Option<&str>) -> Result<File, Box<Error>> {
         find(path, CargoFile::Config).and_then(|path| {
             OpenOptions::new()
                 .read(true)
@@ -89,7 +89,7 @@ impl Manifest {
     ///
     /// Starts at the given path an goes into its parent directories until the manifest file is
     /// found. If no path is given, the process' working directory is used as a starting point.
-    pub fn find_lock_file(path: &Option<&String>) -> Result<File, Box<Error>> {
+    pub fn find_lock_file(path: &Option<&str>) -> Result<File, Box<Error>> {
         find(path, CargoFile::Lock).and_then(|path| {
             OpenOptions::new()
                 .read(true)
@@ -100,7 +100,7 @@ impl Manifest {
     }
 
     /// Open the `Cargo.toml` for a path (or the process' `cwd`)
-    pub fn open(path: &Option<&String>) -> Result<Manifest, Box<Error>> {
+    pub fn open(path: &Option<&str>) -> Result<Manifest, Box<Error>> {
         let mut file = try!(Manifest::find_file(path));
         let mut data = String::new();
         try!(file.read_to_string(&mut data));
@@ -109,7 +109,7 @@ impl Manifest {
     }
 
     /// Open the `Cargo.lock` for a path (or the process' `cwd`)
-    pub fn open_lock_file(path: &Option<&String>) -> Result<Manifest, Box<Error>> {
+    pub fn open_lock_file(path: &Option<&str>) -> Result<Manifest, Box<Error>> {
         let mut file = try!(Manifest::find_lock_file(path));
         let mut data = String::new();
         try!(file.read_to_string(&mut data));


### PR DESCRIPTION
It's a small change, but makes the code cleaner.

AFAIK `&String` is strictly inferior to `&str`; it's less flexible, for no real benefits.

[`clippy` even warns against &String](https://github.com/Manishearth/rust-clippy/wiki#ptr_arg).