### PR TITLE
`cargo list` missing sections as empty

### DIFF
--- a/src/bin/list/list.rs
+++ b/src/bin/list/list.rs
@@ -8,12 +8,10 @@ use list_error::ListError;
 #[allow(deprecated)] // connect -> join
 pub fn list_section(manifest: &Manifest, section: &str) -> Result<String, ListError> {
     let mut output = vec![];
-    let empty_list = Default::default();
 
     let list = try!(manifest.data
                             .get(section)
-                            .map(|field| field.as_table())
-                            .unwrap_or(Some(&empty_list))
+                            .and_then(|field| field.as_table())
                             .ok_or_else(|| ListError::SectionMissing(String::from(section))));
 
     let name_max_len = list.keys().map(|k| k.len()).max().unwrap_or(0);
@@ -78,9 +76,10 @@ lorem-ipsum 0.4.2");
     }
 
     #[test]
-    fn treat_unknown_section_as_empty() {
+    #[should_panic]
+    fn unknown_section() {
         let manifile: Manifest = DEFAULT_CARGO_TOML.parse().unwrap();
 
-        assert_eq!(list_section(&manifile, "lol-dependencies").unwrap(), "");
+        list_section(&manifile, "lol-dependencies").unwrap();
     }
 }

--- a/src/bin/list/list.rs
+++ b/src/bin/list/list.rs
@@ -8,10 +8,12 @@ use list_error::ListError;
 #[allow(deprecated)] // connect -> join
 pub fn list_section(manifest: &Manifest, section: &str) -> Result<String, ListError> {
     let mut output = vec![];
+    let empty_list = Default::default();
 
     let list = try!(manifest.data
                             .get(section)
-                            .and_then(|field| field.as_table())
+                            .map(|field| field.as_table())
+                            .unwrap_or(Some(&empty_list))
                             .ok_or_else(|| ListError::SectionMissing(String::from(section))));
 
     let name_max_len = list.keys().map(|k| k.len()).max().unwrap_or(0);
@@ -76,10 +78,9 @@ lorem-ipsum 0.4.2");
     }
 
     #[test]
-    #[should_panic]
-    fn unknown_section() {
+    fn treat_unknown_section_as_empty() {
         let manifile: Manifest = DEFAULT_CARGO_TOML.parse().unwrap();
 
-        list_section(&manifile, "lol-dependencies").unwrap();
+        assert_eq!(list_section(&manifile, "lol-dependencies").unwrap(), "");
     }
 }

--- a/src/bin/list/main.rs
+++ b/src/bin/list/main.rs
@@ -24,6 +24,7 @@ mod list_error;
 mod tree;
 
 use list::list_section;
+use list_error::ListError;
 use tree::parse_lock_file as list_tree;
 
 static USAGE: &'static str = r"
@@ -79,6 +80,10 @@ fn handle_list(args: &Args) -> Result<String, Box<Error>> {
     } else {
         let manifest = try!(Manifest::open(&args.flag_manifest_path.as_ref().map(|s| &s[..])));
         list_section(&manifest, args.get_section())
+            .or_else(|err| match err {
+                ListError::SectionMissing(..) => Ok("".into()),
+                _ => Err(err),
+            })
     }
     .map_err(From::from)
 }

--- a/tests/cargo-list.rs
+++ b/tests/cargo-list.rs
@@ -2,6 +2,20 @@
 extern crate assert_cli;
 
 #[test]
+fn listing() {
+    assert_cli!("target/debug/cargo-list",
+                &["list", "--manifest-path=tests/fixtures/list/Cargo.toml"] =>
+                Success, r#"cargo-edit      path: "../../../"
+clippy          git: "https://github.com/Manishearth/rust-clippy.git" (optional)
+docopt          0.6
+pad             0.1
+rustc-serialize 0.3
+semver          0.1
+toml            0.1"#)
+        .unwrap();
+}
+
+#[test]
 fn listing_dev() {
     assert_cli!("target/debug/cargo-list",
                 &["list", "--dev", "--manifest-path=tests/fixtures/list/Cargo.toml"] =>
@@ -18,17 +32,21 @@ fn listing_build() {
 }
 
 #[test]
-fn listing() {
+fn treat_missing_section_as_empty() {
+    // empty dependencies
     assert_cli!("target/debug/cargo-list",
-                &["list", "--manifest-path=tests/fixtures/list/Cargo.toml"] =>
-                Success, r#"cargo-edit      path: "../../../"
-clippy          git: "https://github.com/Manishearth/rust-clippy.git" (optional)
-docopt          0.6
-pad             0.1
-rustc-serialize 0.3
-semver          0.1
-toml            0.1"#)
-        .unwrap();
+                &["list", "--manifest-path=tests/fixtures/list-empty/Cargo.toml"] =>
+                Success, "\n").unwrap();
+
+    // empty dev-dependencies
+    assert_cli!("target/debug/cargo-list",
+                &["list", "--dev", "--manifest-path=tests/fixtures/list-empty/Cargo.toml"] =>
+                Success, "\n").unwrap();
+
+    // empty build-dependencies
+    assert_cli!("target/debug/cargo-list",
+                &["list", "--build", "--manifest-path=tests/fixtures/list-empty/Cargo.toml"] =>
+                Success, "\n").unwrap();
 }
 
 #[test]

--- a/tests/fixtures/list-empty/Cargo.toml
+++ b/tests/fixtures/list-empty/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "cargo-list-empty-test-fixture"
+version = "0.1.0"
+
+[[bin]]
+name = "main"
+path = "src/main.rs"


### PR DESCRIPTION
Based on @tbu-'s #42. This just adds integration tests for `cargo list`.