### PR TITLE
Standardize style

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,25 +1,14 @@
 [package]
-name = "cargo-edit"
-authors = ["Without Boats <lee@libertad.ucsd.edu>",
-           "Pascal Hertleif <killercup@gmail.com>",
-           "Sebastian Garrido <sebasgarcep@gmail.com>",
-           "Jonas Platte <mail@jonasplatte.de>"]
-
-version = "0.1.6"
-
+authors = ["Without Boats <lee@libertad.ucsd.edu>", "Pascal Hertleif <killercup@gmail.com>", "Sebastian Garrido <sebasgarcep@gmail.com>", "Jonas Platte <mail@jonasplatte.de>"]
 description = "This extends Cargo to allow you to add and list dependencies by reading/writing to your `Cargo.toml` file from the command line. It contains `cargo add`, `cargo rm`, and `cargo list`."
-readme = "README.md"
-keywords = ["cargo", "cargo-subcommand", "cli", "dependencies", "crates"]
-license = "Apache-2.0/MIT"
-
 documentation = "http://killercup.github.io/cargo-edit/"
 homepage = "https://github.com/killercup/cargo-edit"
+keywords = ["cargo", "cargo-subcommand", "cli", "dependencies", "crates"]
+license = "Apache-2.0/MIT"
+name = "cargo-edit"
+readme = "README.md"
 repository = "https://github.com/killercup/cargo-edit"
-
-[features]
-default = []
-test-external-apis = []
-unstable = []
+version = "0.1.6"
 
 [[bin]]
 name = "cargo-add"
@@ -32,15 +21,23 @@ path = "src/bin/rm/main.rs"
 [dependencies]
 docopt = "0.8"
 pad = "0.1"
-serde = "1.0"
-serde_derive = "1.0"
-serde_json = "1.0"
-semver = { version = "0.7", features = ["serde"] }
-toml = "0.4"
 quick-error = "1.0.0"
 regex = "0.2"
 reqwest = "0.6"
+serde = "1.0"
+serde_derive = "1.0"
+serde_json = "1.0"
+toml = "0.4"
+
+[dependencies.semver]
+features = ["serde"]
+version = "0.7"
 
 [dev-dependencies]
 assert_cli = "0.2.0"
 tempdir = "0.3"
+
+[features]
+default = []
+test-external-apis = []
+unstable = []

--- a/src/bin/add/args.rs
+++ b/src/bin/add/args.rs
@@ -50,7 +50,11 @@ impl Args {
             if target.is_empty() {
                 panic!("Target specification may not be empty");
             }
-            vec!["target".to_owned(), target.clone(), "dependencies".to_owned()]
+            vec![
+                "target".to_owned(),
+                target.clone(),
+                "dependencies".to_owned(),
+            ]
         } else {
             vec!["dependencies".to_owned()]
         }
@@ -62,11 +66,10 @@ impl Args {
             let mut result = Vec::<Dependency>::new();
             for arg_crate in &self.arg_crates {
                 let le_crate = if crate_name_has_version(arg_crate) {
-                        parse_crate_name_with_version(arg_crate)?
-                    } else {
-                        get_latest_dependency(arg_crate, self.flag_allow_prerelease)?
-                    }
-                    .set_optional(self.flag_optional);
+                    parse_crate_name_with_version(arg_crate)?
+                } else {
+                    get_latest_dependency(arg_crate, self.flag_allow_prerelease)?
+                }.set_optional(self.flag_optional);
 
                 result.push(le_crate);
             }
@@ -74,8 +77,10 @@ impl Args {
         }
 
         if crate_name_has_version(&self.arg_crate) {
-            return Ok(vec![parse_crate_name_with_version(&self.arg_crate)?
-                               .set_optional(self.flag_optional)]);
+            return Ok(vec![
+                parse_crate_name_with_version(&self.arg_crate)?
+                    .set_optional(self.flag_optional),
+            ]);
         }
 
 
@@ -107,17 +112,21 @@ impl Args {
     }
 
     fn get_upgrade_prefix(&self) -> Option<&'static str> {
-        self.flag_upgrade.clone().and_then(|flag| match flag.to_uppercase().as_ref() {
-            "NONE" => Some("="),
-            "PATCH" => Some("~"),
-            "MINOR" => Some("^"),
-            "ALL" => Some(">="),
-            _ => {
-                println!("WARN: cannot understand upgrade option \"{}\", using default",
-                         flag);
-                None
-            }
-        })
+        self.flag_upgrade.clone().and_then(
+            |flag| match flag.to_uppercase().as_ref() {
+                "NONE" => Some("="),
+                "PATCH" => Some("~"),
+                "MINOR" => Some("^"),
+                "ALL" => Some(">="),
+                _ => {
+                    println!(
+                        "WARN: cannot understand upgrade option \"{}\", using default",
+                        flag
+                    );
+                    None
+                }
+            },
+        )
     }
 }
 
@@ -188,7 +197,10 @@ fn parse_crate_name_from_uri(name: &str) -> Result<Dependency, Box<Error>> {
         }
     }
 
-    Err(From::from(format!("Unable to obtain crate informations from `{}`.\n", name)))
+    Err(From::from(format!(
+        "Unable to obtain crate informations from `{}`.\n",
+        name
+    )))
 }
 
 #[cfg(test)]
@@ -204,30 +216,47 @@ mod tests {
             ..Args::default()
         };
 
-        assert_eq!(args.parse_dependencies().unwrap(),
-                   vec![Dependency::new("demo").set_version("0.4.2")]);
+        assert_eq!(
+            args.parse_dependencies().unwrap(),
+            vec![Dependency::new("demo").set_version("0.4.2")]
+        );
     }
 
     #[test]
-    #[cfg(feature="test-external-apis")]
+    #[cfg(feature = "test-external-apis")]
     fn test_repo_as_arg_parsing() {
         let github_url = "https://github.com/killercup/cargo-edit/";
-        let args_github = Args { arg_crate: github_url.to_owned(), ..Args::default() };
-        assert_eq!(args_github.parse_dependencies().unwrap(),
-                   vec![Dependency::new("cargo-edit").set_git(github_url)]);
+        let args_github = Args {
+            arg_crate: github_url.to_owned(),
+            ..Args::default()
+        };
+        assert_eq!(
+            args_github.parse_dependencies().unwrap(),
+            vec![Dependency::new("cargo-edit").set_git(github_url)]
+        );
 
         let gitlab_url = "https://gitlab.com/Polly-lang/Polly.git";
-        let args_gitlab = Args { arg_crate: gitlab_url.to_owned(), ..Args::default() };
-        assert_eq!(args_gitlab.parse_dependencies().unwrap(),
-                   vec![Dependency::new("polly").set_git(gitlab_url)]);
+        let args_gitlab = Args {
+            arg_crate: gitlab_url.to_owned(),
+            ..Args::default()
+        };
+        assert_eq!(
+            args_gitlab.parse_dependencies().unwrap(),
+            vec![Dependency::new("polly").set_git(gitlab_url)]
+        );
     }
 
     #[test]
     fn test_path_as_arg_parsing() {
         let self_path = ".";
-        let args_path = Args { arg_crate: self_path.to_owned(), ..Args::default() };
-        assert_eq!(args_path.parse_dependencies().unwrap(),
-                   vec![Dependency::new("cargo-edit").set_path(self_path)]);
+        let args_path = Args {
+            arg_crate: self_path.to_owned(),
+            ..Args::default()
+        };
+        assert_eq!(
+            args_path.parse_dependencies().unwrap(),
+            vec![Dependency::new("cargo-edit").set_path(self_path)]
+        );
     }
 
 }

--- a/src/bin/add/fetch.rs
+++ b/src/bin/add/fetch.rs
@@ -39,10 +39,10 @@ pub fn get_latest_dependency(
     if env::var("CARGO_IS_TEST").is_ok() {
         // We are in a simulated reality. Nothing is real here.
         // FIXME: Use actual test handling code.
-        return Ok(Dependency::new(crate_name).set_version(&format!(
-            "{}--CURRENT_VERSION_TEST",
-            crate_name
-        )));
+        return Ok(
+            Dependency::new(crate_name)
+                .set_version(&format!("{}--CURRENT_VERSION_TEST", crate_name)),
+        );
     }
 
     let crate_versions = fetch_cratesio(&format!("/crates/{}", crate_name))?;
@@ -214,7 +214,8 @@ quick_error! {
 fn fetch_cratesio(path: &str) -> Result<Versions, FetchVersionError> {
     let url = format!("{host}/api/v1{path}", host = REGISTRY_HOST, path = path);
     let response = get_with_timeout(&url, get_default_timeout())?;
-    let versions: Versions = json::from_reader(response).map_err(FetchVersionError::Json)?;
+    let versions: Versions = json::from_reader(response)
+        .map_err(FetchVersionError::Json)?;
     Ok(versions)
 }
 
@@ -256,9 +257,8 @@ where
         .and_then(|cap| match (cap.get(1), cap.get(2)) {
             (Some(user), Some(repo)) => {
                 let url = url_template(user.as_str(), repo.as_str());
-                let data: Result<Manifest, _> = get_cargo_toml_from_git_url(&url).and_then(|m| {
-                    m.parse().map_err(|_| FetchGitError::ParseCargoToml)
-                });
+                let data: Result<Manifest, _> = get_cargo_toml_from_git_url(&url)
+                    .and_then(|m| m.parse().map_err(|_| FetchGitError::ParseCargoToml));
                 data.and_then(|ref manifest| get_name_from_manifest(manifest))
             }
             _ => Err(FetchGitError::IncompleteCaptures),

--- a/src/bin/add/main.rs
+++ b/src/bin/add/main.rs
@@ -73,13 +73,13 @@ fn handle_add(args: &Args) -> Result<(), Box<Error>> {
     let mut manifest = Manifest::open(&args.flag_manifest_path.as_ref().map(|s| &s[..]))?;
     let deps = args.parse_dependencies()?;
 
-    deps
-        .iter()
+    deps.iter()
         .map(|dep| if args.flag_update_only {
             manifest.update_table_entry(&args.get_section(), dep)
         } else {
-            manifest.insert_into_table(&args.get_section(), dep)})
-        .collect::<Result<Vec<_>,_>>()
+            manifest.insert_into_table(&args.get_section(), dep)
+        })
+        .collect::<Result<Vec<_>, _>>()
         .map_err(|err| {
             println!("Could not edit `Cargo.toml`.\n\nERROR: {}", err);
             err
@@ -100,10 +100,11 @@ fn main() {
     }
 
     if let Err(err) = handle_add(&args) {
-        writeln!(io::stderr(),
-                 "Command failed due to unhandled error: {}\n",
-                 err)
-            .unwrap();
+        writeln!(
+            io::stderr(),
+            "Command failed due to unhandled error: {}\n",
+            err
+        ).unwrap();
         process::exit(1);
     }
 }

--- a/src/bin/rm/main.rs
+++ b/src/bin/rm/main.rs
@@ -37,12 +37,11 @@ Remove a dependency to a Cargo.toml manifest file.
 fn handle_rm(args: &Args) -> Result<(), Box<Error>> {
     let mut manifest = Manifest::open(&args.flag_manifest_path.as_ref().map(|s| &s[..]))?;
 
-    manifest.remove_from_table(args.get_section(), args.arg_crate.as_ref())
+    manifest
+        .remove_from_table(args.get_section(), args.arg_crate.as_ref())
         .map_err(From::from)
         .and_then(|_| {
-            let mut file = Manifest::find_file(&args.flag_manifest_path
-                .as_ref()
-                .map(|s| &s[..]))?;
+            let mut file = Manifest::find_file(&args.flag_manifest_path.as_ref().map(|s| &s[..]))?;
             manifest.write_to_file(&mut file)
         })
 }
@@ -58,10 +57,11 @@ fn main() {
     }
 
     if let Err(err) = handle_rm(&args) {
-        writeln!(io::stderr(),
-                 "Could not edit `Cargo.toml`.\n\nERROR: {}",
-                 err)
-            .unwrap();
+        writeln!(
+            io::stderr(),
+            "Could not edit `Cargo.toml`.\n\nERROR: {}",
+            err
+        ).unwrap();
         process::exit(1);
     }
 }

--- a/src/dependency.rs
+++ b/src/dependency.rs
@@ -30,7 +30,10 @@ impl Default for Dependency {
 impl Dependency {
     /// Create a new dependency with a name
     pub fn new(name: &str) -> Dependency {
-        Dependency { name: name.into(), ..Dependency::default() }
+        Dependency {
+            name: name.into(),
+            ..Dependency::default()
+        }
     }
 
     /// Set dependency to a given version

--- a/tests/cargo-add.rs
+++ b/tests/cargo-add.rs
@@ -10,8 +10,8 @@ use utils::{clone_out_test, execute_command, get_toml};
 /// Check 'failure' deps are not present
 fn no_manifest_failures(manifest: &toml::Value) -> bool {
     manifest.get("dependencies.failure").is_none() &&
-    manifest.get("dev-dependencies.failure").is_none() &&
-    manifest.get("build-dependencies.failure").is_none()
+        manifest.get("dev-dependencies.failure").is_none() &&
+        manifest.get("build-dependencies.failure").is_none()
 }
 
 #[test]
@@ -104,11 +104,15 @@ fn adds_dev_build_dependency() {
     // dependency present afterwards
     let toml = get_toml(&manifest);
     let val = &toml["dev-dependencies"]["my-dev-package"];
-    assert_eq!(val.as_str().unwrap(),
-               "my-dev-package--CURRENT_VERSION_TEST");
+    assert_eq!(
+        val.as_str().unwrap(),
+        "my-dev-package--CURRENT_VERSION_TEST"
+    );
     let val = &toml["build-dependencies"]["my-build-package"];
-    assert_eq!(val.as_str().unwrap(),
-               "my-build-package--CURRENT_VERSION_TEST");
+    assert_eq!(
+        val.as_str().unwrap(),
+        "my-build-package--CURRENT_VERSION_TEST"
+    );
 
     // cannot run with both --dev and --build at the same time
     let call = process::Command::new("target/debug/cargo-add")
@@ -132,25 +136,37 @@ fn adds_multiple_dev_build_dependencies() {
     assert!(toml.get("build-dependencies").is_none());
     assert!(toml.get("build-dependencies").is_none());
 
-    execute_command(&["add", "my-dev-package1", "my-dev-package2", "--dev"],
-                    &manifest);
-    execute_command(&["add", "my-build-package1", "--build", "my-build-package2"],
-                    &manifest);
+    execute_command(
+        &["add", "my-dev-package1", "my-dev-package2", "--dev"],
+        &manifest,
+    );
+    execute_command(
+        &["add", "my-build-package1", "--build", "my-build-package2"],
+        &manifest,
+    );
 
     // dependencies present afterwards
     let toml = get_toml(&manifest);
     let val = &toml["dev-dependencies"]["my-dev-package1"];
-    assert_eq!(val.as_str().unwrap(),
-               "my-dev-package1--CURRENT_VERSION_TEST");
+    assert_eq!(
+        val.as_str().unwrap(),
+        "my-dev-package1--CURRENT_VERSION_TEST"
+    );
     let val = &toml["dev-dependencies"]["my-dev-package2"];
-    assert_eq!(val.as_str().unwrap(),
-               "my-dev-package2--CURRENT_VERSION_TEST");
+    assert_eq!(
+        val.as_str().unwrap(),
+        "my-dev-package2--CURRENT_VERSION_TEST"
+    );
     let val = &toml["build-dependencies"]["my-build-package1"];
-    assert_eq!(val.as_str().unwrap(),
-               "my-build-package1--CURRENT_VERSION_TEST");
+    assert_eq!(
+        val.as_str().unwrap(),
+        "my-build-package1--CURRENT_VERSION_TEST"
+    );
     let val = &toml["build-dependencies"]["my-build-package2"];
-    assert_eq!(val.as_str().unwrap(),
-               "my-build-package2--CURRENT_VERSION_TEST");
+    assert_eq!(
+        val.as_str().unwrap(),
+        "my-build-package2--CURRENT_VERSION_TEST"
+    );
 }
 
 #[test]
@@ -161,8 +177,10 @@ fn adds_specified_version() {
     let toml = get_toml(&manifest);
     assert!(toml.get("dependencies").is_none());
 
-    execute_command(&["add", "versioned-package", "--vers", ">=0.1.1"],
-                    &manifest);
+    execute_command(
+        &["add", "versioned-package", "--vers", ">=0.1.1"],
+        &manifest,
+    );
 
     // dependency present afterwards
     let toml = get_toml(&manifest);
@@ -205,8 +223,10 @@ fn adds_multiple_dependencies_with_versions() {
     assert!(toml.get("dependencies").is_none());
     assert!(toml.get("dependencies").is_none());
 
-    execute_command(&["add", "my-package1@>=0.1.1", "my-package2@0.2.3"],
-                    &manifest);
+    execute_command(
+        &["add", "my-package1@>=0.1.1", "my-package2@0.2.3"],
+        &manifest,
+    );
 
     // dependencies present afterwards
     let toml = get_toml(&manifest);
@@ -230,8 +250,10 @@ fn adds_multiple_dependencies_with_some_versions() {
     // dependencies present afterwards
     let toml = get_toml(&manifest);
     let val = &toml["dependencies"]["my-package1"];
-    assert_eq!(val.as_str().expect("not string"),
-               "my-package1--CURRENT_VERSION_TEST");
+    assert_eq!(
+        val.as_str().expect("not string"),
+        "my-package1--CURRENT_VERSION_TEST"
+    );
     let val = &toml["dependencies"]["my-package2"];
     assert_eq!(val.as_str().expect("not string"), "0.2.3");
 }
@@ -244,25 +266,38 @@ fn adds_git_source_using_flag() {
     let toml = get_toml(&manifest);
     assert!(toml.get("dependencies").is_none());
 
-    execute_command(&["add", "git-package", "--git", "http://localhost/git-package.git"],
-                    &manifest);
+    execute_command(
+        &[
+            "add",
+            "git-package",
+            "--git",
+            "http://localhost/git-package.git",
+        ],
+        &manifest,
+    );
 
     let toml = get_toml(&manifest);
     let val = &toml["dependencies"]["git-package"];
-    assert_eq!(val.as_table().unwrap()["git"].as_str().unwrap(),
-               "http://localhost/git-package.git");
+    assert_eq!(
+        val.as_table().unwrap()["git"].as_str().unwrap(),
+        "http://localhost/git-package.git"
+    );
 
     // check this works with other flags (e.g. --dev) as well
     let toml = get_toml(&manifest);
     assert!(toml.get("dev-dependencies").is_none());
 
-    execute_command(&["add", "git-dev-pkg", "--git", "http://site/gp.git", "--dev"],
-                    &manifest);
+    execute_command(
+        &["add", "git-dev-pkg", "--git", "http://site/gp.git", "--dev"],
+        &manifest,
+    );
 
     let toml = get_toml(&manifest);
     let val = &toml["dev-dependencies"]["git-dev-pkg"];
-    assert_eq!(val.as_table().unwrap()["git"].as_str().unwrap(),
-               "http://site/gp.git");
+    assert_eq!(
+        val.as_table().unwrap()["git"].as_str().unwrap(),
+        "http://site/gp.git"
+    );
 }
 
 #[test]
@@ -277,24 +312,30 @@ fn adds_local_source_using_flag() {
 
     let toml = get_toml(&manifest);
     let val = &toml["dependencies"]["local"];
-    assert_eq!(val.as_table().unwrap()["path"].as_str().unwrap(),
-               "/path/to/pkg");
+    assert_eq!(
+        val.as_table().unwrap()["path"].as_str().unwrap(),
+        "/path/to/pkg"
+    );
 
     // check this works with other flags (e.g. --dev) as well
     let toml = get_toml(&manifest);
     assert!(toml.get("dev-dependencies").is_none());
 
-    execute_command(&["add", "local-dev", "--path", "/path/to/pkg-dev", "--dev"],
-                    &manifest);
+    execute_command(
+        &["add", "local-dev", "--path", "/path/to/pkg-dev", "--dev"],
+        &manifest,
+    );
 
     let toml = get_toml(&manifest);
     let val = &toml["dev-dependencies"]["local-dev"];
-    assert_eq!(val.as_table().unwrap()["path"].as_str().unwrap(),
-               "/path/to/pkg-dev");
+    assert_eq!(
+        val.as_table().unwrap()["path"].as_str().unwrap(),
+        "/path/to/pkg-dev"
+    );
 }
 
 #[test]
-#[cfg(feature="test-external-apis")]
+#[cfg(feature = "test-external-apis")]
 fn adds_git_source_without_flag() {
     let (_tmpdir, manifest) = clone_out_test("tests/fixtures/add/Cargo.toml.sample");
 
@@ -302,26 +343,38 @@ fn adds_git_source_without_flag() {
     let toml = get_toml(&manifest);
     assert!(toml.get("dependencies").is_none());
 
-    execute_command(&["add", "https://github.com/killercup/cargo-edit.git"],
-                    &manifest);
+    execute_command(
+        &["add", "https://github.com/killercup/cargo-edit.git"],
+        &manifest,
+    );
 
     let toml = get_toml(&manifest);
     let val = &toml["dependencies"]["cargo-edit"];
-    assert_eq!(val.as_table().unwrap()["git"].as_str().unwrap(),
-               "https://github.com/killercup/cargo-edit.git");
+    assert_eq!(
+        val.as_table().unwrap()["git"].as_str().unwrap(),
+        "https://github.com/killercup/cargo-edit.git"
+    );
 
     // check this works with other flags (e.g. --dev) as well
     let (_tmpdir, manifest) = clone_out_test("tests/fixtures/add/Cargo.toml.sample");
     let toml = get_toml(&manifest);
     assert!(toml.get("dev-dependencies").is_none());
 
-    execute_command(&["add", "https://github.com/killercup/cargo-edit.git", "--dev"],
-                    &manifest);
+    execute_command(
+        &[
+            "add",
+            "https://github.com/killercup/cargo-edit.git",
+            "--dev",
+        ],
+        &manifest,
+    );
 
     let toml = get_toml(&manifest);
     let val = &toml["dev-dependencies"]["cargo-edit"];
-    assert_eq!(val.as_table().unwrap()["git"].as_str().unwrap(),
-               "https://github.com/killercup/cargo-edit.git");
+    assert_eq!(
+        val.as_table().unwrap()["git"].as_str().unwrap(),
+        "https://github.com/killercup/cargo-edit.git"
+    );
 }
 
 #[test]
@@ -340,8 +393,7 @@ fn adds_local_source_without_flag() {
 
     let toml = get_toml(&manifest);
     let val = &toml["dependencies"]["foo-crate"];
-    assert_eq!(val.as_table().unwrap()["path"].as_str().unwrap(),
-               tmpdirstr);
+    assert_eq!(val.as_table().unwrap()["path"].as_str().unwrap(), tmpdirstr);
 
     // check this works with other flags (e.g. --dev) as well
     let (_tmpdir, manifest) = clone_out_test("tests/fixtures/add/Cargo.toml.sample");
@@ -352,8 +404,7 @@ fn adds_local_source_without_flag() {
 
     let toml = get_toml(&manifest);
     let val = &toml["dev-dependencies"]["foo-crate"];
-    assert_eq!(val.as_table().unwrap()["path"].as_str().unwrap(),
-               tmpdirstr);
+    assert_eq!(val.as_table().unwrap()["path"].as_str().unwrap(), tmpdirstr);
 }
 
 #[test]
@@ -381,8 +432,16 @@ fn adds_optional_dependency() {
     let toml = get_toml(&manifest);
     assert!(toml.get("dependencies").is_none());
 
-    execute_command(&["add", "versioned-package", "--vers", ">=0.1.1", "--optional"],
-                    &manifest);
+    execute_command(
+        &[
+            "add",
+            "versioned-package",
+            "--vers",
+            ">=0.1.1",
+            "--optional",
+        ],
+        &manifest,
+    );
 
     // dependency present afterwards
     let toml = get_toml(&manifest);
@@ -398,14 +457,19 @@ fn adds_multiple_optional_dependencies() {
     let toml = get_toml(&manifest);
     assert!(toml.get("dependencies").is_none());
 
-    execute_command(&["add", "--optional", "my-package1", "my-package2"],
-                    &manifest);
+    execute_command(
+        &["add", "--optional", "my-package1", "my-package2"],
+        &manifest,
+    );
 
     // dependencies present afterwards
     let toml = get_toml(&manifest);
-    assert!(&toml["dependencies"]["my-package1"]["optional"].as_bool().expect("optional not a bool"));
-    assert!(&toml["dependencies"]["my-package2"]["optional"].as_bool()
-                .expect("optional not a bool"));
+    assert!(&toml["dependencies"]["my-package1"]["optional"]
+        .as_bool()
+        .expect("optional not a bool"));
+    assert!(&toml["dependencies"]["my-package2"]["optional"]
+        .as_bool()
+        .expect("optional not a bool"));
 }
 
 #[test]
@@ -416,8 +480,10 @@ fn adds_dependency_with_target_triple() {
     let toml = get_toml(&manifest);
     assert!(toml.get("target").is_none());
 
-    execute_command(&["add", "--target", "i686-unknown-linux-gnu", "my-package1"],
-                    &manifest);
+    execute_command(
+        &["add", "--target", "i686-unknown-linux-gnu", "my-package1"],
+        &manifest,
+    );
 
     // dependencies present afterwards
     let toml = get_toml(&manifest);
@@ -447,8 +513,10 @@ fn adds_dependency_with_target_cfg() {
 fn adds_dependency_with_custom_target() {
     let (_tmpdir, manifest) = clone_out_test("tests/fixtures/add/Cargo.toml.sample");
 
-    execute_command(&["add", "--target", "x86_64/windows.json", "my-package1"],
-                    &manifest);
+    execute_command(
+        &["add", "--target", "x86_64/windows.json", "my-package1"],
+        &manifest,
+    );
 
     // dependencies present afterwards
     let toml = get_toml(&manifest);
@@ -466,7 +534,7 @@ fn adds_dependency_with_custom_target() {
 
 
 #[test]
-#[cfg(feature="test-external-apis")]
+#[cfg(feature = "test-external-apis")]
 fn adds_dependency_normalized_name() {
     let (_tmpdir, manifest) = clone_out_test("tests/fixtures/add/Cargo.toml.sample");
 
@@ -504,8 +572,17 @@ fn fails_to_add_optional_dev_dependency() {
     assert!(toml.get("dependencies").is_none());
 
     // Fails because optional dependencies must be in `dependencies` table.
-    execute_command(&["add", "versioned-package", "--vers", ">=0.1.1", "--dev", "--optional"],
-                    &manifest);
+    execute_command(
+        &[
+            "add",
+            "versioned-package",
+            "--vers",
+            ">=0.1.1",
+            "--dev",
+            "--optional",
+        ],
+        &manifest,
+    );
 }
 
 #[test]
@@ -519,13 +596,15 @@ fn fails_to_add_multiple_optional_dev_dependencies() {
     assert!(toml.get("dependencies").is_none());
 
     // Fails because optional dependencies must be in `dependencies` table.
-    execute_command(&["add", "--optional", "my-package1", "my-package2", "--dev"],
-                    &manifest);
+    execute_command(
+        &["add", "--optional", "my-package1", "my-package2", "--dev"],
+        &manifest,
+    );
 }
 
 #[test]
 #[should_panic]
-#[cfg(feature="test-external-apis")]
+#[cfg(feature = "test-external-apis")]
 fn fails_to_add_inexistent_git_source_without_flag() {
     let (_tmpdir, manifest) = clone_out_test("tests/fixtures/add/Cargo.toml.sample");
 
@@ -533,8 +612,10 @@ fn fails_to_add_inexistent_git_source_without_flag() {
     let toml = get_toml(&manifest);
     assert!(toml.get("dependencies").is_none());
 
-    execute_command(&["add", "https://github.com/killercup/fake-git-repo.git"],
-                    &manifest);
+    execute_command(
+        &["add", "https://github.com/killercup/fake-git-repo.git"],
+        &manifest,
+    );
 }
 
 #[test]
@@ -554,17 +635,18 @@ fn upgrade_dependency_version() {
     let (_tmpdir, manifest) = clone_out_test("tests/fixtures/add/Cargo.toml.sample");
 
     // Setup manifest with the dependency `versioned-package@0.1.1`
-    execute_command(&["add", "versioned-package", "--vers", "0.1.1"],
-                    &manifest);
+    execute_command(&["add", "versioned-package", "--vers", "0.1.1"], &manifest);
 
     // Now, update `versioned-package` to the latest version
-    execute_command(&["add", "versioned-package", "--update-only"],
-                    &manifest);
+    execute_command(&["add", "versioned-package", "--update-only"], &manifest);
 
     // Verify that `versioned-package` has been updated successfully.
     let toml = get_toml(&manifest);
     let val = &toml["dependencies"]["versioned-package"];
-    assert_eq!(val.as_str().expect("not string"), "versioned-package--CURRENT_VERSION_TEST");
+    assert_eq!(
+        val.as_str().expect("not string"),
+        "versioned-package--CURRENT_VERSION_TEST"
+    );
 }
 
 #[test]
@@ -573,12 +655,13 @@ fn fails_to_update_missing_dependency() {
     let (_tmpdir, manifest) = clone_out_test("tests/fixtures/add/Cargo.toml.sample");
 
     // Update the non-existent `failure` to the latest version
-    execute_command(&["add", "failure", "--update-only"],
-                    &manifest);
+    execute_command(&["add", "failure", "--update-only"], &manifest);
 
     // Verify that `failure` has not been added
     assert!(no_manifest_failures(&get_toml(&manifest)));
-    get_toml(&manifest)["dependencies"].get("failure").expect("not added");
+    get_toml(&manifest)["dependencies"]
+        .get("failure")
+        .expect("not added");
 }
 
 #[test]
@@ -590,8 +673,7 @@ Usage:
     cargo add <crate> [--dev|--build|--optional] [--vers=<ver>|--git=<uri>|--path=<uri>] [options]
     cargo add <crates>... [--dev|--build|--optional] [options]
     cargo add (-h|--help)
-    cargo add --version")
-        .unwrap();
+    cargo add --version").unwrap();
 }
 
 #[test]
@@ -603,6 +685,5 @@ Usage:
     cargo add <crate> [--dev|--build|--optional] [--vers=<ver>|--git=<uri>|--path=<uri>] [options]
     cargo add <crates>... [--dev|--build|--optional] [options]
     cargo add (-h|--help)
-    cargo add --version")
-        .unwrap();
+    cargo add --version").unwrap();
 }

--- a/tests/cargo-rm.rs
+++ b/tests/cargo-rm.rs
@@ -40,8 +40,7 @@ fn remove_section_after_removed_last_dependency() {
 
     let toml = get_toml(&manifest);
     assert!(toml["dev-dependencies"].get("regex").is_some());
-    assert_eq!(toml["dev-dependencies"].as_table().unwrap().len(),
-               1);
+    assert_eq!(toml["dev-dependencies"].as_table().unwrap().len(), 1);
 
     execute_command(&["rm", "--dev", "regex"], &manifest);
 
@@ -93,8 +92,7 @@ fn invalid_section() {
                 &["rm", "semver", "--build", &format!("--manifest-path={}", manifest)]
                 => Error 1, "Could not edit `Cargo.toml`.
 
-ERROR: The table `build-dependencies` could not be found.")
-        .unwrap();
+ERROR: The table `build-dependencies` could not be found.").unwrap();
 }
 
 #[test]
@@ -105,8 +103,7 @@ fn invalid_dependency_in_section() {
                 &["rm", "semver", "--dev", &format!("--manifest-path={}", manifest)]
                 => Error 1, "Could not edit `Cargo.toml`.
 
-ERROR: The dependency `semver` could not be found in `dev-dependencies`.")
-        .unwrap();
+ERROR: The dependency `semver` could not be found in `dev-dependencies`.").unwrap();
 }
 
 #[test]
@@ -117,8 +114,7 @@ fn no_argument() {
 Usage:
     cargo rm <crate> [--dev|--build] [options]
     cargo rm (-h|--help)
-    cargo rm --version")
-        .unwrap();
+    cargo rm --version").unwrap();
 }
 
 #[test]
@@ -129,6 +125,5 @@ fn unknown_flags() {
 Usage:
     cargo rm <crate> [--dev|--build] [options]
     cargo rm (-h|--help)
-    cargo rm --version")
-        .unwrap();
+    cargo rm --version").unwrap();
 }

--- a/tests/utils.rs
+++ b/tests/utils.rs
@@ -11,14 +11,21 @@ pub fn clone_out_test(source: &str) -> (tempdir::TempDir, String) {
         .expect("failed to construct temporary directory");
     fs::copy(source, tmpdir.path().join("Cargo.toml"))
         .unwrap_or_else(|err| panic!("could not copy test manifest: {}", err));
-    let path = tmpdir.path().join("Cargo.toml").to_str().unwrap().to_string().clone();
+    let path = tmpdir
+        .path()
+        .join("Cargo.toml")
+        .to_str()
+        .unwrap()
+        .to_string()
+        .clone();
 
     (tmpdir, path)
 }
 
 /// Execute localc cargo command, includes `--manifest-path`
 pub fn execute_command<S>(command: &[S], manifest: &str)
-    where S: AsRef<OsStr>
+where
+    S: AsRef<OsStr>,
 {
     let subcommand_name = &command[0].as_ref().to_str().unwrap();
 


### PR DESCRIPTION
The reasoning is simple: Running cargo-add and rustfmt will currently cause this diff. If you do that now, we can freely use these tools in the future without a huge mess.