### PR TITLE
Refactor `cargo list` (cf. #50)

### DIFF
--- a/src/bin/list/list.rs
+++ b/src/bin/list/list.rs
@@ -1,5 +1,3 @@
-use std::error::Error;
-
 use pad::{Alignment, PadStr};
 use toml;
 
@@ -8,7 +6,7 @@ use list_error::ListError;
 
 /// List the dependencies for manifest section
 #[allow(deprecated)] // connect -> join
-pub fn list_section(manifest: &Manifest, section: &str) -> Result<String, Box<Error>> {
+pub fn list_section(manifest: &Manifest, section: &str) -> Result<String, ListError> {
     let mut output = vec![];
 
     let list = try!(manifest.data
@@ -26,7 +24,7 @@ pub fn list_section(manifest: &Manifest, section: &str) -> Result<String, Box<Er
                         .and_then(|field| field.as_str().map(|s| s.to_owned()))
                         .or_else(|| val.lookup("git").map(|repo| format!("git: {}", repo)))
                         .or_else(|| val.lookup("path").map(|path| format!("path: {}", path)))
-                        .ok_or(ListError::VersionMissing(name.clone())))
+                        .ok_or_else(|| ListError::VersionMissing(name.clone(), section.to_owned())))
             }
             _ => String::from(""),
         };

--- a/src/bin/list/list.rs
+++ b/src/bin/list/list.rs
@@ -31,10 +31,23 @@ pub fn list_section(manifest: &Manifest, section: &str) -> Result<String, Box<Er
             _ => String::from(""),
         };
 
-        output.push(format!("{name} {version}",
+        let optional = if let toml::Value::Table(_) = *val {
+            val.lookup("optional")
+               .and_then(|field| field.as_bool())
+               .unwrap_or(false)
+        } else {
+            false
+        };
+
+        output.push(format!("{name} {version}{optional}",
                             name = name.pad_to_width_with_alignment(name_max_len,
                                                                     Alignment::Left),
-                            version = version));
+                            version = version,
+                            optional = if optional {
+                                format!(" (optional)")
+                            } else {
+                                String::from("")
+                            }));
     }
 
     Ok(output.connect("\n"))

--- a/src/bin/list/list.rs
+++ b/src/bin/list/list.rs
@@ -22,11 +22,11 @@ pub fn list_section(manifest: &Manifest, section: &str) -> Result<String, Box<Er
         let version = match *val {
             toml::Value::String(ref version) => version.clone(),
             toml::Value::Table(_) => {
-                let v = try!(val.lookup("version")
-                                .and_then(|field| field.as_str())
-                                .or_else(|| val.lookup("git").map(|_| "git"))
-                                .ok_or(ListError::VersionMissing(name.clone())));
-                String::from(v)
+                try!(val.lookup("version")
+                        .and_then(|field| field.as_str().map(|s| s.to_owned()))
+                        .or_else(|| val.lookup("git").map(|repo| format!("git: {}", repo)))
+                        .or_else(|| val.lookup("path").map(|path| format!("path: {}", path)))
+                        .ok_or(ListError::VersionMissing(name.clone())))
             }
             _ => String::from(""),
         };

--- a/src/bin/list/list_error.rs
+++ b/src/bin/list/list_error.rs
@@ -1,27 +1,24 @@
-use std::fmt;
-use std::error::Error;
-
-#[derive(Debug)]
-pub enum ListError {
-    SectionMissing(String),
-    VersionMissing(String),
-}
-
-impl Error for ListError {
-    fn description(&self) -> &'static str {
-        match *self {
-            ListError::SectionMissing(_) => "Couldn't read section",
-            ListError::VersionMissing(_) => "Couldn't read version",
+quick_error! {
+    #[derive(Debug)]
+    pub enum ListError {
+        SectionMissing(section: String) {
+            description("Couldn't read section")
+            display("Couldn't read section `{}`.", section)
         }
-    }
-}
-
-impl fmt::Display for ListError {
-    fn fmt(&self, format: &mut fmt::Formatter) -> Result<(), fmt::Error> {
-        let desc: String = match *self {
-            ListError::SectionMissing(ref name) => format!("Couldn't read section {}", name),
-            ListError::VersionMissing(ref name) => format!("Couldn't read version of {}", name),
-        };
-        format.write_str(&desc)
+        VersionMissing(dep: String, section: String) {
+            description("Couldn't read version")
+            display("Couldn't read version of `{}` in section `{}`.", dep, section)
+        }
+        PackagesMissing {
+            description("Couldn't read list of packages in `Cargo.lock` file.")
+        }
+        PackageInvalid {
+            description("Invalid package record")
+            display("Invalid package record in `Cargo.lock`")
+        }
+        PackageFieldMissing(field: &'static str) {
+            description("Field missing in package record")
+            display("Field `{}` missing in package record in `Cargo.lock`.", field)
+        }
     }
 }

--- a/src/bin/list/main.rs
+++ b/src/bin/list/main.rs
@@ -25,7 +25,8 @@ use tree::parse_lock_file as list_tree;
 
 static USAGE: &'static str = r"
 Usage:
-    cargo list [<section>] [options]
+    cargo list [--dev|--build] [options]
+    cargo list --tree
     cargo list (-h|--help)
     cargo list --version
 
@@ -33,30 +34,35 @@ Options:
     --manifest-path=<path>  Path to the manifest to list dependencies of.
     --tree                  List dependencies recursively as tree.
     -h --help               Show this help page.
+    --version               Show version.
 
 Display a crate's dependencies using its Cargo.toml file.
 ";
 
-#[derive(Debug, RustcDecodable)]
 /// Docopts input args.
+#[derive(Debug, RustcDecodable)]
 struct Args {
-    arg_section: Option<String>,
-    flag_manifest_path: Option<String>,
+    /// dev-dependency
+    flag_dev: bool,
+    /// build-dependency
+    flag_build: bool,
+    /// Render tree of dependencies
     flag_tree: bool,
+    /// `Cargo.toml` path
+    flag_manifest_path: Option<String>,
+    /// `--version`
     flag_version: bool,
 }
 
 impl Args {
-    pub fn get_section(&self) -> &str {
-        let section = self.arg_section.as_ref().map(|s| &s[..]).unwrap_or("dependencies");
-
-        match section {
-            // Handle shortcuts
-            "deps" => "dependencies",
-            "dev-deps" => "dev-dependencies",
-            "build-deps" => "build-dependencies",
-            // No shortcut
-            field => field,
+    /// Get dependency section
+    fn get_section(&self) -> &'static str {
+        if self.flag_dev {
+            "dev-dependencies"
+        } else if self.flag_build {
+            "build-dependencies"
+        } else {
+            "dependencies"
         }
     }
 }

--- a/src/bin/rm/args.rs
+++ b/src/bin/rm/args.rs
@@ -1,4 +1,5 @@
 ///! Handle `cargo rm` arguments
+
 #[derive(Debug, RustcDecodable)]
 /// Docopts input args.
 pub struct Args {

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -205,7 +205,7 @@ impl Manifest {
                     if empty {
                         section.remove();
                     }
-                };
+                }
                 result
             }
         }

--- a/tests/cargo-list.rs
+++ b/tests/cargo-list.rs
@@ -5,7 +5,15 @@ extern crate assert_cli;
 fn listing_dev() {
     assert_cli!("target/debug/cargo-list",
                 &["list", "--dev", "--manifest-path=tests/fixtures/list/Cargo.toml"] =>
-                Success, r"gcc 0.3.19")
+                Success, r#"term 0.2.12"#)
+        .unwrap();
+}
+
+#[test]
+fn listing_build() {
+    assert_cli!("target/debug/cargo-list",
+                &["list", "--build", "--manifest-path=tests/fixtures/list/Cargo.toml"] =>
+                Success, r#"gcc 0.3.19"#)
         .unwrap();
 }
 
@@ -13,12 +21,13 @@ fn listing_dev() {
 fn listing() {
     assert_cli!("target/debug/cargo-list",
                 &["list", "--manifest-path=tests/fixtures/list/Cargo.toml"] =>
-                Success, r"clippy          git
+                Success, r#"cargo-edit      path: "../../../"
+clippy          git: "https://github.com/Manishearth/rust-clippy.git"
 docopt          0.6
 pad             0.1
 rustc-serialize 0.3
 semver          0.1
-toml            0.1")
+toml            0.1"#)
         .unwrap();
 }
 
@@ -26,7 +35,7 @@ toml            0.1")
 fn tree() {
     assert_cli!("target/debug/cargo-list",
                 &["list", "--tree", "--manifest-path=tests/fixtures/tree/Cargo.lock"] =>
-                Success, r"├── clippy (0.0.5)
+                Success, r#"├── clippy (0.0.5)
 ├── docopt (0.6.67)
 │   ├── regex (0.1.38)
 │   │   ├── aho-corasick (0.2.1)
@@ -42,19 +51,19 @@ fn tree() {
 ├── rustc-serialize (0.3.15)
 ├── semver (0.1.19)
 └── toml (0.1.20)
-    └── rustc-serialize (0.3.15)")
+    └── rustc-serialize (0.3.15)"#)
         .unwrap();
 }
 
 #[test]
 fn unknown_flags() {
     assert_cli!("target/debug/cargo-list", &["list", "foo", "--flag"] => Error 1,
-                r"Unknown flag: '--flag'
+                r#"Unknown flag: '--flag'
 
 Usage:
     cargo list [--dev|--build] [options]
     cargo list --tree
     cargo list (-h|--help)
-    cargo list --version")
+    cargo list --version"#)
         .unwrap();
 }

--- a/tests/cargo-list.rs
+++ b/tests/cargo-list.rs
@@ -22,7 +22,7 @@ fn listing() {
     assert_cli!("target/debug/cargo-list",
                 &["list", "--manifest-path=tests/fixtures/list/Cargo.toml"] =>
                 Success, r#"cargo-edit      path: "../../../"
-clippy          git: "https://github.com/Manishearth/rust-clippy.git"
+clippy          git: "https://github.com/Manishearth/rust-clippy.git" (optional)
 docopt          0.6
 pad             0.1
 rustc-serialize 0.3

--- a/tests/cargo-list.rs
+++ b/tests/cargo-list.rs
@@ -2,6 +2,14 @@
 extern crate assert_cli;
 
 #[test]
+fn listing_dev() {
+    assert_cli!("target/debug/cargo-list",
+                &["list", "--dev", "--manifest-path=tests/fixtures/list/Cargo.toml"] =>
+                Success, r"gcc 0.3.19")
+        .unwrap();
+}
+
+#[test]
 fn listing() {
     assert_cli!("target/debug/cargo-list",
                 &["list", "--manifest-path=tests/fixtures/list/Cargo.toml"] =>
@@ -44,7 +52,8 @@ fn unknown_flags() {
                 r"Unknown flag: '--flag'
 
 Usage:
-    cargo list [<section>] [options]
+    cargo list [--dev|--build] [options]
+    cargo list --tree
     cargo list (-h|--help)
     cargo list --version")
         .unwrap();

--- a/tests/fixtures/list/Cargo.toml
+++ b/tests/fixtures/list/Cargo.toml
@@ -21,3 +21,6 @@ rustc-serialize = "0.3"
 semver = "0.1"
 toml = "0.1"
 clippy = {git = "https://github.com/Manishearth/rust-clippy.git", optional = true}
+
+[dev-dependencies]
+gcc = "0.3.19"

--- a/tests/fixtures/list/Cargo.toml
+++ b/tests/fixtures/list/Cargo.toml
@@ -10,17 +10,27 @@ path = "src/main.rs"
 name = "cargo-list"
 path = "src/bin/list.rs"
 
-[features]
-default = []
-dev = ["clippy"]
-
 [dependencies]
 docopt = "0.6"
 pad = "0.1"
 rustc-serialize = "0.3"
 semver = "0.1"
 toml = "0.1"
-clippy = {git = "https://github.com/Manishearth/rust-clippy.git", optional = true}
+
+[dependencies.clippy]
+git = "https://github.com/Manishearth/rust-clippy.git"
+optional = true
+
+[dependencies.cargo-edit]
+optional = false
+path = "../../../"
 
 [dev-dependencies]
+term = "0.2.12"
+
+[build-dependencies]
 gcc = "0.3.19"
+
+[features]
+default = []
+dev = ["clippy"]


### PR DESCRIPTION
Like described in #50, this changes `cargo list` to be more strict in what it can show.

I also added support for showing git repo URLs and paths. ~~I'll see if I can easily add "optional" markers.~~ <ins>Yep.</ins>