### PR TITLE
Treat missing sections as empty, not as error

### DIFF
--- a/src/bin/list/list.rs
+++ b/src/bin/list/list.rs
@@ -8,12 +8,10 @@ use list_error::ListError;
 #[allow(deprecated)] // connect -> join
 pub fn list_section(manifest: &Manifest, section: &str) -> Result<String, ListError> {
     let mut output = vec![];
-    let empty_list = Default::default();
 
     let list = try!(manifest.data
                             .get(section)
-                            .map(|field| field.as_table())
-                            .unwrap_or(Some(&empty_list))
+                            .and_then(|field| field.as_table())
                             .ok_or_else(|| ListError::SectionMissing(String::from(section))));
 
     let name_max_len = list.keys().map(|k| k.len()).max().unwrap_or(0);
@@ -78,9 +76,10 @@ lorem-ipsum 0.4.2");
     }
 
     #[test]
-    fn treat_unknown_section_as_empty() {
+    #[should_panic]
+    fn unknown_section() {
         let manifile: Manifest = DEFAULT_CARGO_TOML.parse().unwrap();
 
-        assert_eq!(list_section(&manifile, "lol-dependencies").unwrap(), "");
+        list_section(&manifile, "lol-dependencies").unwrap();
     }
 }

--- a/src/bin/list/list.rs
+++ b/src/bin/list/list.rs
@@ -8,10 +8,12 @@ use list_error::ListError;
 #[allow(deprecated)] // connect -> join
 pub fn list_section(manifest: &Manifest, section: &str) -> Result<String, ListError> {
     let mut output = vec![];
+    let empty_list = Default::default();
 
     let list = try!(manifest.data
                             .get(section)
-                            .and_then(|field| field.as_table())
+                            .map(|field| field.as_table())
+                            .unwrap_or(Some(&empty_list))
                             .ok_or_else(|| ListError::SectionMissing(String::from(section))));
 
     let name_max_len = list.keys().map(|k| k.len()).max().unwrap_or(0);
@@ -76,10 +78,9 @@ lorem-ipsum 0.4.2");
     }
 
     #[test]
-    #[should_panic]
-    fn unknown_section() {
+    fn treat_unknown_section_as_empty() {
         let manifile: Manifest = DEFAULT_CARGO_TOML.parse().unwrap();
 
-        list_section(&manifile, "lol-dependencies").unwrap();
+        assert_eq!(list_section(&manifile, "lol-dependencies").unwrap(), "");
     }
 }

--- a/src/bin/list/main.rs
+++ b/src/bin/list/main.rs
@@ -24,6 +24,7 @@ mod list_error;
 mod tree;
 
 use list::list_section;
+use list_error::ListError;
 use tree::parse_lock_file as list_tree;
 
 static USAGE: &'static str = r"
@@ -79,6 +80,10 @@ fn handle_list(args: &Args) -> Result<String, Box<Error>> {
     } else {
         let manifest = try!(Manifest::open(&args.flag_manifest_path.as_ref().map(|s| &s[..])));
         list_section(&manifest, args.get_section())
+            .or_else(|err| match err {
+                ListError::SectionMissing(..) => Ok("".into()),
+                _ => Err(err),
+            })
     }
     .map_err(From::from)
 }


### PR DESCRIPTION
This allows you to execute cargo list for a crate that does not have any
dependencies. A downside of this approach is that you don't get an error
anymore if you misspell the section name.

Sample `Cargo.toml` that it rejected before:

    [package]
    name = "name"
    version = "0.0.1"
    authors = ["Author Name <author@example.com>"]