### PR TITLE
Use latest rustfmt-nightly and clippy in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,11 +6,13 @@ rust:
 - stable
 matrix:
   include:
-  - rust: nightly-2017-06-25
+  - rust: nightly-2017-07-25
     before_script:
-    - cargo install clippy --vers 0.0.140
+    - cargo install clippy --vers 0.0.145
+    - cargo install rustfmt-nightly --vers 0.2.1
     script:
     - cargo clippy -- -D warnings
+    - cargo fmt -- --write-mode diff
   allow_failures:
   - rust: nightly
 before_script:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1,6 +1,6 @@
 [root]
 name = "cargo-edit"
-version = "0.1.6"
+version = "0.2.0"
 dependencies = [
  "assert_cli 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "docopt 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/src/bin/add/main.rs
+++ b/src/bin/add/main.rs
@@ -1,8 +1,7 @@
 //! `cargo add`
-
 #![warn(missing_docs, missing_debug_implementations, missing_copy_implementations, trivial_casts,
-        trivial_numeric_casts, unsafe_code, unstable_features, unused_import_braces,
-        unused_qualifications)]
+       trivial_numeric_casts, unsafe_code, unstable_features, unused_import_braces,
+       unused_qualifications)]
 
 extern crate reqwest;
 extern crate docopt;

--- a/src/bin/rm/main.rs
+++ b/src/bin/rm/main.rs
@@ -1,8 +1,7 @@
 //! `cargo rm`
-
 #![warn(missing_docs, missing_debug_implementations, missing_copy_implementations, trivial_casts,
-        trivial_numeric_casts, unsafe_code, unstable_features, unused_import_braces,
-        unused_qualifications)]
+       trivial_numeric_casts, unsafe_code, unstable_features, unused_import_braces,
+       unused_qualifications)]
 
 extern crate docopt;
 extern crate toml;

--- a/src/bin/upgrade/main.rs
+++ b/src/bin/upgrade/main.rs
@@ -1,8 +1,7 @@
 //! `cargo upgrade`
-
 #![warn(missing_docs, missing_debug_implementations, missing_copy_implementations, trivial_casts,
-        trivial_numeric_casts, unsafe_code, unstable_features, unused_import_braces,
-        unused_qualifications)]
+       trivial_numeric_casts, unsafe_code, unstable_features, unused_import_braces,
+       unused_qualifications)]
 
 extern crate docopt;
 extern crate pad;
@@ -15,7 +14,7 @@ use std::io::{self, Write};
 use std::process;
 
 extern crate cargo_edit;
-use cargo_edit::{Manifest, get_latest_dependency};
+use cargo_edit::{get_latest_dependency, Manifest};
 
 static USAGE: &'static str = r"
 Upgrade all dependencies in a manifest file to the latest version.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,9 +1,8 @@
 //! Show and Edit Cargo's Manifest Files
-
 #![cfg_attr(test, allow(dead_code))]
 #![warn(missing_docs, missing_debug_implementations, missing_copy_implementations, trivial_casts,
-        trivial_numeric_casts, unsafe_code, unstable_features, unused_import_braces,
-        unused_qualifications)]
+       trivial_numeric_casts, unsafe_code, unstable_features, unused_import_braces,
+       unused_qualifications)]
 
 #[macro_use]
 extern crate quick_error;
@@ -21,6 +20,6 @@ mod manifest;
 mod dependency;
 
 pub use dependency::Dependency;
-pub use fetch::{get_latest_dependency, get_crate_name_from_github, get_crate_name_from_gitlab,
-                get_crate_name_from_path};
+pub use fetch::{get_crate_name_from_github, get_crate_name_from_gitlab, get_crate_name_from_path,
+                get_latest_dependency};
 pub use manifest::Manifest;


### PR DESCRIPTION
The clippy update is boring - nothing exciting happened.

Rustfmt is more interesting. This PR checks that rusfmt thinks the code is all properly formatted. An unfortunate side-effect is that we are now pinned to a specific version of rustfmt. This will prevent spontaneous breakages when rustfmt next updates, though, so it's probably acceptable...

Inspired by #146