### PR TITLE
Add tests for removing existing dependencies

### DIFF
--- a/tests/fixtures/rm/Cargo.toml
+++ b/tests/fixtures/rm/Cargo.toml
@@ -6,9 +6,8 @@ version = "0.1.0"
 name = "main"
 path = "src/main.rs"
 
-[features]
-default = []
-dev = ["clippy"]
+[build-dependencies]
+semver = "0.1.0"
 
 [dependencies]
 docopt = "0.6"


### PR DESCRIPTION
This adds `remove_existing_dependency` and
`remove_existing_dependency_from_specific_section` to test removing
dependencies from arbitrary, build, and dev sections.

This also modifies the Cargo.toml fixture to add a build section to test
removing from this section.