### PR TITLE
Switch to use error-chain

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = "0.3.0-alpha.1"
 dependencies = [
  "assert_cli 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "docopt 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "error-chain 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "pad 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "pretty_assertions 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "quick-error 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "reqwest 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "semver 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -457,11 +457,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "getopts 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
-
-[[package]]
-name = "quick-error"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "quote"
@@ -944,7 +939,6 @@ dependencies = [
 "checksum pkg-config 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "3a8b4c6b8165cd1a1cd4b9b120978131389f64bdaf456435caa41e630edba903"
 "checksum pretty_assertions 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "1d510007841e87c7a6d829a36f7f0acb72aef12e38cc89073fe39810c1d976ac"
 "checksum pulldown-cmark 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "8361e81576d2e02643b04950e487ec172b687180da65c731c03cf336784e6c07"
-"checksum quick-error 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3c36987d4978eb1be2e422b1e0423a557923a5c3e7e6f31d5699e9aafaefa469"
 "checksum quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)" = "7a6e920b65c65f10b2ae65c831a81a073a89edd28c7cce89475bff467ab4167a"
 "checksum rand 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)" = "022e0636ec2519ddae48154b028864bdce4eaf7d35226ab8e65c611be97b189d"
 "checksum redox_syscall 0.1.26 (registry+https://github.com/rust-lang/crates.io-index)" = "9df6a71a1e67be2104410736b2389fb8e383c1d7e9e792d629ff13c02867147a"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,8 +49,8 @@ repository = "killercup/cargo-edit"
 
 [dependencies]
 docopt = "0.8"
+error-chain = "0.10.0"
 pad = "0.1"
-quick-error = "1.0.0"
 regex = "0.2"
 reqwest = "0.7.1"
 serde = "1.0"

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,0 +1,37 @@
+error_chain!{
+    errors {
+        /// Failed to fetch crate from crates.io
+        FetchVersionFailure {
+            description("Failed to fetch crate version from crates.io")
+        }
+        /// Invalid JSON from crates.io response
+        InvalidCratesIoJson {
+            description("Invalid JSON (the crate may not exist)")
+        }
+        /// No versions available
+        NoVersionsAvailable {
+            description("No available versions exist. Either all were yanked \
+                         or only prerelease versions exist. Trying with the \
+                         --fetch-prereleases flag might solve the issue."
+            )
+        }
+        /// Unable to parse external Cargo.toml
+        ParseCargoToml {
+            description("Unable to parse external Cargo.toml")
+        }
+        /// Cargo.toml could not be found.
+        MissingManifest {
+            description("Unable to find Cargo.toml")
+        }
+        /// The TOML table could not be found.
+        NonExistentTable(table: String) {
+            description("non existent table")
+            display("The table `{}` could not be found.", table)
+        }
+        /// The dependency could not be found.
+        NonExistentDependency(name: String, table: String) {
+            description("non existent dependency")
+            display("The dependency `{}` could not be found in `{}`.", name, table)
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,7 @@
        unused_qualifications)]
 
 #[macro_use]
-extern crate quick_error;
+extern crate error_chain;
 extern crate regex;
 extern crate reqwest;
 extern crate semver;
@@ -16,11 +16,13 @@ extern crate serde_json;
 extern crate termcolor;
 extern crate toml;
 
+mod dependency;
+mod errors;
 mod fetch;
 mod manifest;
-mod dependency;
 
 pub use dependency::Dependency;
+pub use errors::*;
 pub use fetch::{get_crate_name_from_github, get_crate_name_from_gitlab, get_crate_name_from_path,
                 get_latest_dependency};
 pub use manifest::Manifest;

--- a/tests/cargo-add.rs
+++ b/tests/cargo-add.rs
@@ -1,7 +1,6 @@
 extern crate assert_cli;
 #[macro_use]
 extern crate pretty_assertions;
-extern crate tempdir;
 extern crate toml;
 
 use std::process;

--- a/tests/cargo-rm.rs
+++ b/tests/cargo-rm.rs
@@ -81,9 +81,8 @@ fn invalid_dependency() {
         &format!("--manifest-path={}", manifest),
     ]).fails_with(1)
         .prints_error_exactly(
-            "Could not edit `Cargo.toml`.
-
-ERROR: The dependency `invalid_dependency_name` could not be found in `dependencies`.",
+            "Command failed due to unhandled error: The dependency `invalid_dependency_name` could \
+             not be found in `dependencies`.",
         )
         .unwrap();
 }
@@ -101,9 +100,8 @@ fn invalid_section() {
         &format!("--manifest-path={}", manifest),
     ]).fails_with(1)
         .prints_error_exactly(
-            "Could not edit `Cargo.toml`.
-
-ERROR: The table `build-dependencies` could not be found.",
+            "Command failed due to unhandled error: The table `build-dependencies` could not be \
+             found.",
         )
         .unwrap();
 }
@@ -120,9 +118,8 @@ fn invalid_dependency_in_section() {
         &format!("--manifest-path={}", manifest),
     ]).fails_with(1)
         .prints_error_exactly(
-            "Could not edit `Cargo.toml`.
-
-ERROR: The dependency `semver` could not be found in `dev-dependencies`.",
+            "Command failed due to unhandled error: The dependency `semver` could not be found in \
+             `dev-dependencies`.",
         )
         .unwrap();
 }

--- a/tests/test_manifest.rs
+++ b/tests/test_manifest.rs
@@ -9,8 +9,10 @@ fn invalid_manifest() {
         "--manifest-path=tests/fixtures/manifest-invalid/Cargo.toml.sample",
     ]).fails_with(1)
         .prints_error_exactly(
-            "Command failed due to unhandled error: \
-             failed to parse datetime for key `invalid-section.key`",
+            r"Command failed due to unhandled error: Unable to parse Cargo.toml
+
+Caused by: Manifest not valid TOML
+Caused by: failed to parse datetime for key `invalid-section.key`",
         )
         .unwrap();
 }

--- a/tests/utils.rs
+++ b/tests/utils.rs
@@ -5,7 +5,7 @@ use std::{fs, process};
 use std::ffi::OsStr;
 use std::io::prelude::*;
 
-/// Create temporary working directory with Cargo.toml mainifest
+/// Create temporary working directory with Cargo.toml manifest
 pub fn clone_out_test(source: &str) -> (tempdir::TempDir, String) {
     let tmpdir =
         tempdir::TempDir::new("cargo-edit-test").expect("failed to construct temporary directory");


### PR DESCRIPTION
I've kept the quick-error style errors where they're used multiple times, and otherwise converted to string errors - our errors are for diagnostics only (not for anyone to try and do anything with).

This is the first step to solving #159.