### PR TITLE
Return error if name in crates.io is different

### DIFF
--- a/src/bin/add/args.rs
+++ b/src/bin/add/args.rs
@@ -60,8 +60,7 @@ impl Args {
                 let le_crate = if crate_name_has_version(&arg_crate) {
                     try!(parse_crate_name_with_version(arg_crate))
                 } else {
-                    let v = try!(get_latest_version(&self.arg_crate));
-                    Dependency::new(arg_crate).set_version(&v)
+                    try!(get_latest_version(&self.arg_crate))
                 }.set_optional(self.flag_optional);
 
                 result.push(le_crate);
@@ -86,8 +85,7 @@ impl Args {
         } else if let Some(ref path) = self.flag_path {
             dependency.set_path(path)
         } else {
-            let v = try!(get_latest_version(&self.arg_crate));
-            dependency.set_version(&v)
+            try!(get_latest_version(&self.arg_crate))
         };
 
         Ok(vec![dependency])

--- a/src/bin/add/fetch_version.rs
+++ b/src/bin/add/fetch_version.rs
@@ -3,45 +3,39 @@ use rustc_serialize::json;
 use rustc_serialize::json::{BuilderError, Json};
 use curl::{ErrCode, http};
 use curl::http::handle::{Method, Request};
+use cargo_edit::Dependency;
 
 const REGISTRY_HOST: &'static str = "https://crates.io";
 
 /// Query latest version fromc crates.io
 ///
-/// The latest version will be returned as a string. This will fail, when
+/// The latest version will be returned as a dependency. This will fail, when
 ///
 /// - there is no Internet connection,
 /// - the response from crates.io was an error or in an incorrect format,
 /// - or when a crate with the given name does not exist on crates.io.
-pub fn get_latest_version(crate_name: &str) -> Result<String, FetchVersionError> {
+pub fn get_latest_version(crate_name: &str) -> Result<Dependency, FetchVersionError> {
     if env::var("CARGO_IS_TEST").is_ok() {
         // We are in a simulated reality. Nothing is real here.
         // FIXME: Use actual test handling code.
-        return Ok("CURRENT_VERSION_TEST".into());
+        return Ok(Dependency::default());
     }
 
     let crate_data = try!(fetch(&format!("/crates/{}", crate_name)));
     let crate_json = try!(Json::from_str(&crate_data));
 
-    // issue 51
-    // return error if name in crates.io is different from what we have
-    let not_found = Err(FetchVersionError::CratesIo(CratesIoError::NotFound));
-    match crate_json.find_path(&["crate", "name"]).and_then(|n| n.as_string()) {
-        Some(name) => {
-            if name != crate_name {
-                return not_found;
-            }
-        }
-        None => return not_found,
+    let name = try!(crate_json.find_path(&["crate", "name"])
+                              .and_then(|n| n.as_string())
+                              .ok_or(FetchVersionError::CratesIo(CratesIoError::NotFound)));
+    if name != crate_name {
+        println!("STDOUT: Added {} instead of {}", name, crate_name)
     }
 
-    crate_json.as_object()
-              .and_then(|c| c.get("crate"))
-              .and_then(|c| c.as_object())
-              .and_then(|c| c.get("max_version"))
-              .and_then(|v| v.as_string())
-              .map(|v| v.to_owned())
-              .ok_or(FetchVersionError::GetVersion)
+    let version = try!(crate_json.find_path(&["crate", "max_version"])
+                                 .and_then(|v| v.as_string())
+                                 .ok_or(FetchVersionError::CratesIo(CratesIoError::NotFound)));
+
+    Ok(Dependency::new(name).set_version(version))
 }
 
 quick_error! {
@@ -130,7 +124,7 @@ mod tests {
     #[test]
     fn invalid_crate_name() {
         assert!(match get_latest_version("error-def") {
-            Ok(_) => false,
+            Ok(dependency) => dependency.name == "error_def",
             Err(_) => true,
         });
     }


### PR DESCRIPTION
As described in #51, I have added a check to validate the crate_name is the same as the one on crates.io or return an error.

```
$ ./target/debug/cargo-add add error-def
Command failed due to unhandled error: crates.io Error: NotFound
$
$ ./target/debug/cargo-add add error_def
$
```

I have added a couple of tests as well, but they actually hit crates.io endpoint.
