### PR TITLE
Enable clippy properly and fix non-spurious warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ before_script:
 script:
 - |
   travis-cargo build &&
+  travis-cargo --only nightly-2017-06-25 build -- --features dev &&
   travis-cargo test -- --features test-external-apis &&
   travis-cargo bench &&
   travis-cargo --only stable doc

--- a/src/bin/add/args.rs
+++ b/src/bin/add/args.rs
@@ -6,16 +6,6 @@ use fetch::{get_crate_name_from_github, get_crate_name_from_gitlab, get_crate_na
 use semver;
 use std::error::Error;
 
-macro_rules! toml_table {
-    ($($key:expr => $value:expr),+) => {
-        {
-            let mut dep = BTreeMap::new();
-            $(dep.insert(String::from($key), $value);)+
-            toml::Value::Table(dep)
-        }
-    }
-}
-
 #[derive(Debug, RustcDecodable)]
 /// Docopts input args.
 pub struct Args {
@@ -93,7 +83,7 @@ impl Args {
                 let dependency = Dependency::new(&self.arg_crate);
 
                 if let Some(ref version) = self.flag_vers {
-                    try!(semver::VersionReq::parse(&version));
+                    try!(semver::VersionReq::parse(version));
                     dependency.set_version(version)
                 } else if let Some(ref repo) = self.flag_git {
                     dependency.set_git(repo)
@@ -174,11 +164,11 @@ fn crate_name_is_path(name: &str) -> bool {
 }
 
 fn parse_crate_name_with_version(name: &str) -> Result<Dependency, Box<Error>> {
-    assert!(crate_name_has_version(&name));
+    assert!(crate_name_has_version(name));
 
     let xs: Vec<&str> = name.splitn(2, '@').collect();
     let (name, version) = (xs[0], xs[1]);
-    try!(semver::VersionReq::parse(&version));
+    try!(semver::VersionReq::parse(version));
 
     Ok(Dependency::new(name).set_version(version))
 }

--- a/src/bin/add/fetch.rs
+++ b/src/bin/add/fetch.rs
@@ -93,7 +93,7 @@ fn get_latest_stable_version_from_json() {
     }"#)
         .unwrap();
 
-    assert_eq!(read_latest_version(json, false).unwrap().version().unwrap(),
+    assert_eq!(read_latest_version(&json, false).unwrap().version().unwrap(),
                "0.5.0");
 }
 
@@ -115,7 +115,7 @@ fn get_latest_unstable_or_stable_version_from_json() {
     }"#)
         .unwrap();
 
-    assert_eq!(read_latest_version(json, true).unwrap().version().unwrap(),
+    assert_eq!(read_latest_version(&json, true).unwrap().version().unwrap(),
                "0.6.0-alpha");
 }
 
@@ -137,7 +137,7 @@ fn get_latest_version_from_json_test() {
     }"#)
         .unwrap();
 
-    assert_eq!(read_latest_version(json, false).unwrap().version().unwrap(),
+    assert_eq!(read_latest_version(&json, false).unwrap().version().unwrap(),
                "0.3.0");
 }
 
@@ -159,7 +159,7 @@ fn get_no_latest_version_from_json_when_all_are_yanked() {
     }"#)
         .unwrap();
 
-    assert!(read_latest_version(json, false).is_err());
+    assert!(read_latest_version(&json, false).is_err());
 }
 
 quick_error! {

--- a/src/bin/add/fetch.rs
+++ b/src/bin/add/fetch.rs
@@ -28,7 +28,7 @@ pub fn get_latest_dependency(crate_name: &str, flag_allow_prerelease: bool) -> R
     let crate_data = try!(fetch_cratesio(&format!("/crates/{}", crate_name)));
     let crate_json = try!(Json::from_str(&crate_data));
 
-    let dep = try!(read_latest_version(crate_json, flag_allow_prerelease));
+    let dep = try!(read_latest_version(&crate_json, flag_allow_prerelease));
 
     if dep.name != crate_name {
         println!("WARN: Added `{}` instead of `{}`", dep.name, crate_name);
@@ -50,7 +50,7 @@ fn version_is_stable(version: &Object) -> bool {
 ///
 /// Assumes the version are sorted so that the first non-yanked version is the
 /// latest, and thus the one we want.
-fn read_latest_version(crate_json: Json, flag_allow_prerelease: bool) -> Result<Dependency, FetchVersionError> {
+fn read_latest_version(crate_json: &Json, flag_allow_prerelease: bool) -> Result<Dependency, FetchVersionError> {
     let versions = try!(crate_json.as_object()
         .and_then(|c| c.get("versions"))
         .and_then(Json::as_array)

--- a/src/bin/add/main.rs
+++ b/src/bin/add/main.rs
@@ -76,9 +76,9 @@ fn handle_add(args: &Args) -> Result<(), Box<Error>> {
     deps
         .iter()
         .map(|dep| if args.flag_update_only {
-            manifest.update_table_entry(&args.get_section(), &dep)
+            manifest.update_table_entry(&args.get_section(), dep)
         } else {
-            manifest.insert_into_table(&args.get_section(), &dep)})
+            manifest.insert_into_table(&args.get_section(), dep)})
         .collect::<Result<Vec<_>,_>>()
         .map_err(|err| {
             println!("Could not edit `Cargo.toml`.\n\nERROR: {}", err);

--- a/src/bin/list/tree.rs
+++ b/src/bin/list/tree.rs
@@ -31,7 +31,7 @@ fn parse_dep_from_str(input: &str) -> Option<Dependency> {
 fn get_root_deps(lock_file: &toml::value::Table) -> Result<Vec<Dependency>, ListError> {
     let root_deps = try!(lock_file.get("root")
         .and_then(|field| field.get("dependencies").to_owned())
-        .ok_or(ListError::SectionMissing("dependencies".to_owned())));
+        .ok_or_else(|| ListError::SectionMissing("dependencies".to_owned())));
 
     Ok(root_deps.as_array()
         .into_iter()

--- a/tests/cargo-add.rs
+++ b/tests/cargo-add.rs
@@ -5,7 +5,14 @@ extern crate toml;
 
 use std::process;
 mod utils;
-use utils::{clone_out_test, execute_command, get_toml, no_manifest_failures};
+use utils::{clone_out_test, execute_command, get_toml};
+
+/// Check 'failure' deps are not present
+fn no_manifest_failures(manifest: &toml::Value) -> bool {
+    manifest.get("dependencies.failure").is_none() &&
+    manifest.get("dev-dependencies.failure").is_none() &&
+    manifest.get("build-dependencies.failure").is_none()
+}
 
 #[test]
 fn adds_dependency() {

--- a/tests/utils.rs
+++ b/tests/utils.rs
@@ -44,10 +44,3 @@ pub fn get_toml(manifest_path: &str) -> toml::Value {
     f.read_to_string(&mut s).unwrap();
     s.parse().unwrap()
 }
-
-/// Assert 'failure' deps are not present
-pub fn no_manifest_failures(manifest: &toml::Value) -> bool {
-    manifest.get("dependencies.failure").is_none() &&
-    manifest.get("dev-dependencies.failure").is_none() &&
-    manifest.get("build-dependencies.failure").is_none()
-}


### PR DESCRIPTION
See #121.

This enables clippy for `nightly-2017-06-25` and fixes most of the clippy warnings.