### PR TITLE
`cargo add` Now Uses `--vers` Instead of `--ver`

### DIFF
--- a/src/bin/add/args.rs
+++ b/src/bin/add/args.rs
@@ -25,7 +25,7 @@ pub struct Args {
     /// build-dependency
     pub flag_build: bool,
     /// Version
-    pub flag_ver: Option<String>,
+    pub flag_vers: Option<String>,
     /// Git repo Path
     pub flag_git: Option<String>,
     /// Crate directory path
@@ -58,7 +58,7 @@ impl Args {
 
         let dependency = Dependency::new(&self.arg_crate).set_optional(self.flag_optional);
 
-        let dependency = if let Some(ref version) = self.flag_ver {
+        let dependency = if let Some(ref version) = self.flag_vers {
             try!(semver::VersionReq::parse(&version));
             dependency.set_version(version)
         } else if let Some(ref repo) = self.flag_git {
@@ -80,7 +80,7 @@ impl Default for Args {
             arg_crate: "demo".to_owned(),
             flag_dev: false,
             flag_build: false,
-            flag_ver: None,
+            flag_vers: None,
             flag_git: None,
             flag_path: None,
             flag_optional: false,
@@ -111,7 +111,7 @@ mod tests {
     fn test_dependency_parsing() {
         let args = Args {
             arg_crate: "demo".to_owned(),
-            flag_ver: Some("0.4.2".to_owned()),
+            flag_vers: Some("0.4.2".to_owned()),
             ..Args::default()
         };
 

--- a/src/bin/add/main.rs
+++ b/src/bin/add/main.rs
@@ -26,24 +26,29 @@ use args::Args;
 
 static USAGE: &'static str = r"
 Usage:
-    cargo add <crate> [--dev|--build|--optional] [--ver=<semver>|--git=<uri>|--path=<uri>] [options]
+    cargo add <crate> [--dev|--build|--optional] [--vers=<ver>|--git=<uri>|--path=<uri>] [options]
     cargo add (-h|--help)
     cargo add --version
 
-Options:
-    -D --dev                Add crate as development dependency.
-    -B --build              Add crate as build dependency.
-    --ver=<semver>          Specify the version to grab from the registry (crates.io).
+Specify what crate to add:
+    --vers <ver>            Specify the version to grab from the registry (crates.io).
                             You can also specify versions as part of the name, e.g
                             `cargo add bitflags@0.3.2`.
-    --git=<uri>             Specify a git repository to download the crate from.
-    --path=<uri>            Specify the path the crate should be loaded from.
-    --optional              Add as an optional dependency (for use in features.)
+    --git <uri>             Specify a git repository to download the crate from.
+    --path <uri>            Specify the path the crate should be loaded from.
+
+Specify where to add the crate:
+    -D --dev                Add crate as development dependency.
+    -B --build              Add crate as build dependency.
+    --optional              Add as an optional dependency (for use in features). This does not work
+                            for `dev-dependencies` or `build-dependencies`.
+
+Options:
     --manifest-path=<path>  Path to the manifest to add a dependency to.
     -h --help               Show this help page.
     --version               Show version.
 
-Add a dependency to a Cargo.toml manifest file.
+This command allows you to add a dependency to a Cargo.toml manifest file.
 ";
 
 fn handle_add(args: &Args) -> Result<(), Box<Error>> {

--- a/tests/cargo-add.rs
+++ b/tests/cargo-add.rs
@@ -61,7 +61,7 @@ fn adds_fixed_version() {
     let toml = get_toml(&manifest);
     assert!(toml.lookup("dependencies.versioned-package").is_none());
 
-    execute_command(&["add", "versioned-package", "--ver", ">=0.1.1"], &manifest);
+    execute_command(&["add", "versioned-package", "--vers", ">=0.1.1"], &manifest);
 
     // dependency present afterwards
     let toml = get_toml(&manifest);
@@ -70,7 +70,7 @@ fn adds_fixed_version() {
 
     // cannot run with both --dev and --build at the same time
     let call = process::Command::new("target/debug/cargo-add")
-                   .args(&["add", "failure", "--ver", "invalid version string"])
+                   .args(&["add", "failure", "--vers", "invalid version string"])
                    .arg(format!("--manifest-path={}", &manifest))
                    .output()
                    .unwrap();
@@ -158,7 +158,7 @@ fn package_kinds_are_mutually_exclusive() {
 
     let call = process::Command::new("target/debug/cargo-add")
                    .args(&["add", "failure"])
-                   .args(&["--ver", "0.4.3"])
+                   .args(&["--vers", "0.4.3"])
                    .args(&["--git", "git://git.git"])
                    .args(&["--path", "/path/here"])
                    .arg(format!("--manifest-path={}", &manifest))
@@ -177,7 +177,7 @@ fn adds_optional_dep() {
     let toml = get_toml(&manifest);
     assert!(toml.lookup("dependencies.versioned-package").is_none());
 
-    execute_command(&["add", "versioned-package", "--ver", ">=0.1.1", "--optional"], &manifest);
+    execute_command(&["add", "versioned-package", "--vers", ">=0.1.1", "--optional"], &manifest);
 
     // dependency present afterwards
     let toml = get_toml(&manifest);
@@ -195,7 +195,7 @@ fn failt_to_add_optional_dev_dep() {
     assert!(toml.lookup("dependencies.versioned-package").is_none());
 
     // Fails because optional dependencies must be in `dependencies` table.
-    execute_command(&["add", "versioned-package", "--ver", ">=0.1.1", "--dev", "--optional"],
+    execute_command(&["add", "versioned-package", "--vers", ">=0.1.1", "--dev", "--optional"],
                     &manifest);
 }
 
@@ -205,7 +205,7 @@ fn no_argument() {
                 r"Invalid arguments.
 
 Usage:
-    cargo add <crate> [--dev|--build|--optional] [--ver=<semver>|--git=<uri>|--path=<uri>] [options]
+    cargo add <crate> [--dev|--build|--optional] [--vers=<ver>|--git=<uri>|--path=<uri>] [options]
     cargo add (-h|--help)
     cargo add --version")
         .unwrap();
@@ -217,7 +217,7 @@ fn unknown_flags() {
                 r"Unknown flag: '--flag'
 
 Usage:
-    cargo add <crate> [--dev|--build|--optional] [--ver=<semver>|--git=<uri>|--path=<uri>] [options]
+    cargo add <crate> [--dev|--build|--optional] [--vers=<ver>|--git=<uri>|--path=<uri>] [options]
     cargo add (-h|--help)
     cargo add --version")
         .unwrap();


### PR DESCRIPTION
Also expands the CLI docs a bit.

cf. #43