### PR TITLE
Output error position on TOML parse error

### DIFF
--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -30,15 +30,15 @@ quick_error! {
         }
         ParseError(error: String, loline: usize, locol: usize, hiline: usize, hicol: usize) {
             description("parse error")
-            display("{}:{}{} {}",
-                loline + 1, locol + 1,
-                if loline != hiline || locol != hicol {
-                    format!("-{}:{}", hiline + 1,
-                            hicol + 1)
+            display("{line}:{col}{upto} {error_msg}",
+                line = loline + 1,
+                col = locol + 1,
+                upto = if loline != hiline || locol != hicol {
+                    format!("-{}:{}", hiline + 1, hicol + 1)
                 } else {
                     "".to_string()
                 },
-                error)
+                error_msg = error)
         }
     }
 }

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -241,14 +241,14 @@ impl str::FromStr for Manifest {
         let mut parser = toml::Parser::new(&input);
 
         parser.parse()
-              .ok_or_else(|| format_parse_error(parser))
+              .ok_or_else(|| format_parse_error(&parser))
               .map_err(Option::unwrap)
               .map_err(From::from)
               .map(|data| Manifest { data: data })
     }
 }
 
-fn format_parse_error(parser: toml::Parser) -> Option<ManifestError> {
+fn format_parse_error(parser: &toml::Parser) -> Option<ManifestError> {
     parser.errors.first().map(|error| {
         let (loline, locol) = parser.to_linecol(error.lo);
         let (hiline, hicol) = parser.to_linecol(error.hi);

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -249,14 +249,11 @@ impl str::FromStr for Manifest {
 }
 
 fn format_parse_error(mut parser: toml::Parser) -> Option<ManifestError> {
-    match parser.errors.pop() {
-        Some(error) => {
-            let (loline, locol) = parser.to_linecol(error.lo);
-            let (hiline, hicol) = parser.to_linecol(error.hi);
-            Some(ManifestError::ParseError(error.desc, loline, locol, hiline, hicol))       
-        },
-        None => None
-    }
+    parser.errors.pop().map(|error| {
+        let (loline, locol) = parser.to_linecol(error.lo);
+        let (hiline, hicol) = parser.to_linecol(error.hi);
+        ManifestError::ParseError(error.desc.clone(), loline, locol, hiline, hicol)
+    })
 }
 
 #[cfg(test)]

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -241,15 +241,15 @@ impl str::FromStr for Manifest {
         let mut parser = toml::Parser::new(&input);
 
         parser.parse()
-              .ok_or(format_parse_error(parser))
+              .ok_or_else(|| format_parse_error(parser))
               .map_err(Option::unwrap)
               .map_err(From::from)
               .map(|data| Manifest { data: data })
     }
 }
 
-fn format_parse_error(mut parser: toml::Parser) -> Option<ManifestError> {
-    parser.errors.pop().map(|error| {
+fn format_parse_error(parser: toml::Parser) -> Option<ManifestError> {
+    parser.errors.first().map(|error| {
         let (loline, locol) = parser.to_linecol(error.lo);
         let (hiline, hicol) = parser.to_linecol(error.hi);
         ManifestError::ParseError(error.desc.clone(), loline, locol, hiline, hicol)

--- a/tests/fixtures/manifest-invalid/Cargo.toml.sample
+++ b/tests/fixtures/manifest-invalid/Cargo.toml.sample
@@ -1,0 +1,6 @@
+[package]
+name = "manifest-invalid-test-fixture"
+version = "0.1.0"
+
+[invalid-section]
+key = invalid-value

--- a/tests/test_manifest.rs
+++ b/tests/test_manifest.rs
@@ -1,0 +1,10 @@
+#[macro_use]
+extern crate assert_cli;
+
+#[test]
+fn invalid_manifest() {
+    assert_cli!("target/debug/cargo-list",
+                &["list", "--manifest-path=tests/fixtures/manifest-invalid/Cargo.toml.sample"] =>
+                Error(1), r#"6:7-6:8 expected a value"#)
+        .unwrap();
+}


### PR DESCRIPTION
When the input TOML file can not be parsed the file position (line, column) of the last parse error is printed with the error message. The formatting of the file position is the same as in cargo itself (but missing the file name currently).

I was not sure where to place the new test. Since it's the first test for code in manifest.rs I created a new test_manifest.rs.

Disclaimer: This is my first PR ever and also I'm a complete Rust noob. I hope this is useful somehow anyway.