### PR TITLE
Properly support updating dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5,6 +5,7 @@ dependencies = [
  "assert_cli 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "docopt 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "pad 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pretty_assertions 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "quick-error 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "reqwest 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -103,6 +104,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "getopts 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "difference"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "docopt"
@@ -306,6 +312,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "pkg-config"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "pretty_assertions"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "difference 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "quick-error"
@@ -630,6 +644,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum core-foundation-sys 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "065a5d7ffdcbc8fa145d6f0746f3555025b9097a9e9cda59f7467abae670c78d"
 "checksum crypt32-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e34988f7e069e0b2f3bfc064295161e489b2d4e04a2e4248fb94360cdf00b4ec"
 "checksum difference 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ffef4c144e881a906ed5bd6e1e749dc1955cd3f0c7969d3d34122a971981c5ea"
+"checksum difference 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b3304d19798a8e067e48d8e69b2c37f0b5e9b4e462504ad9e27e9f3fce02bba8"
 "checksum docopt 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3b5b93718f8b3e5544fcc914c43de828ca6c6ace23e0332c6080a2977b49787a"
 "checksum dtoa 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "80c8b71fd71146990a9742fc06dcbbde19161a267e0ad4e572c35162f4578c90"
 "checksum foreign-types 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3e4056b9bd47f8ac5ba12be771f77a0dae796d1bbaaf5fd0b9c2d38b69b8a29d"
@@ -657,6 +672,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum pad 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "d1bf3336e626b898e7263790d432a711d4277e22faea20dd9f70e0cab268fa58"
 "checksum percent-encoding 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "de154f638187706bde41d9b4738748933d64e6b37bdbffc0b47a97d16a6ae356"
 "checksum pkg-config 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "3a8b4c6b8165cd1a1cd4b9b120978131389f64bdaf456435caa41e630edba903"
+"checksum pretty_assertions 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "1d510007841e87c7a6d829a36f7f0acb72aef12e38cc89073fe39810c1d976ac"
 "checksum quick-error 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3c36987d4978eb1be2e422b1e0423a557923a5c3e7e6f31d5699e9aafaefa469"
 "checksum quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)" = "7a6e920b65c65f10b2ae65c831a81a073a89edd28c7cce89475bff467ab4167a"
 "checksum rand 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)" = "022e0636ec2519ddae48154b028864bdce4eaf7d35226ab8e65c611be97b189d"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,6 @@ appveyor = { repository = "killercup/cargo-edit" }
 [[bin]]
 name = "cargo-add"
 path = "src/bin/add/main.rs"
-
 [[bin]]
 name = "cargo-rm"
 path = "src/bin/rm/main.rs"
@@ -40,6 +39,7 @@ version = "0.7"
 
 [dev-dependencies]
 assert_cli = "0.2.0"
+pretty_assertions = "0.2.1"
 tempdir = "0.3"
 
 [features]

--- a/README.md
+++ b/README.md
@@ -91,7 +91,8 @@ Options:
     --upgrade=<method>      Choose method of semantic version upgrade. Must be one of
                             "none" (exact version), "patch" (`~` modifier), "minor"
                             (`^` modifier, default), or "all" (`>=`).
-    --update-only           Only add the updated dependency if it already exists.
+    --update-only           If the dependency already exists, it will have its version updated,
+                            preserving all other fields. The dependency will not be added if absent.
     --manifest-path=<path>  Path to the manifest to add a dependency to.
     --allow-prerelease      Include prerelease versions when fetching from crates.io (e.g.
                             '0.6.0-alpha'). Defaults to false.
@@ -105,8 +106,7 @@ and set the appropriate `--git` or `--path` value.
 Please note that Cargo treats versions like "1.2.3" as "^1.2.3" (and that "^1.2.3" is specified
 as ">=1.2.3 and <2.0.0"). By default, `cargo add` will use this format, as it is the one that the
 crates.io registry suggests. One goal of `cargo add` is to prevent you from using wildcard
-dependencies (version set to "*").tomatically get the crate name and set the
-appropriate `--git` or `--path` value. 
+dependencies (version set to "*").
 ```
 
 ### `cargo rm`

--- a/src/bin/add/args.rs
+++ b/src/bin/add/args.rs
@@ -5,6 +5,7 @@ use fetch::{get_crate_name_from_github, get_crate_name_from_gitlab, get_crate_na
             get_latest_dependency};
 use semver;
 use std::error::Error;
+use std::path::PathBuf;
 
 #[derive(Debug, Deserialize)]
 /// Docopts input args.
@@ -22,13 +23,13 @@ pub struct Args {
     /// Git repo Path
     pub flag_git: Option<String>,
     /// Crate directory path
-    pub flag_path: Option<String>,
+    pub flag_path: Option<PathBuf>,
     /// Crate directory path
     pub flag_target: Option<String>,
     /// Optional dependency
     pub flag_optional: bool,
     /// `Cargo.toml` path
-    pub flag_manifest_path: Option<String>,
+    pub flag_manifest_path: Option<PathBuf>,
     /// `--version`
     pub flag_version: bool,
     /// `---upgrade`
@@ -40,7 +41,7 @@ pub struct Args {
 }
 
 impl Args {
-    /// Get depenency section
+    /// Get dependency section
     pub fn get_section(&self) -> Vec<String> {
         if self.flag_dev {
             vec!["dev-dependencies".to_owned()]
@@ -93,7 +94,7 @@ impl Args {
                 } else if let Some(ref repo) = self.flag_git {
                     dependency.set_git(repo)
                 } else if let Some(ref path) = self.flag_path {
-                    dependency.set_path(path)
+                    dependency.set_path(path.to_str().unwrap())
                 } else {
                     let dep = get_latest_dependency(&self.arg_crate, self.flag_allow_prerelease)?;
                     let v = format!("{prefix}{version}",
@@ -175,7 +176,7 @@ fn crate_name_is_path(name: &str) -> bool {
 fn parse_crate_name_with_version(name: &str) -> Result<Dependency, Box<Error>> {
     assert!(crate_name_has_version(name));
 
-    let xs: Vec<&str> = name.splitn(2, '@').collect();
+    let xs: Vec<_> = name.splitn(2, '@').collect();
     let (name, version) = (xs[0], xs[1]);
     semver::VersionReq::parse(version)?;
 

--- a/src/bin/add/fetch.rs
+++ b/src/bin/add/fetch.rs
@@ -311,7 +311,7 @@ pub fn get_crate_name_from_gitlab(repo: &str) -> Result<String, FetchGitError> {
 /// Cargo.toml is not present in the root of the path.
 pub fn get_crate_name_from_path(path: &str) -> Result<String, FetchGitError> {
     let cargo_file = Path::new(path).join("Cargo.toml");
-    Manifest::open(&cargo_file.to_str())
+    Manifest::open(&Some(cargo_file))
         .map_err(|_| FetchGitError::LocalCargoToml)
         .and_then(|ref manifest| get_name_from_manifest(manifest))
 }

--- a/src/bin/add/main.rs
+++ b/src/bin/add/main.rs
@@ -52,7 +52,8 @@ Options:
     --upgrade=<method>      Choose method of semantic version upgrade. Must be one of
                             "none" (exact version), "patch" (`~` modifier), "minor"
                             (`^` modifier, default), or "all" (`>=`).
-    --update-only           Only add the updated dependency if it already exists.
+    --update-only           If the dependency already exists, it will have its version updated,
+                            preserving all other fields. The dependency will not be added if absent.
     --manifest-path=<path>  Path to the manifest to add a dependency to.
     --allow-prerelease      Include prerelease versions when fetching from crates.io (e.g.
                             '0.6.0-alpha'). Defaults to false.
@@ -70,8 +71,9 @@ dependencies (version set to "*").
 "#;
 
 fn handle_add(args: &Args) -> Result<(), Box<Error>> {
-    let mut manifest = Manifest::open(&args.flag_manifest_path.as_ref().map(|s| &s[..]))?;
-    let deps = args.parse_dependencies()?;
+    let manifest_path = args.flag_manifest_path.as_ref().map(From::from);
+    let mut manifest = Manifest::open(&manifest_path)?;
+    let deps = &args.parse_dependencies()?;
 
     deps.iter()
         .map(|dep| if args.flag_update_only {
@@ -85,7 +87,7 @@ fn handle_add(args: &Args) -> Result<(), Box<Error>> {
             err
         })?;
 
-    let mut file = Manifest::find_file(&args.flag_manifest_path.as_ref().map(|s| &s[..]))?;
+    let mut file = Manifest::find_file(&manifest_path)?;
     manifest.write_to_file(&mut file)
 }
 

--- a/src/bin/rm/main.rs
+++ b/src/bin/rm/main.rs
@@ -35,13 +35,14 @@ Remove a dependency from a Cargo.toml manifest file.
 ";
 
 fn handle_rm(args: &Args) -> Result<(), Box<Error>> {
-    let mut manifest = Manifest::open(&args.flag_manifest_path.as_ref().map(|s| &s[..]))?;
+    let manifest_path = args.flag_manifest_path.as_ref().map(From::from);
+    let mut manifest = Manifest::open(&manifest_path)?;
 
     manifest
         .remove_from_table(args.get_section(), args.arg_crate.as_ref())
         .map_err(From::from)
         .and_then(|_| {
-            let mut file = Manifest::find_file(&args.flag_manifest_path.as_ref().map(|s| &s[..]))?;
+            let mut file = Manifest::find_file(&manifest_path)?;
             manifest.write_to_file(&mut file)
         })
 }

--- a/src/dependency.rs
+++ b/src/dependency.rs
@@ -71,8 +71,8 @@ impl Dependency {
 
     /// Convert dependency to TOML
     ///
-    /// Returns a tuple with the dependency's name and either the version as a String or the
-    /// the path/git repository as a table. (If the dependency is set as `optional`, a tables is
+    /// Returns a tuple with the dependency's name and either the version as a `String` or the
+    /// path/git repository as a `Table`. (If the dependency is set as `optional`, a `Table` is
     /// returned in any case.)
     pub fn to_toml(&self) -> (String, toml::Value) {
         let data: toml::Value = match (self.optional, self.source.clone()) {
@@ -93,7 +93,9 @@ impl Dependency {
                         data.insert("path".into(), toml::Value::String(v));
                     }
                 }
-                data.insert("optional".into(), toml::Value::Boolean(optional));
+                if self.optional {
+                    data.insert("optional".into(), toml::Value::Boolean(optional));
+                }
 
                 toml::Value::Table(data)
             }


### PR DESCRIPTION
Now, if we attempt to add a dependency that already exists, we will not
throw away information. i.e. an optional dependency will always remain
as such.

Also some minor refactoring to use PathBuf instead of String where
appropriate.

This is a necessary prerequisite for a follow-on PR that implements a `cargo upgrade`