### PR TITLE
Check that `cargo test` leaves files unchanged

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,7 @@ script:
   travis-cargo test -- --features test-external-apis &&
   travis-cargo bench &&
   travis-cargo --only stable doc
+- git diff --exit-code
 addons:
   apt:
     packages:


### PR DESCRIPTION
Follow-up from #148. This should catch any future issues where
Cargo.lock is not up to date.