### PR TITLE
Remove manifest section after its last dependency has been removed

### DIFF
--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -37,7 +37,7 @@ enum CargoFile {
 }
 
 /// A Cargo Manifest
-#[derive(Debug, PartialEq)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct Manifest {
     /// Manifest contents as TOML data
     pub data: toml::Table,
@@ -233,17 +233,12 @@ impl str::FromStr for Manifest {
 mod tests {
     use super::*;
     use dependency::Dependency;
-    use std::collections::BTreeMap;
     use toml;
 
     #[test]
     fn add_remove_dependency() {
         let mut manifest = Manifest { data: toml::Table::new() };
-        // Create a copy containing empty "dependencies" table because removing
-        //   the last entry in a table does not remove the section.
-        let mut copy = Manifest { data: toml::Table::new() };
-        copy.data.insert("dependencies".to_owned(),
-                         toml::Value::Table(BTreeMap::new()));
+        let copy = manifest.clone();
         let dep = Dependency::new("cargo-edit").set_version("0.1.0");
         let _ = manifest.insert_into_table("dependencies", &dep);
         assert!(manifest.remove_from_table("dependencies", &dep.name).is_ok());
@@ -264,6 +259,5 @@ mod tests {
         let other_dep = Dependency::new("other-dep").set_version("0.1.0");
         let _ = manifest.insert_into_table("dependencies", &other_dep);
         assert!(manifest.remove_from_table("dependencies", &dep.name).is_err());
-
     }
 }

--- a/tests/cargo-rm.rs
+++ b/tests/cargo-rm.rs
@@ -4,6 +4,21 @@ extern crate assert_cli;
 mod utils;
 use utils::{clone_out_test, execute_command, get_toml};
 
+#[test]
+fn remove_section_after_removed_last_dependency() {
+    let (_tmpdir, manifest) = clone_out_test("tests/fixtures/rm/Cargo.toml");
+
+    let toml = get_toml(&manifest);
+    assert!(toml.lookup("dev-dependencies.regex").is_some());
+    assert_eq!(toml.lookup("dev-dependencies").unwrap().as_table().unwrap().len(), 1);
+
+    execute_command(&["rm", "-D", "regex"], &manifest);
+
+    let toml = get_toml(&manifest);
+    assert!(toml.lookup("dev-dependencies.regex").is_none());
+    assert!(toml.lookup("dev-dependencies").is_none());
+}
+
 // https://github.com/killercup/cargo-edit/issues/32
 #[test]
 fn issue_32() {


### PR DESCRIPTION
This also adds another assert to the doctest, a unit test in src/manifest.rs, and an integration test in tests/cargo-rm.rs

This is checklist item 5 as part of #28.

I'd love suggestions on how to do this better:
```rust
if let Some(b) = section.get().as_table().and_then(|x| Some(x.is_empty())) {
    if b {
        section.remove();
    }
};
```