### PR TITLE
Support selecting which binaries to install

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,12 +13,15 @@ version = "0.2.0"
 [[bin]]
 name = "cargo-add"
 path = "src/bin/add/main.rs"
+required-features = ["add"]
 [[bin]]
 name = "cargo-rm"
 path = "src/bin/rm/main.rs"
+required-features = ["rm"]
 [[bin]]
 name = "cargo-upgrade"
 path = "src/bin/upgrade/main.rs"
+required-features = ["upgrade"]
 [badges.appveyor]
 repository = "killercup/cargo-edit"
 
@@ -47,6 +50,9 @@ pretty_assertions = "0.2.1"
 tempdir = "0.3"
 
 [features]
-default = []
+default = ["add", "rm", "upgrade"]
 test-external-apis = []
 unstable = []
+add = []
+rm = []
+upgrade = []

--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ $ cargo install cargo-edit
 
 (Please check [`cargo`'s documentation](http://doc.crates.io/) to learn how `cargo install` works and how to set up your system so it finds binaries installed by `cargo`.)
 
+Install a sub-set of the commands with `cargo install -f --no-default-features --features "<COMMANDS>"`, where `<COMMANDS>` is a space-separated list of commands; i.e. `add rm upgrade` for the full set.
+
 ## Available Subcommands
 
 ### `cargo add`


### PR DESCRIPTION
Fixes #152. Done using features.

Testing this from my working copy:

```
$ cargo install -f --no-default-features --features "add upgrade"
  Installing cargo-edit v0.2.0 (file:///home/benjamin/rust/cargo-edit)
   Compiling cargo-edit v0.2.0 (file:///home/benjamin/rust/cargo-edit)
    Finished release [optimized] target(s) in 13.64 secs
   Replacing /home/benjamin/.cargo/bin/cargo-add
   Replacing /home/benjamin/.cargo/bin/cargo-upgrade
```