### PR TITLE
Fetch non-prerelease versions

### DIFF
--- a/src/bin/add/args.rs
+++ b/src/bin/add/args.rs
@@ -44,7 +44,7 @@ pub struct Args {
     /// `---upgrade`
     pub flag_upgrade: Option<String>,
     /// '--fetch-prereleases'
-    pub flag_fetch_prereleases: bool,
+    pub flag_allow_prerelease: bool,
 }
 
 impl Args {
@@ -72,7 +72,7 @@ impl Args {
                 let le_crate = if crate_name_has_version(arg_crate) {
                         try!(parse_crate_name_with_version(arg_crate))
                     } else {
-                        try!(get_latest_dependency(arg_crate, self.flag_fetch_prereleases))
+                        try!(get_latest_dependency(arg_crate, self.flag_allow_prerelease))
                     }
                     .set_optional(self.flag_optional);
 
@@ -98,7 +98,7 @@ impl Args {
                 } else if let Some(ref path) = self.flag_path {
                     dependency.set_path(path)
                 } else {
-                    let dep = try!(get_latest_dependency(&self.arg_crate, self.flag_fetch_prereleases));
+                    let dep = try!(get_latest_dependency(&self.arg_crate, self.flag_allow_prerelease));
                     let v = format!("{prefix}{version}",
                                     prefix = self.get_upgrade_prefix().unwrap_or(""),
                                     // if version is unavailable
@@ -144,7 +144,7 @@ impl Default for Args {
             flag_manifest_path: None,
             flag_version: false,
             flag_upgrade: None,
-            flag_fetch_prereleases: false,
+            flag_allow_prerelease: false,
         }
     }
 }

--- a/src/bin/add/args.rs
+++ b/src/bin/add/args.rs
@@ -43,6 +43,8 @@ pub struct Args {
     pub flag_version: bool,
     /// `---upgrade`
     pub flag_upgrade: Option<String>,
+    /// '--fetch-prereleases'
+    pub flag_fetch_prereleases: bool,
 }
 
 impl Args {
@@ -70,7 +72,7 @@ impl Args {
                 let le_crate = if crate_name_has_version(arg_crate) {
                         try!(parse_crate_name_with_version(arg_crate))
                     } else {
-                        try!(get_latest_dependency(arg_crate))
+                        try!(get_latest_dependency(arg_crate, self.flag_fetch_prereleases))
                     }
                     .set_optional(self.flag_optional);
 
@@ -96,7 +98,7 @@ impl Args {
                 } else if let Some(ref path) = self.flag_path {
                     dependency.set_path(path)
                 } else {
-                    let dep = try!(get_latest_dependency(&self.arg_crate));
+                    let dep = try!(get_latest_dependency(&self.arg_crate, self.flag_fetch_prereleases));
                     let v = format!("{prefix}{version}",
                                     prefix = self.get_upgrade_prefix().unwrap_or(""),
                                     // if version is unavailable
@@ -142,6 +144,7 @@ impl Default for Args {
             flag_manifest_path: None,
             flag_version: false,
             flag_upgrade: None,
+            flag_fetch_prereleases: false,
         }
     }
 }

--- a/src/bin/add/fetch.rs
+++ b/src/bin/add/fetch.rs
@@ -4,9 +4,9 @@ use curl::http::handle::{Method, Request};
 use regex::Regex;
 use rustc_serialize::json;
 use rustc_serialize::json::{BuilderError, Json, Object};
+use semver::Version;
 use std::env;
 use std::path::Path;
-use semver::Version;
 
 const REGISTRY_HOST: &'static str = "https://crates.io";
 
@@ -38,9 +38,12 @@ pub fn get_latest_dependency(crate_name: &str, flag_fetch_prereleases: bool) -> 
 }
 
 // Checks whether a version object is a stable release
-fn version_is_stable (version: &Object) -> bool {
-    version.get("num").and_then(Json::as_string).and_then(|s| Version::parse(s).ok())
-        .map(|s| !s.is_prerelease()).unwrap_or(false)
+fn version_is_stable(version: &Object) -> bool {
+    version.get("num")
+        .and_then(Json::as_string)
+        .and_then(|s| Version::parse(s).ok())
+        .map(|s| !s.is_prerelease())
+        .unwrap_or(false)
 }
 
 /// Read latest version from JSON structure
@@ -73,7 +76,7 @@ fn read_latest_version(crate_json: Json, flag_fetch_prereleases: bool) -> Result
 }
 
 #[test]
-fn get_latest_stable_version_from_json () {
+fn get_latest_stable_version_from_json() {
     let json = Json::from_str(r#"{
       "versions": [
         {
@@ -95,7 +98,7 @@ fn get_latest_stable_version_from_json () {
 }
 
 #[test]
-fn get_latest_unstable_or_stable_version_from_json () {
+fn get_latest_unstable_or_stable_version_from_json() {
     let json = Json::from_str(r#"{
       "versions": [
         {

--- a/src/bin/add/main.rs
+++ b/src/bin/add/main.rs
@@ -53,7 +53,7 @@ Options:
                             "none" (exact version), "patch" (`~` modifier), "minor"
                             (`^` modifier, default), or "all" (`>=`).
     --manifest-path=<path>  Path to the manifest to add a dependency to.
-    --fetch-prereleases     Include prerelease versions when fetching from crates.io (e.g.
+    --allow-prerelease      Include prerelease versions when fetching from crates.io (e.g.
                             '0.6.0-alpha'). Defaults to false.
     -h --help               Show this help page.
     --version               Show version.

--- a/src/bin/add/main.rs
+++ b/src/bin/add/main.rs
@@ -53,6 +53,8 @@ Options:
                             "none" (exact version), "patch" (`~` modifier), "minor"
                             (`^` modifier, default), or "all" (`>=`).
     --manifest-path=<path>  Path to the manifest to add a dependency to.
+    --fetch-prereleases     Include prerelease versions when fetching from crates.io (e.g.
+                            '0.6.0-alpha'). Defaults to false.
     -h --help               Show this help page.
     --version               Show version.
 


### PR DESCRIPTION
Solves #96. Passes all tests and adds a couple to test the new features. Updates the version fetcher algorithm to ignore prerelease versions unless the --fetch-prereleases flag is passed to it.

@killercup Any suggestions/changes?