### PR TITLE
Fix help text of cargo-list

### DIFF
--- a/src/bin/list/main.rs
+++ b/src/bin/list/main.rs
@@ -31,7 +31,7 @@ Usage:
     cargo list --version
 
 Options:
-    --manifest-path=<path>  Path to the manifest to add a dependency to.
+    --manifest-path=<path>  Path to the manifest to list dependencies of.
     --tree                  List dependencies recursively as tree.
     -h --help               Show this help page.
 


### PR DESCRIPTION
It seems the --manifest-path help text was copied from the cargo-add
command.