### PR TITLE
Add `--update-only` flag to cargo-add

### DIFF
--- a/src/bin/add/args.rs
+++ b/src/bin/add/args.rs
@@ -43,6 +43,8 @@ pub struct Args {
     pub flag_version: bool,
     /// `---upgrade`
     pub flag_upgrade: Option<String>,
+    /// `--update-only`
+    pub flag_update_only: bool,
     /// '--fetch-prereleases'
     pub flag_allow_prerelease: bool,
 }
@@ -144,6 +146,7 @@ impl Default for Args {
             flag_manifest_path: None,
             flag_version: false,
             flag_upgrade: None,
+            flag_update_only: false,
             flag_allow_prerelease: false,
         }
     }

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -165,9 +165,8 @@ impl Manifest {
                              dep: &Dependency)
                              -> Result<(), ManifestError> {
         let (ref name, ref data) = dep.to_toml();
-        let manifest = &mut self.data;
 
-        let mut entry = manifest;
+        let mut entry = &mut self.data;
         for part in table {
             let tmp_entry = entry; // Make the borrow checker happy
             let value = tmp_entry.entry(part.clone())
@@ -178,6 +177,30 @@ impl Manifest {
             }
         }
         entry.insert(name.clone(), data.clone());
+        Ok(())
+    }
+
+    /// Update an entry in Cargo.toml.
+    #[cfg_attr(feature = "dev", allow(toplevel_ref_arg))]
+    pub fn update_table_entry(&mut self,
+                              table: &[String],
+                              dep: &Dependency)
+                              -> Result<(), ManifestError> {
+        let (ref name, ref data) = dep.to_toml();
+
+        let mut entry = &mut self.data;
+        for part in table {
+            let tmp_entry = entry; // Make the borrow checker happy
+            let value = tmp_entry.entry(part.clone())
+                .or_insert_with(|| toml::Value::Table(BTreeMap::new()));
+            match *value {
+                toml::Value::Table(ref mut table) => entry = table,
+                _ => return Err(ManifestError::NonExistentTable(part.clone())),
+            }
+        }
+        if entry.contains_key(name) {
+            entry.insert(name.clone(), data.clone());
+        }
         Ok(())
     }
 
@@ -275,6 +298,29 @@ mod tests {
         let _ = manifest.insert_into_table(&["dependencies".to_owned()], &dep);
         assert!(manifest.remove_from_table("dependencies", &dep.name).is_ok());
         assert_eq!(manifest, clone);
+    }
+
+    #[test]
+    fn update_dependency() {
+        let mut manifest = Manifest { data: toml::Table::new() };
+        let dep = Dependency::new("cargo-edit").set_version("0.1.0");
+        manifest.insert_into_table(&["dependencies".to_owned()], &dep).unwrap();
+
+        let new_dep = Dependency::new("cargo-edit").set_version("0.2.0");
+        manifest.update_table_entry(&["dependencies".to_owned()], &new_dep).unwrap();
+    }
+
+    #[test]
+    fn update_wrong_dependency() {
+        let mut manifest = Manifest { data: toml::Table::new() };
+        let dep = Dependency::new("cargo-edit").set_version("0.1.0");
+        manifest.insert_into_table(&["dependencies".to_owned()], &dep).unwrap();
+        let original = manifest.clone();
+
+        let new_dep = Dependency::new("wrong-dep").set_version("0.2.0");
+        manifest.update_table_entry(&["dependencies".to_owned()], &new_dep).unwrap();
+
+        assert_eq!(manifest, original);
     }
 
     #[test]

--- a/tests/cargo-add.rs
+++ b/tests/cargo-add.rs
@@ -549,6 +549,38 @@ fn fails_to_add_inexistent_local_source_without_flag() {
 }
 
 #[test]
+fn upgrade_dependency_version() {
+    let (_tmpdir, manifest) = clone_out_test("tests/fixtures/add/Cargo.toml.sample");
+
+    // Setup manifest with the dependency `versioned-package@0.1.1`
+    execute_command(&["add", "versioned-package", "--vers", "0.1.1"],
+                    &manifest);
+
+    // Now, update `versioned-package` to the latest version
+    execute_command(&["add", "versioned-package", "--update-only"],
+                    &manifest);
+
+    // Verify that `versioned-package` has been updated successfully.
+    let toml = get_toml(&manifest);
+    let val = toml.lookup("dependencies.versioned-package").expect("not added");
+    assert_eq!(val.as_str().expect("not string"), "versioned-package--CURRENT_VERSION_TEST");
+}
+
+#[test]
+#[should_panic(expected = "not added")]
+fn fails_to_update_missing_dependency() {
+    let (_tmpdir, manifest) = clone_out_test("tests/fixtures/add/Cargo.toml.sample");
+
+    // Update the non-existent `failure` to the latest version
+    execute_command(&["add", "failure", "--update-only"],
+                    &manifest);
+
+    // Verify that `failure` has not been added
+    assert!(no_manifest_failures(&get_toml(&manifest)));
+    get_toml(&manifest).lookup("dependencies.failure").expect("not added");
+}
+
+#[test]
 fn no_argument() {
     assert_cli!("target/debug/cargo-add", &["add"] => Error 1,
                 r"Invalid arguments.


### PR DESCRIPTION
This adds the specified dependency/ies only if they are already present. Thus, it acts like a 'cargo upgrade' (see #74).

This PR is a partial solution to the problem of updating dependencies in `Cargo.toml` for crates in a workspace that do not share the same set of dependencies. Once this has been merged, one will then be able to upgrade the dependency `foo` for all crates by running `cargo multi add --update-only foo` (using [cargo-multi](https://crates.io/crates/cargo-multi)).