### PR TITLE
Multiple crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1,6 +1,6 @@
 [root]
 name = "cargo-edit"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "assert_cli 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "clippy 0.0.29 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,8 @@
 [package]
 name = "cargo-edit"
-authors = ["Without Boats <lee@libertad.ucsd.edu>", "Pascal Hertleif <killercup@gmail.com>"]
+authors = ["Without Boats <lee@libertad.ucsd.edu>",
+           "Pascal Hertleif <killercup@gmail.com>",
+           "Jonas Platte <mail@jonasplatte.de>"]
 
 version = "0.1.2"
 

--- a/src/bin/add/fetch_version.rs
+++ b/src/bin/add/fetch_version.rs
@@ -15,9 +15,9 @@ const REGISTRY_HOST: &'static str = "https://crates.io";
 /// - or when a crate with the given name does not exist on crates.io.
 pub fn get_latest_version(crate_name: &str) -> Result<String, FetchVersionError> {
     if env::var("CARGO_IS_TEST").is_ok() {
-        // We are in a simulated reality. Nothing is real here. Wildcard dependecies are okay.
+        // We are in a simulated reality. Nothing is real here.
         // FIXME: Use actual test handling code.
-        return Ok("*".into());
+        return Ok("CURRENT_VERSION_TEST".into());
     }
 
     let crate_data = try!(fetch(&format!("/crates/{}", crate_name)));

--- a/src/bin/add/main.rs
+++ b/src/bin/add/main.rs
@@ -27,7 +27,7 @@ use args::Args;
 static USAGE: &'static str = r#"
 Usage:
     cargo add <crate> [--dev|--build|--optional] [--vers=<ver>|--git=<uri>|--path=<uri>] [options]
-    cargo add <crate>... [--dev|--build|--optional] [options]
+    cargo add <crates>... [--dev|--build|--optional] [options]
     cargo add (-h|--help)
     cargo add --version
 

--- a/src/bin/add/main.rs
+++ b/src/bin/add/main.rs
@@ -27,6 +27,7 @@ use args::Args;
 static USAGE: &'static str = r#"
 Usage:
     cargo add <crate> [--dev|--build|--optional] [--vers=<ver>|--git=<uri>|--path=<uri>] [options]
+    cargo add <crate>... [--dev|--build|--optional] [options]
     cargo add (-h|--help)
     cargo add --version
 
@@ -58,20 +59,17 @@ dependencies (version set to "*").
 
 fn handle_add(args: &Args) -> Result<(), Box<Error>> {
     let mut manifest = try!(Manifest::open(&args.flag_manifest_path.as_ref().map(|s| &s[..])));
-    let dep = try!(args.parse_dependency());
+    let deps = try!(args.parse_dependencies());
 
-    manifest.insert_into_table(&args.get_section(), &dep)
-            .map_err(From::from)
-            .and_then(|_| {
-                let mut file = try!(Manifest::find_file(&args.flag_manifest_path
-                                                             .as_ref()
-                                                             .map(|s| &s[..])));
-                manifest.write_to_file(&mut file)
-            })
-            .or_else(|err| {
-                println!("Could not edit `Cargo.toml`.\n\nERROR: {}", err);
-                Err(err)
-            })
+    for dep in deps {
+        if let Err(err) = manifest.insert_into_table(&args.get_section(), &dep) {
+            println!("Could not edit `Cargo.toml`.\n\nERROR: {}", err);
+            return Err(From::from(err));
+        }
+    }
+
+    let mut file = try!(Manifest::find_file(&args.flag_manifest_path.as_ref().map(|s| &s[..])));
+    manifest.write_to_file(&mut file)
 }
 
 fn main() {

--- a/tests/cargo-add.rs
+++ b/tests/cargo-add.rs
@@ -8,7 +8,7 @@ mod utils;
 use utils::{clone_out_test, execute_command, get_toml, no_manifest_failures};
 
 #[test]
-fn adds_dependencies() {
+fn adds_dependency() {
     let (_tmpdir, manifest) = clone_out_test("tests/fixtures/add/Cargo.toml.sample");
 
     // dependency not present beforehand
@@ -43,7 +43,7 @@ fn adds_multiple_dependencies() {
 }
 
 #[test]
-fn adds_dev_build_dependencies() {
+fn adds_dev_build_dependency() {
     let (_tmpdir, manifest) = clone_out_test("tests/fixtures/add/Cargo.toml.sample");
 
     // dependency not present beforehand
@@ -254,7 +254,7 @@ fn package_kinds_are_mutually_exclusive() {
 }
 
 #[test]
-fn adds_optional_dependencies() {
+fn adds_optional_dependency() {
     let (_tmpdir, manifest) = clone_out_test("tests/fixtures/add/Cargo.toml.sample");
 
     // dependency not present beforehand

--- a/tests/cargo-add.rs
+++ b/tests/cargo-add.rs
@@ -292,7 +292,7 @@ fn adds_multiple_optional_dependencies() {
 
 #[test]
 #[should_panic]
-fn failt_to_add_optional_dev_dependency() {
+fn fails_to_add_optional_dev_dependency() {
     let (_tmpdir, manifest) = clone_out_test("tests/fixtures/add/Cargo.toml.sample");
 
     // dependency not present beforehand
@@ -301,6 +301,20 @@ fn failt_to_add_optional_dev_dependency() {
 
     // Fails because optional dependencies must be in `dependencies` table.
     execute_command(&["add", "versioned-package", "--vers", ">=0.1.1", "--dev", "--optional"],
+                    &manifest);
+}
+
+#[test]
+#[should_panic]
+fn fails_to_add_multiple_optional_dev_dependency() {
+    let (_tmpdir, manifest) = clone_out_test("tests/fixtures/add/Cargo.toml.sample");
+
+    // dependency not present beforehand
+    let toml = get_toml(&manifest);
+    assert!(toml.lookup("dependencies.versioned-package").is_none());
+
+    // Fails because optional dependencies must be in `dependencies` table.
+    execute_command(&["add", "--optional", "my-package1", "my-package2", "--dev"],
                     &manifest);
 }
 

--- a/tests/cargo-add.rs
+++ b/tests/cargo-add.rs
@@ -306,12 +306,13 @@ fn fails_to_add_optional_dev_dependency() {
 
 #[test]
 #[should_panic]
-fn fails_to_add_multiple_optional_dev_dependency() {
+fn fails_to_add_multiple_optional_dev_dependencies() {
     let (_tmpdir, manifest) = clone_out_test("tests/fixtures/add/Cargo.toml.sample");
 
-    // dependency not present beforehand
+    // dependencies not present beforehand
     let toml = get_toml(&manifest);
-    assert!(toml.lookup("dependencies.versioned-package").is_none());
+    assert!(toml.lookup("dependencies.my-package1").is_none());
+    assert!(toml.lookup("dependencies.my-package2").is_none());
 
     // Fails because optional dependencies must be in `dependencies` table.
     execute_command(&["add", "--optional", "my-package1", "my-package2", "--dev"],

--- a/tests/cargo-add.rs
+++ b/tests/cargo-add.rs
@@ -208,7 +208,7 @@ fn no_argument() {
 
 Usage:
     cargo add <crate> [--dev|--build|--optional] [--vers=<ver>|--git=<uri>|--path=<uri>] [options]
-    cargo add <crate>... [--dev|--build|--optional] [options]
+    cargo add <crates>... [--dev|--build|--optional] [options]
     cargo add (-h|--help)
     cargo add --version")
         .unwrap();
@@ -221,7 +221,7 @@ fn unknown_flags() {
 
 Usage:
     cargo add <crate> [--dev|--build|--optional] [--vers=<ver>|--git=<uri>|--path=<uri>] [options]
-    cargo add <crate>... [--dev|--build|--optional] [options]
+    cargo add <crates>... [--dev|--build|--optional] [options]
     cargo add (-h|--help)
     cargo add --version")
         .unwrap();

--- a/tests/cargo-add.rs
+++ b/tests/cargo-add.rs
@@ -208,6 +208,7 @@ fn no_argument() {
 
 Usage:
     cargo add <crate> [--dev|--build|--optional] [--vers=<ver>|--git=<uri>|--path=<uri>] [options]
+    cargo add <crate>... [--dev|--build|--optional] [options]
     cargo add (-h|--help)
     cargo add --version")
         .unwrap();
@@ -220,6 +221,7 @@ fn unknown_flags() {
 
 Usage:
     cargo add <crate> [--dev|--build|--optional] [--vers=<ver>|--git=<uri>|--path=<uri>] [options]
+    cargo add <crate>... [--dev|--build|--optional] [options]
     cargo add (-h|--help)
     cargo add --version")
         .unwrap();


### PR DESCRIPTION
I've been talking about this with @jplatte on IRC for a while.

We still need to add some tests for this. E.g.:

- [x] adding zero crates fails (_already exists_)
- [x] adding ≥2 crates works and fetches the latest version numbers from crates.io
- [x] adding ≥2 crates with `--dev` and `--build` works
- [x] adding ≥2 crates with `--optional`
- [x] adding ≥2 crates with `--optional` but also with `--dev`(or `--build`) fails
- [x] adding ≥2 crates with explicit versions (e.g. `cargo add regex@0.1.42 nom@1.0.0`) works
- [x] adding ≥2 crates with mixed explicit versions (e.g. `cargo add regex nom@1.0.0`) works

Concerns #59