### PR TITLE
Pretty

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15,7 +15,7 @@ dependencies = [
  "serde_json 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempdir 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "termcolor 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "toml 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "toml 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -796,7 +796,7 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.4.2"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "serde 1.0.10 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -983,7 +983,7 @@ dependencies = [
 "checksum tokio-proto 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8fbb47ae81353c63c487030659494b295f6cb6576242f907f203473b191b0389"
 "checksum tokio-service 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "24da22d077e0f15f55162bdbdc661228c1581892f52074fb242678d015b45162"
 "checksum tokio-tls 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "d88e411cac1c87e405e4090be004493c5d8072a370661033b1a64ea205ec2e13"
-"checksum toml 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "b0601da6c97135c8d330c7a13a013ca6cd4143221b01de2f8d4edc50a9e551c7"
+"checksum toml 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)" = "a7540f4ffc193e0d3c94121edb19b055670d369f77d5804db11ae053a45b6e7e"
 "checksum unicase 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2e01da42520092d0cd2d6ac3ae69eb21a22ad43ff195676b86f8c37f487d6b80"
 "checksum unicode-bidi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "49f2bd0c6468a8230e1db229cff8029217cf623c767ea5d60bfbd42729ea54d5"
 "checksum unicode-normalization 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "51ccda9ef9efa3f7ef5d91e8f9b83bbe6955f9bf86aec89d5cce2c874625920f"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,23 +1,42 @@
 [package]
-authors = ["Without Boats <lee@libertad.ucsd.edu>", "Pascal Hertleif <killercup@gmail.com>", "Sebastian Garrido <sebasgarcep@gmail.com>", "Jonas Platte <mail@jonasplatte.de>", "Benjamin Gill <git@bgill.eu>", "Andronik Ordian <write@reusable.software>"]
-categories = ["development-tools", "development-tools::cargo-plugins"]
+authors = [
+    "Without Boats <lee@libertad.ucsd.edu>",
+    "Pascal Hertleif <killercup@gmail.com>",
+    "Sebastian Garrido <sebasgarcep@gmail.com>",
+    "Jonas Platte <mail@jonasplatte.de>",
+    "Benjamin Gill <git@bgill.eu>",
+    "Andronik Ordian <write@reusable.software>",
+]
+categories = [
+    "development-tools",
+    "development-tools::cargo-plugins",
+]
 description = "This extends Cargo to allow you to add and remove dependencies by modifying your `Cargo.toml` file from the command line. It contains `cargo add`, `cargo rm`, and `cargo upgrade`."
 documentation = "http://killercup.github.io/cargo-edit/"
 homepage = "https://github.com/killercup/cargo-edit"
-keywords = ["cargo", "cargo-subcommand", "cli", "dependencies", "crates"]
+keywords = [
+    "cargo",
+    "cargo-subcommand",
+    "cli",
+    "dependencies",
+    "crates",
+]
 license = "Apache-2.0/MIT"
 name = "cargo-edit"
 readme = "README.md"
 repository = "https://github.com/killercup/cargo-edit"
 version = "0.2.0"
+
 [[bin]]
 name = "cargo-add"
 path = "src/bin/add/main.rs"
 required-features = ["add"]
+
 [[bin]]
 name = "cargo-rm"
 path = "src/bin/rm/main.rs"
 required-features = ["rm"]
+
 [[bin]]
 name = "cargo-upgrade"
 path = "src/bin/upgrade/main.rs"
@@ -38,7 +57,7 @@ serde = "1.0"
 serde_derive = "1.0"
 serde_json = "1.0"
 termcolor = "0.3"
-toml = "0.4"
+toml = "0.4.5"
 
 [dependencies.semver]
 features = ["serde"]
@@ -50,9 +69,13 @@ pretty_assertions = "0.2.1"
 tempdir = "0.3"
 
 [features]
-default = ["add", "rm", "upgrade"]
+add = []
+default = [
+    "add",
+    "rm",
+    "upgrade",
+]
+rm = []
 test-external-apis = []
 unstable = []
-add = []
-rm = []
 upgrade = []


### PR DESCRIPTION
this uses the newly added `toml::pretty_string` to format the `Cargo.toml`.

I opted to demo by formatting its own `Cargo.toml` file (`cargo run --bin cargo-rm -- regex` and then added back in). I can remove the changes to `Cargo.toml` (except the update to `toml=0.4.4`) if you would like -- but I thought it was a good demo :smile:

Closes #151 