### PR TITLE
Switch from curl to hyper, refactor JSON handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,14 +4,14 @@ version = "0.1.1"
 dependencies = [
  "assert_cli 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "clippy 0.0.29 (registry+https://github.com/rust-lang/crates.io-index)",
- "curl 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "docopt 0.6.78 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hyper 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "pad 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "quick-error 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "semver 0.1.20 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempdir 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "toml 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)",
+ "toml 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -46,6 +46,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "bitflags"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "clippy"
 version = "0.0.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -54,27 +59,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "curl"
-version = "0.2.14"
+name = "cookie"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "curl-sys 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "openssl-sys 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "url 0.2.38 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "curl-sys"
-version = "0.1.29"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "gcc 0.3.20 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "libz-sys 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "openssl-sys 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "pkg-config 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "openssl 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-serialize 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "time 0.1.34 (registry+https://github.com/rust-lang/crates.io-index)",
+ "url 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -90,17 +82,25 @@ name = "docopt"
 version = "0.6.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "regex 0.1.43 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 0.1.44 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "strsim 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "gcc"
-version = "0.3.20"
+version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "advapi32-sys 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "gdi32-sys"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
  "winapi 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -110,8 +110,61 @@ version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "hpack"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "log 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "httparse"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "hyper"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cookie 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "httparse 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "language-tags 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mime 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num_cpus 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "openssl 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-serialize 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solicit 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "time 0.1.34 (registry+https://github.com/rust-lang/crates.io-index)",
+ "traitobject 0.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "typeable 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicase 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "url 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "kernel32-sys"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "winapi 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "language-tags"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "lazy_static"
+version = "0.1.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "libc"
-version = "0.2.2"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -123,21 +176,11 @@ dependencies = [
 ]
 
 [[package]]
-name = "libz-sys"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "gcc 0.3.20 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "pkg-config 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "log"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -150,17 +193,70 @@ name = "memchr"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "mime"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "log 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 0.6.7 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "num"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "rand 0.3.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-serialize 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "num_cpus"
+version = "0.2.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "kernel32-sys 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "openssl"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bitflags 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gcc 0.3.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "openssl-sys 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "openssl-sys-extras 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "openssl-sys"
-version = "0.7.1"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gdi32-sys 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "libressl-pnacl-sys 2.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "pkg-config 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "user32-sys 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "openssl-sys-extras"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "gcc 0.3.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "openssl-sys 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -195,13 +291,13 @@ version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "advapi32-sys 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "regex"
-version = "0.1.43"
+version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "aho-corasick 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -225,6 +321,23 @@ version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "serde"
+version = "0.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "num 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "solicit"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "hpack 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "strsim"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -238,12 +351,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "time"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "kernel32-sys 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "toml"
-version = "0.1.23"
+version = "0.1.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "rustc-serialize 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "traitobject"
+version = "0.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "typeable"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "unicase"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "unicode-normalization"
@@ -257,12 +395,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "url"
-version = "0.2.38"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "matches 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "user32-sys"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "winapi 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ pad = "0.1"
 rustc-serialize = "0.3"
 semver = "0.1"
 toml = "0.1"
-curl = "0.2.11"
+hyper = "0.7.1"
 quick-error = "0.1.3"
 clippy = {version = "0.0.29", optional = true}
 

--- a/src/bin/add/fetch_version.rs
+++ b/src/bin/add/fetch_version.rs
@@ -1,8 +1,10 @@
 use std::env;
-use rustc_serialize::json;
+use std::io::Read;
 use rustc_serialize::json::{BuilderError, Json};
-use curl::{ErrCode, http};
-use curl::http::handle::{Method, Request};
+use hyper::Client;
+use hyper::header::{Connection, ContentType};
+use hyper::error::Error as HyperError;
+use hyper::status::StatusCode;
 
 const REGISTRY_HOST: &'static str = "https://crates.io";
 
@@ -13,6 +15,7 @@ const REGISTRY_HOST: &'static str = "https://crates.io";
 /// - there is no Internet connection,
 /// - the response from crates.io was an error or in an incorrect format,
 /// - or when a crate with the given name does not exist on crates.io.
+#[allow(trivial_casts)]
 pub fn get_latest_version(crate_name: &str) -> Result<String, FetchVersionError> {
     if env::var("CARGO_IS_TEST").is_ok() {
         // We are in a simulated reality. Nothing is real here. Wildcard dependecies are okay.
@@ -20,26 +23,37 @@ pub fn get_latest_version(crate_name: &str) -> Result<String, FetchVersionError>
         return Ok("*".into());
     }
 
-    let crate_data = try!(fetch(&format!("/crates/{}", crate_name)));
-    let crate_json = try!(Json::from_str(&crate_data));
+    let client = Client::new();
+    let mut res = try!(
+        client.get(&format!("{}/api/v1/crates/{}", REGISTRY_HOST, crate_name))
+        .header(Connection::close())
+        .header(ContentType::json())
+        .send());
 
-    crate_json.as_object()
-              .and_then(|c| c.get("crate"))
-              .and_then(|c| c.as_object())
-              .and_then(|c| c.get("max_version"))
-              .and_then(|v| v.as_string())
-              .map(|v| v.to_owned())
-              .ok_or(FetchVersionError::GetVersion)
+    if !res.status.is_success() {
+        return Err(FetchVersionError::CratesIo(res.status));
+    }
+
+    // FIXME: Trivial cast
+    let json = try!(Json::from_reader(&mut res as &mut Read));
+
+    json.find_path(&["crate", "max_version"])
+        .and_then(|v| v.as_string())
+        .map(|v| v.to_owned())
+        .ok_or(FetchVersionError::GetVersion)
 }
 
 quick_error! {
     #[derive(Debug)]
     pub enum FetchVersionError {
-        CratesIo(err: CratesIoError) {
+        Http(err: HyperError) {
+            from()
+            cause(err)
+        }
+        CratesIo(err: StatusCode) {
             from()
             description("crates.io Error")
             display("crates.io Error: {}", err)
-            cause(err)
         }
         Json(err: BuilderError) {
             from()
@@ -47,66 +61,8 @@ quick_error! {
             display("Error parsing JSON: {}", err)
             cause(err)
         }
-        GetVersion { description("get version error") }
-    }
-}
-
-// ---
-// The following was mostly copied from [1] and is therefore
-// (c) 2015 Alex Crichton <alex@alexcrichton.com>
-//
-// [1]: https://github.com/rust-lang/cargo/blob/bd690d8dff83c7b7714f236a08304ee20732382b/src/crates-io/lib.rs
-// ---
-
-fn fetch(path: &str) -> Result<String, FetchVersionError> {
-    let mut http_handle = http::Handle::new();
-    let req = Request::new(&mut http_handle, Method::Get)
-                  .uri(format!("{}/api/v1{}", REGISTRY_HOST, path))
-                  .header("Accept", "application/json")
-                  .content_type("application/json");
-    handle(req.exec()).map_err(From::from)
-}
-
-fn handle(response: Result<http::Response, ErrCode>) -> Result<String, CratesIoError> {
-    let response = try!(response.map_err(CratesIoError::Curl));
-    match response.get_code() {
-        0 => {} // file upload url sometimes
-        200 => {}
-        403 => return Err(CratesIoError::Unauthorized),
-        404 => return Err(CratesIoError::NotFound),
-        _ => return Err(CratesIoError::NotOkResponse(response)),
-    }
-
-    let body = match String::from_utf8(response.move_body()) {
-        Ok(body) => body,
-        Err(..) => return Err(CratesIoError::NonUtf8Body),
-    };
-    match json::decode::<ApiErrorList>(&body) {
-        Ok(errors) => {
-            return Err(CratesIoError::Api(errors.errors.into_iter().map(|s| s.detail).collect()));
+        GetVersion {
+            description("get version error")
         }
-        Err(..) => {}
-    }
-    Ok(body)
-}
-
-#[derive(RustcDecodable)]
-struct ApiErrorList {
-    errors: Vec<ApiError>,
-}
-#[derive(RustcDecodable)]
-struct ApiError {
-    detail: String,
-}
-
-quick_error! {
-    #[derive(Debug)]
-    pub enum CratesIoError {
-        Curl(e: ErrCode) {}
-        NotOkResponse(e: http::Response)  {}
-        NonUtf8Body  {}
-        Api(e: Vec<String>)  {}
-        Unauthorized  {}
-        NotFound {}
     }
 }

--- a/src/bin/add/main.rs
+++ b/src/bin/add/main.rs
@@ -9,9 +9,8 @@ extern crate docopt;
 extern crate toml;
 extern crate semver;
 extern crate rustc_serialize;
-extern crate curl;
-#[macro_use]
-extern crate quick_error;
+extern crate hyper;
+#[macro_use]extern crate quick_error;
 
 use std::error::Error;
 use std::process;


### PR DESCRIPTION
I had some time this morning, so I finally replaced curl with hyper and along the way got rid of a lot of HTTP/JSON handling. Might also help with #55.

@Seeker14491, @iopq, could you test this on Windows?
