### PR TITLE
Be more cautious with bogus crate naming

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1,24 +1,3 @@
-[root]
-name = "cargo-edit"
-version = "0.3.0-alpha.1"
-dependencies = [
- "assert_cli 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "cargo_metadata 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "docopt 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "error-chain 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "pad 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "pretty_assertions 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "reqwest 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "semver 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.14 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.14 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "tempdir 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "termcolor 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "toml 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
 [[package]]
 name = "adler32"
 version = "1.0.2"
@@ -106,6 +85,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "byteorder 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "iovec 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "cargo-edit"
+version = "0.3.0-alpha.1"
+dependencies = [
+ "assert_cli 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cargo_metadata 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "docopt 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "error-chain 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pad 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pretty_assertions 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "reqwest 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "semver 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tempdir 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "termcolor 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "toml 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/tests/cargo-add.rs
+++ b/tests/cargo-add.rs
@@ -214,7 +214,12 @@ fn adds_specified_version() {
 
     // cannot run with both --dev and --build at the same time
     let call = process::Command::new("target/debug/cargo-add")
-        .args(&["add", BOGUS_CRATE_NAME, "--vers", "invalid version string"])
+        .args(&[
+            "add",
+            BOGUS_CRATE_NAME,
+            "--vers",
+            "invalid version string",
+        ])
         .arg(format!("--manifest-path={}", &manifest))
         .output()
         .unwrap();

--- a/tests/cargo-add.rs
+++ b/tests/cargo-add.rs
@@ -7,12 +7,16 @@ use std::process;
 mod utils;
 use utils::{clone_out_test, execute_command, get_toml};
 
+/// Some of the tests need to have a crate name that does not exist on crates.io. Hence this rather
+/// silly constant. Tests _will_ fail, though, if a crate is ever published with this name.
+const BOGUS_CRATE_NAME: &str = "tests-will-break-if-there-is-ever-a-real-package-with-this-name";
+
 /// Check 'failure' deps are not present
 fn no_manifest_failures(manifest: &toml::Value) -> bool {
     let no_failure_key_in = |section| {
         manifest
             .get(section)
-            .map(|m| m.get("failure").is_none())
+            .map(|m| m.get(BOGUS_CRATE_NAME).is_none())
             .unwrap_or(true)
     };
     no_failure_key_in("dependencies") && no_failure_key_in("dev-dependencies") &&
@@ -137,7 +141,7 @@ fn adds_dev_build_dependency() {
 
     // cannot run with both --dev and --build at the same time
     let call = process::Command::new("target/debug/cargo-add")
-        .args(&["add", "failure", "--dev", "--build"])
+        .args(&["add", BOGUS_CRATE_NAME, "--dev", "--build"])
         .arg(format!("--manifest-path={}", &manifest))
         .output()
         .unwrap();
@@ -210,7 +214,7 @@ fn adds_specified_version() {
 
     // cannot run with both --dev and --build at the same time
     let call = process::Command::new("target/debug/cargo-add")
-        .args(&["add", "failure", "--vers", "invalid version string"])
+        .args(&["add", BOGUS_CRATE_NAME, "--vers", "invalid version string"])
         .arg(format!("--manifest-path={}", &manifest))
         .output()
         .unwrap();
@@ -433,7 +437,7 @@ fn package_kinds_are_mutually_exclusive() {
     let (_tmpdir, manifest) = clone_out_test("tests/fixtures/add/Cargo.toml.sample");
 
     let call = process::Command::new("target/debug/cargo-add")
-        .args(&["add", "failure"])
+        .args(&["add", BOGUS_CRATE_NAME])
         .args(&["--vers", "0.4.3"])
         .args(&["--git", "git://git.git"])
         .args(&["--path", "/path/here"])


### PR DESCRIPTION
The crate `failure` has just been published. We need a sillier name that has less chance of becoming a real crate in future.