### PR TITLE
Add basic workspace support – `cargo upgrade --all`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14,6 +14,7 @@ dependencies = [
  "serde_derive 1.0.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempdir 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "termcolor 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -705,6 +706,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "termcolor"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "wincolor 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "thread_local"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -863,6 +872,15 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "wincolor"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "ws2_32-sys"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -957,6 +975,7 @@ dependencies = [
 "checksum synom 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a393066ed9010ebaed60b9eafa373d4b1baac186dd7e008555b0f702b51945b6"
 "checksum take 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b157868d8ac1f56b64604539990685fa7611d8fa9e5476cf0c02cf34d32917c5"
 "checksum tempdir 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "87974a6f5c1dfb344d733055601650059a3363de2a6104819293baff662132d6"
+"checksum termcolor 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9a5193a56b8d82014662c4b933dea6bec851daf018a2b01722e007daaf5f9dca"
 "checksum thread_local 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "1697c4b57aeeb7a536b647165a2825faddffb1d3bad386d507709bd51a90bb14"
 "checksum time 0.1.38 (registry+https://github.com/rust-lang/crates.io-index)" = "d5d788d3aa77bc0ef3e9621256885555368b47bd495c13dd2e7413c89f845520"
 "checksum tokio-core 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "6a20ba4738d283cac7495ca36e045c80c2a8df3e05dd0909b17a06646af5a7ed"
@@ -976,4 +995,5 @@ dependencies = [
 "checksum void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 "checksum winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
 "checksum winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "2d315eee3b34aca4797b2da6b13ed88266e6d612562a0c46390af8299fc699bc"
+"checksum wincolor 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "a39ee4464208f6430992ff20154216ab2357772ac871d994c51628d60e58b8b0"
 "checksum ws2_32-sys 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d59cefebd0c892fa2dd6de581e937301d8552cb44489cdff035c6187cb63fa5e"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ reqwest = "0.7.1"
 serde = "1.0"
 serde_derive = "1.0"
 serde_json = "1.0"
+termcolor = "0.3"
 toml = "0.4"
 
 [dependencies.semver]

--- a/README.md
+++ b/README.md
@@ -148,11 +148,12 @@ $ cargo upgrade -d libc --dependency serde
 Upgrade all dependencies in a manifest file to the latest version.
 
 Usage:
-    cargo upgrade [--dependency <dep>...] [--manifest-path <path>]
+    cargo upgrade [--all] [--dependency <dep>...] [--manifest-path <path>]
     cargo upgrade (-h | --help)
     cargo upgrade (-V | --version)
 
 Options:
+    --all                       Upgrade all packages in the workspace.
     -d --dependency <dep>       Specific dependency to upgrade. If this option is used, only the
                                 specified dependencies will be upgraded.
     --manifest-path <path>      Path to the manifest to upgrade.
@@ -161,6 +162,9 @@ Options:
 
 Dev, build, and all target dependencies will also be upgraded. Only dependencies from crates.io are
 supported. Git/path dependencies will be ignored.
+
+All packages in the workspace will be upgraded if the `--all` flag is supplied. The `--all` flag may
+be supplied in the presence of a virtual manifest.
 ```
 
 ## License

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,7 @@ extern crate serde;
 #[macro_use]
 extern crate serde_derive;
 extern crate serde_json;
+extern crate termcolor;
 extern crate toml;
 
 mod fetch;

--- a/tests/cargo-upgrade.rs
+++ b/tests/cargo-upgrade.rs
@@ -4,6 +4,8 @@ extern crate pretty_assertions;
 extern crate tempdir;
 extern crate toml;
 
+use std::fs;
+
 mod utils;
 use utils::{clone_out_test, execute_command, get_toml};
 
@@ -31,11 +33,9 @@ fn upgrade_all() {
     execute_command(&["upgrade"], &manifest);
 
     // Verify that `versioned-package` has been updated successfully.
-    let toml = get_toml(&manifest);
-    let val = &toml["dependencies"]["versioned-package"];
     assert_eq!(
-        val.as_str().expect("not string"),
-        "versioned-package--CURRENT_VERSION_TEST"
+        get_toml(&manifest)["dependencies"]["versioned-package"],
+        toml::value::Value::String("versioned-package--CURRENT_VERSION_TEST".to_string())
     );
 }
 
@@ -54,17 +54,14 @@ fn upgrade_specified_only() {
     execute_command(&["upgrade", "-d", "versioned-package"], &manifest);
 
     // Verify that `versioned-package` was upgraded, but not `versioned-package-2`
+    let dependencies = &get_toml(&manifest)["dependencies"];
     assert_eq!(
-        get_toml(&manifest)["dependencies"]["versioned-package"]
-            .as_str()
-            .expect("not string"),
-        "versioned-package--CURRENT_VERSION_TEST"
+        dependencies["versioned-package"],
+        toml::value::Value::String("versioned-package--CURRENT_VERSION_TEST".to_string())
     );
     assert_eq!(
-        get_toml(&manifest)["dependencies"]["versioned-package-2"]
-            .as_str()
-            .expect("not string"),
-        "0.1.1"
+        dependencies["versioned-package-2"],
+        toml::value::Value::String("0.1.1".to_string())
     );
 }
 
@@ -103,13 +100,74 @@ fn upgrade_optional_dependency() {
     let toml = get_toml(&manifest);
     let val = &toml["dependencies"]["versioned-package"];
     assert_eq!(
-        val["version"].as_str().expect("not string"),
-        "versioned-package--CURRENT_VERSION_TEST"
+        val["version"],
+        toml::value::Value::String("versioned-package--CURRENT_VERSION_TEST".to_string())
     );
-    assert_eq!(
-        val["optional"].as_bool().expect("optional not a bool"),
-        true
-    );
+    assert_eq!(val["optional"], toml::value::Value::Boolean(true));
+}
+
+#[test]
+fn upgrade_workspace() {
+    // Create a temporary directory and copy in the root manifest, the dummy rust file, and
+    // workspace member manifests.
+    let tmpdir = tempdir::TempDir::new("upgrade_workspace")
+        .expect("failed to construct temporary directory");
+
+    // Helper to copy in files to the temporary workspace. The standard library doesn't have a good
+    // equivalent of `cp -r`, hence this oddity.
+    let copy_in = |dir, file| {
+        let file_path = tmpdir
+            .path()
+            .join(dir)
+            .join(file)
+            .to_str()
+            .unwrap()
+            .to_string();
+
+        fs::create_dir_all(tmpdir.path().join(dir)).unwrap();
+
+        fs::copy(
+            format!("tests/fixtures/workspace/{}/{}", dir, file),
+            &file_path,
+        ).unwrap_or_else(|err| panic!("could not copy test file: {}", err));
+
+        file_path
+    };
+
+    let root_manifest = copy_in(".", "Cargo.toml");
+    copy_in(".", "dummy.rs");
+
+    let workspace_manifests = &["one", "two", "implicit/three", "explicit/four"]
+        .iter()
+        .map(|member| copy_in(member, "Cargo.toml"))
+        .collect::<Vec<_>>();
+
+    execute_command(&["upgrade", "--all"], &root_manifest);
+
+    // All of the workspace members have `libc` as a dependency.
+    for workspace_member in workspace_manifests {
+        assert_eq!(
+            get_toml(workspace_member)["dependencies"]["libc"],
+            toml::value::Value::String("libc--CURRENT_VERSION_TEST".to_string())
+        );
+    }
+}
+
+#[test]
+fn invalid_manifest() {
+    let (_tmpdir, manifest) = clone_out_test("tests/fixtures/upgrade/Cargo.toml.invalid");
+
+    assert_cli::Assert::command(&[
+        "target/debug/cargo-upgrade",
+        "upgrade",
+        "--all",
+        "--manifest-path",
+        &manifest,
+    ]).fails_with(1)
+        .prints_error(
+            "Command failed due to unhandled error: Failed to get metadata",
+        )
+        .unwrap();
 }
 
 #[test]
@@ -120,9 +178,24 @@ fn unknown_flags() {
             r"Unknown flag: '--flag'
 
 Usage:
-    cargo upgrade [--dependency <dep>...] [--manifest-path <path>]
+    cargo upgrade [--all] [--dependency <dep>...] [--manifest-path <path>]
     cargo upgrade (-h | --help)
     cargo upgrade (-V | --version)",
         )
+        .unwrap();
+}
+
+#[test]
+fn upgrade_prints_messages() {
+    let (_tmpdir, manifest) = clone_out_test("tests/fixtures/upgrade/Cargo.toml.source");
+
+    assert_cli::Assert::command(&[
+        "target/debug/cargo-upgrade",
+        "upgrade",
+        "-d",
+        "docopt",
+        &format!("--manifest-path={}", manifest),
+    ]).succeeds()
+        .prints("docopt v0.8 -> v")
         .unwrap();
 }

--- a/tests/fixtures/upgrade/Cargo.toml.invalid
+++ b/tests/fixtures/upgrade/Cargo.toml.invalid
@@ -1,0 +1,1 @@
+This is clearly not a valid Cargo.toml.

--- a/tests/fixtures/workspace/Cargo.toml
+++ b/tests/fixtures/workspace/Cargo.toml
@@ -1,0 +1,6 @@
+[workspace]
+members = [
+    "one",
+    "two",
+    "explicit/*"
+]

--- a/tests/fixtures/workspace/explicit/four/Cargo.toml
+++ b/tests/fixtures/workspace/explicit/four/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "four"
+version = "0.1.0"
+
+[lib]
+path = "../../dummy.rs"
+
+[dependencies]
+libc = "0.2.28"

--- a/tests/fixtures/workspace/implicit/three/Cargo.toml
+++ b/tests/fixtures/workspace/implicit/three/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "three"
+version = "0.1.0"
+
+[lib]
+path = "../../dummy.rs"
+
+[dependencies]
+libc = "0.2.28"

--- a/tests/fixtures/workspace/one/Cargo.toml
+++ b/tests/fixtures/workspace/one/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "one"
+version = "0.1.0"
+
+[lib]
+path = "../dummy.rs"
+
+[dependencies]
+libc = "0.2.28"
+three = { path = "../implicit/three"}

--- a/tests/fixtures/workspace/two/Cargo.toml
+++ b/tests/fixtures/workspace/two/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "two"
+version = "0.1.0"
+
+[[bin]]
+name = "two"
+path = "../dummy.rs"
+
+[dependencies]
+libc = "0.2.28"

--- a/tests/utils.rs
+++ b/tests/utils.rs
@@ -8,7 +8,7 @@ use std::io::prelude::*;
 /// Create temporary working directory with Cargo.toml mainifest
 pub fn clone_out_test(source: &str) -> (tempdir::TempDir, String) {
     let tmpdir =
-        tempdir::TempDir::new("cargo-add-test").expect("failed to construct temporary directory");
+        tempdir::TempDir::new("cargo-edit-test").expect("failed to construct temporary directory");
     fs::copy(source, tmpdir.path().join("Cargo.toml"))
         .unwrap_or_else(|err| panic!("could not copy test manifest: {}", err));
     let path = tmpdir


### PR DESCRIPTION
`cargo upgrade --all` uses `cargo metadata` to discover the workspace members, and then runs over all members of the workspace.

Note that we just run though each workspace member in turn. This means that we are likely to be doing dependency resolution multiple times. This is probably acceptable for an initial release, but a better long-term solution would implement caching so as to only look up each dependency once.

This is the first stage of resolving #147 