### PR TITLE
Add More Integration Tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2,7 +2,7 @@
 name = "cargo-edit"
 version = "0.1.0"
 dependencies = [
- "assert_cli 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "assert_cli 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "clippy 0.0.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "curl 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "docopt 0.6.73 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -38,7 +38,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "assert_cli"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "ansi_term 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,5 +33,5 @@ quick-error = "0.1.3"
 clippy = {version = "0.0.21", optional = true}
 
 [dev-dependencies]
-assert_cli = "0.1.0"
+assert_cli = "0.2.0"
 tempdir = "0.3"

--- a/src/bin/add/fetch_version.rs
+++ b/src/bin/add/fetch_version.rs
@@ -83,7 +83,7 @@ fn handle(response: Result<http::Response, ErrCode>) -> Result<String, CratesIoE
     };
     match json::decode::<ApiErrorList>(&body) {
         Ok(errors) => {
-            return Err(CratesIoError::Api(errors.errors.into_iter().map(|s| s.detail).collect()))
+            return Err(CratesIoError::Api(errors.errors.into_iter().map(|s| s.detail).collect()));
         }
         Err(..) => {}
     }

--- a/src/bin/add/main.rs
+++ b/src/bin/add/main.rs
@@ -15,6 +15,7 @@ extern crate quick_error;
 
 use std::error::Error;
 use std::process;
+use std::io::{self, Write};
 
 extern crate cargo_edit;
 use cargo_edit::Manifest;
@@ -74,7 +75,7 @@ fn main() {
     }
 
     if let Err(err) = handle_add(&args) {
-        println!("Command failed due to unhandled error: {}", err);
+        write!(io::stderr(), "Command failed due to unhandled error: {}", err).unwrap();
         process::exit(1);
     }
 }

--- a/src/bin/add/main.rs
+++ b/src/bin/add/main.rs
@@ -75,7 +75,10 @@ fn main() {
     }
 
     if let Err(err) = handle_add(&args) {
-        write!(io::stderr(), "Command failed due to unhandled error: {}", err).unwrap();
+        write!(io::stderr(),
+               "Command failed due to unhandled error: {}",
+               err)
+            .unwrap();
         process::exit(1);
     }
 }

--- a/src/bin/list/main.rs
+++ b/src/bin/list/main.rs
@@ -12,6 +12,7 @@ extern crate toml;
 
 use std::error::Error;
 use std::process;
+use std::io::{self, Write};
 
 extern crate cargo_edit;
 use cargo_edit::Manifest;
@@ -91,7 +92,7 @@ fn main() {
     }
 
     if let Err(err) = handle_list(&args) {
-        println!("{}", err);
+        write!(io::stderr(), "{}", err).unwrap();
         process::exit(1);
     }
 }

--- a/src/bin/rm/main.rs
+++ b/src/bin/rm/main.rs
@@ -60,7 +60,10 @@ fn main() {
     }
 
     if let Err(err) = handle_rm(&args) {
-        write!(io::stderr(), "Could not edit `Cargo.toml`.\n\nERROR: {}", err).unwrap();
+        write!(io::stderr(),
+               "Could not edit `Cargo.toml`.\n\nERROR: {}",
+               err)
+            .unwrap();
         process::exit(1);
     }
 }

--- a/src/bin/rm/main.rs
+++ b/src/bin/rm/main.rs
@@ -12,6 +12,7 @@ extern crate rustc_serialize;
 
 use std::error::Error;
 use std::process;
+use std::io::{self, Write};
 
 extern crate cargo_edit;
 use cargo_edit::Manifest;
@@ -46,10 +47,6 @@ fn handle_rm(args: &Args) -> Result<(), Box<Error>> {
                                                              .map(|s| &s[..])));
                 manifest.write_to_file(&mut file)
             })
-            .or_else(|err| {
-                println!("Could not edit `Cargo.toml`.\n\nERROR: {}", err);
-                Err(err)
-            })
 }
 
 fn main() {
@@ -62,7 +59,8 @@ fn main() {
         process::exit(0);
     }
 
-    if let Err(_) = handle_rm(&args) {
+    if let Err(err) = handle_rm(&args) {
+        write!(io::stderr(), "Could not edit `Cargo.toml`.\n\nERROR: {}", err).unwrap();
         process::exit(1);
     }
 }

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -136,19 +136,16 @@ impl Manifest {
                                                 })
                                                 .ok_or(ManifestError::MissingManifest));
 
-        let new_contents = format!(
-          "[{}]\n{}{}",
-          proj_header,
-          proj_data,
-          toml::Value::Table(toml)
-        );
+        let new_contents = format!("[{}]\n{}{}",
+                                   proj_header,
+                                   proj_data,
+                                   toml::Value::Table(toml));
         let new_contents_bytes = new_contents.as_bytes();
 
         // We need to truncate the file, otherwise the new contents
         // will be mixed up with the old ones.
         try!(file.set_len(new_contents_bytes.len() as u64));
-        file.write_all(new_contents_bytes)
-            .map_err(From::from)
+        file.write_all(new_contents_bytes).map_err(From::from)
     }
 
     /// Add entry to a Cargo.toml.

--- a/tests/cargo-add.rs
+++ b/tests/cargo-add.rs
@@ -1,3 +1,5 @@
+#[macro_use]
+extern crate assert_cli;
 extern crate tempdir;
 extern crate toml;
 
@@ -147,4 +149,28 @@ fn package_kinds_are_mutually_exclusive() {
 
     assert!(!call.status.success());
     assert!(no_manifest_failures(&get_toml(&manifest)));
+}
+
+#[test]
+fn no_argument() {
+    assert_cli!("target/debug/cargo-add", &["add"] => Error 1,
+                r"Invalid arguments.
+
+Usage:
+    cargo add <crate> [--dev|--build] [--ver=<semver>|--git=<uri>|--path=<uri>] [options]
+    cargo add (-h|--help)
+    cargo add --version")
+        .unwrap();
+}
+
+#[test]
+fn unknown_flags() {
+    assert_cli!("target/debug/cargo-add", &["add", "foo", "--flag"] => Error 1,
+                r"Unknown flag: '--flag'
+
+Usage:
+    cargo add <crate> [--dev|--build] [--ver=<semver>|--git=<uri>|--path=<uri>] [options]
+    cargo add (-h|--help)
+    cargo add --version")
+        .unwrap();
 }

--- a/tests/cargo-add.rs
+++ b/tests/cargo-add.rs
@@ -3,7 +3,7 @@ extern crate toml;
 
 use std::process;
 mod utils;
-use utils::*;
+use utils::{clone_out_test, execute_command, get_toml, no_manifest_failures};
 
 #[test]
 fn adds_dependencies() {

--- a/tests/cargo-add.rs
+++ b/tests/cargo-add.rs
@@ -44,9 +44,10 @@ fn adds_dev_build_dependencies() {
 
     // cannot run with both --dev and --build at the same time
     let call = process::Command::new("target/debug/cargo-add")
-        .args(&["add", "failure", "--dev", "--build"])
-        .arg(format!("--manifest-path={}", &manifest))
-        .output().unwrap();
+                   .args(&["add", "failure", "--dev", "--build"])
+                   .arg(format!("--manifest-path={}", &manifest))
+                   .output()
+                   .unwrap();
 
     assert!(!call.status.success());
     assert!(no_manifest_failures(&get_toml(&manifest)));
@@ -69,9 +70,10 @@ fn adds_fixed_version() {
 
     // cannot run with both --dev and --build at the same time
     let call = process::Command::new("target/debug/cargo-add")
-        .args(&["add", "failure", "--ver", "invalid version string"])
-        .arg(format!("--manifest-path={}", &manifest))
-        .output().unwrap();
+                   .args(&["add", "failure", "--ver", "invalid version string"])
+                   .arg(format!("--manifest-path={}", &manifest))
+                   .output()
+                   .unwrap();
 
     assert!(!call.status.success());
     assert!(no_manifest_failures(&get_toml(&manifest)));
@@ -85,27 +87,25 @@ fn adds_git_source() {
     let toml = get_toml(&manifest);
     assert!(toml.lookup("dependencies.git-package").is_none());
 
-    execute_command(
-        &["add", "git-package", "--git", "http://localhost/git-package.git"],
-        &manifest);
+    execute_command(&["add", "git-package", "--git", "http://localhost/git-package.git"],
+                    &manifest);
 
     let toml = get_toml(&manifest);
     let val = toml.lookup("dependencies.git-package").unwrap();
     assert_eq!(val.as_table().unwrap().get("git").unwrap().as_str().unwrap(),
-        "http://localhost/git-package.git");
+               "http://localhost/git-package.git");
 
     // check this works with other flags (e.g. --dev) as well
     let toml = get_toml(&manifest);
     assert!(toml.lookup("dev-dependencies.git-dev-pkg").is_none());
 
-    execute_command(
-        &["add", "git-dev-pkg", "--git", "http://site/gp.git", "--dev"],
-        &manifest);
+    execute_command(&["add", "git-dev-pkg", "--git", "http://site/gp.git", "--dev"],
+                    &manifest);
 
     let toml = get_toml(&manifest);
     let val = toml.lookup("dev-dependencies.git-dev-pkg").unwrap();
     assert_eq!(val.as_table().unwrap().get("git").unwrap().as_str().unwrap(),
-        "http://site/gp.git");
+               "http://site/gp.git");
 }
 
 #[test]
@@ -121,18 +121,19 @@ fn adds_local_source() {
     let toml = get_toml(&manifest);
     let val = toml.lookup("dependencies.local").unwrap();
     assert_eq!(val.as_table().unwrap().get("path").unwrap().as_str().unwrap(),
-        "/path/to/pkg");
+               "/path/to/pkg");
 
     // check this works with other flags (e.g. --dev) as well
     let toml = get_toml(&manifest);
     assert!(toml.lookup("dev-dependencies.local-dev").is_none());
 
-    execute_command(&["add", "local-dev", "--path", "/path/to/pkg-dev", "--dev"], &manifest);
+    execute_command(&["add", "local-dev", "--path", "/path/to/pkg-dev", "--dev"],
+                    &manifest);
 
     let toml = get_toml(&manifest);
     let val = toml.lookup("dev-dependencies.local-dev").unwrap();
     assert_eq!(val.as_table().unwrap().get("path").unwrap().as_str().unwrap(),
-        "/path/to/pkg-dev");
+               "/path/to/pkg-dev");
 }
 
 #[test]
@@ -140,12 +141,13 @@ fn package_kinds_are_mutually_exclusive() {
     let (_tmpdir, manifest) = clone_out_test("tests/fixtures/add/Cargo.toml.sample");
 
     let call = process::Command::new("target/debug/cargo-add")
-        .args(&["add", "failure"])
-        .args(&["--ver", "0.4.3"])
-        .args(&["--git", "git://git.git"])
-        .args(&["--path", "/path/here"])
-        .arg(format!("--manifest-path={}", &manifest))
-        .output().unwrap();
+                   .args(&["add", "failure"])
+                   .args(&["--ver", "0.4.3"])
+                   .args(&["--git", "git://git.git"])
+                   .args(&["--path", "/path/here"])
+                   .arg(format!("--manifest-path={}", &manifest))
+                   .output()
+                   .unwrap();
 
     assert!(!call.status.success());
     assert!(no_manifest_failures(&get_toml(&manifest)));

--- a/tests/cargo-list.rs
+++ b/tests/cargo-list.rs
@@ -1,12 +1,10 @@
-extern crate assert_cli;
-
-use assert_cli::assert_cli_output;
+#[macro_use] extern crate assert_cli;
 
 #[test]
 fn listing() {
-    assert_cli_output("target/debug/cargo-list",
-                      &["list", "--manifest-path=tests/fixtures/list/Cargo.toml"],
-                      r"clippy          git
+    assert_cli!("target/debug/cargo-list",
+                &["list", "--manifest-path=tests/fixtures/list/Cargo.toml"] =>
+                Success, r"clippy          git
 docopt          0.6
 pad             0.1
 rustc-serialize 0.3
@@ -17,9 +15,9 @@ toml            0.1")
 
 #[test]
 fn tree() {
-    assert_cli_output("target/debug/cargo-list",
-                      &["list", "--tree", "--manifest-path=tests/fixtures/tree/Cargo.lock"],
-                      r"├── clippy (0.0.5)
+    assert_cli!("target/debug/cargo-list",
+                &["list", "--tree", "--manifest-path=tests/fixtures/tree/Cargo.lock"] =>
+                Success, r"├── clippy (0.0.5)
 ├── docopt (0.6.67)
 │   ├── regex (0.1.38)
 │   │   ├── aho-corasick (0.2.1)

--- a/tests/cargo-list.rs
+++ b/tests/cargo-list.rs
@@ -1,4 +1,5 @@
-#[macro_use] extern crate assert_cli;
+#[macro_use]
+extern crate assert_cli;
 
 #[test]
 fn listing() {
@@ -34,5 +35,17 @@ fn tree() {
 ├── semver (0.1.19)
 └── toml (0.1.20)
     └── rustc-serialize (0.3.15)")
+        .unwrap();
+}
+
+#[test]
+fn unknown_flags() {
+    assert_cli!("target/debug/cargo-list", &["list", "foo", "--flag"] => Error 1,
+                r"Unknown flag: '--flag'
+
+Usage:
+    cargo list [<section>] [options]
+    cargo list (-h|--help)
+    cargo list --version")
         .unwrap();
 }

--- a/tests/cargo-rm.rs
+++ b/tests/cargo-rm.rs
@@ -1,9 +1,7 @@
-extern crate assert_cli;
-
-use assert_cli::assert_cli_output;
+#[macro_use] extern crate assert_cli;
 
 mod utils;
-use utils::*;
+use utils::{clone_out_test, execute_command, get_toml};
 
 // https://github.com/killercup/cargo-edit/issues/32
 #[test]
@@ -28,16 +26,11 @@ fn issue_32() {
     assert!(toml.lookup("dependencies.bar").is_none());
 }
 
-
-
-
-
 #[test]
-#[ignore]
 fn no_argument() {
-    assert_cli_output("target/debug/cargo-rm",
-                      &["rm"],
-                      r"Invalid arguments.
+    assert_cli!("target/debug/cargo-rm", &["rm"] => Error 1,
+                r"Invalid arguments.
+
 Usage:
     cargo rm <crate> [--dev|--build] [options]
     cargo rm (-h|--help)
@@ -46,11 +39,9 @@ Usage:
 }
 
 #[test]
-#[ignore]
 fn unknown_flags() {
-    assert_cli_output("target/debug/cargo-rm",
-                      &["rm", "foo", "--flag"],
-                      r"Unknown flag: '--flag'
+    assert_cli!("target/debug/cargo-rm", &["rm", "foo", "--flag"] => Error 1,
+                r"Unknown flag: '--flag'
 
 Usage:
     cargo rm <crate> [--dev|--build] [options]

--- a/tests/cargo-rm.rs
+++ b/tests/cargo-rm.rs
@@ -1,4 +1,5 @@
-#[macro_use] extern crate assert_cli;
+#[macro_use]
+extern crate assert_cli;
 
 mod utils;
 use utils::{clone_out_test, execute_command, get_toml};
@@ -24,6 +25,42 @@ fn issue_32() {
     let toml = get_toml(&manifest);
     assert!(toml.lookup("dependencies.foo").is_none());
     assert!(toml.lookup("dependencies.bar").is_none());
+}
+
+#[test]
+fn invalid_dependency() {
+    let (_tmpdir, manifest) = clone_out_test("tests/fixtures/rm/Cargo.toml");
+
+    assert_cli!("target/debug/cargo-rm",
+                &["rm", "invalid_dependency_name", &format!("--manifest-path={}", manifest)]
+                => Error 1, "Could not edit `Cargo.toml`.
+
+ERROR: The dependency `invalid_dependency_name` could not be found in `dependencies`.")
+        .unwrap();
+}
+
+#[test]
+fn invalid_section() {
+    let (_tmpdir, manifest) = clone_out_test("tests/fixtures/rm/Cargo.toml");
+
+    assert_cli!("target/debug/cargo-rm",
+                &["rm", "semver", "--build", &format!("--manifest-path={}", manifest)]
+                => Error 1, "Could not edit `Cargo.toml`.
+
+ERROR: The table `build-dependencies` could not be found.")
+        .unwrap();
+}
+
+#[test]
+fn invalid_dependency_in_section() {
+    let (_tmpdir, manifest) = clone_out_test("tests/fixtures/rm/Cargo.toml");
+
+    assert_cli!("target/debug/cargo-rm",
+                &["rm", "semver", "--dev", &format!("--manifest-path={}", manifest)]
+                => Error 1, "Could not edit `Cargo.toml`.
+
+ERROR: The dependency `semver` could not be found in `dev-dependencies`.")
+        .unwrap();
 }
 
 #[test]

--- a/tests/fixtures/rm/Cargo.toml
+++ b/tests/fixtures/rm/Cargo.toml
@@ -17,3 +17,6 @@ rustc-serialize = "0.3"
 semver = "0.1"
 toml = "0.1"
 clippy = {git = "https://github.com/Manishearth/rust-clippy.git", optional = true}
+
+[dev-dependencies]
+regex = "0.1.41"

--- a/tests/utils.rs
+++ b/tests/utils.rs
@@ -5,6 +5,7 @@ use std::{fs, process};
 use std::io::prelude::*;
 use std::ffi::OsStr;
 
+/// Create temporary working directory with Cargo.toml mainifest
 pub fn clone_out_test(source: &str) -> (tempdir::TempDir, String) {
     let tmpdir = tempdir::TempDir::new("cargo-add-test")
         .ok().expect("failed to construct temporary directory");
@@ -15,6 +16,7 @@ pub fn clone_out_test(source: &str) -> (tempdir::TempDir, String) {
     (tmpdir, path)
 }
 
+/// Execute localc cargo command, includes `--manifest-path`
 pub fn execute_command<S>(command: &[S], manifest: &str) where S: AsRef<OsStr> {
     let subcommand_name = &command[0].as_ref().to_str().unwrap();
 
@@ -32,6 +34,7 @@ pub fn execute_command<S>(command: &[S], manifest: &str) where S: AsRef<OsStr> {
     }
 }
 
+/// Parse a manifest file as TOML
 pub fn get_toml(manifest_path: &str) -> toml::Value {
     let mut f = fs::File::open(manifest_path).unwrap();
     let mut s = String::new();
@@ -39,7 +42,7 @@ pub fn get_toml(manifest_path: &str) -> toml::Value {
     toml::Value::Table(toml::Parser::new(&s).parse().unwrap())
 }
 
-/// 'failure' dep not present
+/// Assert 'failure' deps are not present
 pub fn no_manifest_failures(manifest: &toml::Value) -> bool {
     manifest.lookup("dependencies.failure").is_none() &&
     manifest.lookup("dev-dependencies.failure").is_none() &&

--- a/tests/utils.rs
+++ b/tests/utils.rs
@@ -8,7 +8,8 @@ use std::ffi::OsStr;
 /// Create temporary working directory with Cargo.toml mainifest
 pub fn clone_out_test(source: &str) -> (tempdir::TempDir, String) {
     let tmpdir = tempdir::TempDir::new("cargo-add-test")
-        .ok().expect("failed to construct temporary directory");
+                     .ok()
+                     .expect("failed to construct temporary directory");
     fs::copy(source, tmpdir.path().join("Cargo.toml"))
         .unwrap_or_else(|err| panic!("could not copy test manifest: {}", err));
     let path = tmpdir.path().join("Cargo.toml").to_str().unwrap().to_string().clone();
@@ -17,14 +18,17 @@ pub fn clone_out_test(source: &str) -> (tempdir::TempDir, String) {
 }
 
 /// Execute localc cargo command, includes `--manifest-path`
-pub fn execute_command<S>(command: &[S], manifest: &str) where S: AsRef<OsStr> {
+pub fn execute_command<S>(command: &[S], manifest: &str)
+    where S: AsRef<OsStr>
+{
     let subcommand_name = &command[0].as_ref().to_str().unwrap();
 
     let call = process::Command::new(&format!("target/debug/cargo-{}", subcommand_name))
-        .args(command)
-        .arg(format!("--manifest-path={}", manifest))
-        .env("CARGO_IS_TEST", "1")
-        .output().unwrap();
+                   .args(command)
+                   .arg(format!("--manifest-path={}", manifest))
+                   .env("CARGO_IS_TEST", "1")
+                   .output()
+                   .unwrap();
 
     if !call.status.success() {
         println!("Status code: {:?}", call.status);


### PR DESCRIPTION
I added a few integration tests for basic stuff (invalid/no args) as well es more special ones for the nice error messages of `cargo rm`. Along the way, I also changed the binaries to log error to `stderr`.

Thanks for the good basis, @MrJohz!