### PR TITLE
Remove unused Cargo.lock search handling

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,10 +6,10 @@ rust:
 - stable
 matrix:
   include:
-  - rust: nightly-2017-07-25
+  - rust: nightly-2017-11-02
     before_script:
-    - cargo install clippy --vers 0.0.145
-    - cargo install rustfmt-nightly --vers 0.2.1
+    - cargo install clippy --vers 0.0.168
+    - cargo install rustfmt-nightly --vers 0.2.13
     script:
     - cargo clippy -- -D warnings
     - cargo fmt -- --write-mode diff

--- a/src/bin/add/args.rs
+++ b/src/bin/add/args.rs
@@ -78,8 +78,7 @@ impl Args {
 
         if crate_name_has_version(&self.arg_crate) {
             return Ok(vec![
-                parse_crate_name_with_version(&self.arg_crate)?
-                    .set_optional(self.flag_optional),
+                parse_crate_name_with_version(&self.arg_crate)?.set_optional(self.flag_optional),
             ]);
         }
 
@@ -114,8 +113,9 @@ impl Args {
     }
 
     fn get_upgrade_prefix(&self) -> Option<&'static str> {
-        self.flag_upgrade.clone().and_then(
-            |flag| match flag.to_uppercase().as_ref() {
+        self.flag_upgrade
+            .clone()
+            .and_then(|flag| match flag.to_uppercase().as_ref() {
                 "NONE" => Some("="),
                 "PATCH" => Some("~"),
                 "MINOR" => Some("^"),
@@ -127,8 +127,7 @@ impl Args {
                     );
                     None
                 }
-            },
-        )
+            })
     }
 }
 
@@ -178,8 +177,7 @@ fn parse_crate_name_with_version(name: &str) -> Result<Dependency> {
 
     let xs: Vec<_> = name.splitn(2, '@').collect();
     let (name, version) = (xs[0], xs[1]);
-    semver::VersionReq::parse(version)
-        .chain_err(|| "Invalid crate version requirement")?;
+    semver::VersionReq::parse(version).chain_err(|| "Invalid crate version requirement")?;
 
     Ok(Dependency::new(name).set_version(version))
 }

--- a/src/bin/add/main.rs
+++ b/src/bin/add/main.rs
@@ -1,7 +1,7 @@
 //! `cargo add`
 #![warn(missing_docs, missing_debug_implementations, missing_copy_implementations, trivial_casts,
-       trivial_numeric_casts, unsafe_code, unstable_features, unused_import_braces,
-       unused_qualifications)]
+        trivial_numeric_casts, unsafe_code, unstable_features, unused_import_braces,
+        unused_qualifications)]
 
 extern crate docopt;
 #[macro_use]

--- a/src/bin/rm/main.rs
+++ b/src/bin/rm/main.rs
@@ -1,7 +1,7 @@
 //! `cargo rm`
 #![warn(missing_docs, missing_debug_implementations, missing_copy_implementations, trivial_casts,
-       trivial_numeric_casts, unsafe_code, unstable_features, unused_import_braces,
-       unused_qualifications)]
+        trivial_numeric_casts, unsafe_code, unstable_features, unused_import_braces,
+        unused_qualifications)]
 
 extern crate docopt;
 #[macro_use]

--- a/src/bin/upgrade/main.rs
+++ b/src/bin/upgrade/main.rs
@@ -1,7 +1,7 @@
 //! `cargo upgrade`
 #![warn(missing_docs, missing_debug_implementations, missing_copy_implementations, trivial_casts,
-       trivial_numeric_casts, unsafe_code, unstable_features, unused_import_braces,
-       unused_qualifications)]
+        trivial_numeric_casts, unsafe_code, unstable_features, unused_import_braces,
+        unused_qualifications)]
 
 extern crate cargo_metadata;
 extern crate docopt;
@@ -95,8 +95,8 @@ where
 
     for (table_path, table) in manifest.get_sections() {
         for (name, old_value) in &table {
-            if (only_update.is_empty() || only_update.contains(name)) &&
-                is_version_dependency(old_value)
+            if (only_update.is_empty() || only_update.contains(name))
+                && is_version_dependency(old_value)
             {
                 let latest_version = new_dependency(name)?;
 

--- a/src/fetch.rs
+++ b/src/fetch.rs
@@ -10,7 +10,7 @@ use std::time::Duration;
 
 use errors::*;
 
-const REGISTRY_HOST: &'static str = "https://crates.io";
+const REGISTRY_HOST: &str = "https://crates.io";
 
 #[derive(Deserialize)]
 struct Versions {
@@ -19,10 +19,8 @@ struct Versions {
 
 #[derive(Deserialize)]
 struct CrateVersion {
-    #[serde(rename = "crate")]
-    name: String,
-    #[serde(rename = "num")]
-    version: semver::Version,
+    #[serde(rename = "crate")] name: String,
+    #[serde(rename = "num")] version: semver::Version,
     yanked: bool,
 }
 
@@ -187,10 +185,10 @@ fn get_no_latest_version_from_json_when_all_are_yanked() {
 
 fn fetch_cratesio(path: &str) -> Result<Versions> {
     let url = format!("{host}/api/v1{path}", host = REGISTRY_HOST, path = path);
-    let response = get_with_timeout(&url, get_default_timeout())
-        .chain_err(|| ErrorKind::FetchVersionFailure)?;
-    let versions: Versions = json::from_reader(response)
-        .chain_err(|| ErrorKind::InvalidCratesIoJson)?;
+    let response =
+        get_with_timeout(&url, get_default_timeout()).chain_err(|| ErrorKind::FetchVersionFailure)?;
+    let versions: Versions =
+        json::from_reader(response).chain_err(|| ErrorKind::InvalidCratesIoJson)?;
     Ok(versions)
 }
 
@@ -220,9 +218,8 @@ where
 /// - Cargo.toml is not present in the root of the master branch,
 /// - the response from github is an error or in an incorrect format.
 pub fn get_crate_name_from_github(repo: &str) -> Result<String> {
-    let re = Regex::new(
-        r"^https://github.com/([-_0-9a-zA-Z]+)/([-_0-9a-zA-Z]+)(/|.git)?$",
-    ).unwrap();
+    let re =
+        Regex::new(r"^https://github.com/([-_0-9a-zA-Z]+)/([-_0-9a-zA-Z]+)(/|.git)?$").unwrap();
     get_crate_name_from_repository(repo, &re, |user, repo| {
         format!(
             "https://raw.githubusercontent.com/{user}/{repo}/master/Cargo.toml",
@@ -240,9 +237,8 @@ pub fn get_crate_name_from_github(repo: &str) -> Result<String> {
 /// - Cargo.toml is not present in the root of the master branch,
 /// - the response from gitlab is an error or in an incorrect format.
 pub fn get_crate_name_from_gitlab(repo: &str) -> Result<String> {
-    let re = Regex::new(
-        r"^https://gitlab.com/([-_0-9a-zA-Z]+)/([-_0-9a-zA-Z]+)(/|.git)?$",
-    ).unwrap();
+    let re =
+        Regex::new(r"^https://gitlab.com/([-_0-9a-zA-Z]+)/([-_0-9a-zA-Z]+)(/|.git)?$").unwrap();
     get_crate_name_from_repository(repo, &re, |user, repo| {
         format!(
             "https://gitlab.com/{user}/{repo}/raw/master/Cargo.toml",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,8 @@
 //! Show and Edit Cargo's Manifest Files
 #![cfg_attr(test, allow(dead_code))]
 #![warn(missing_docs, missing_debug_implementations, missing_copy_implementations, trivial_casts,
-       trivial_numeric_casts, unsafe_code, unstable_features, unused_import_braces,
-       unused_qualifications)]
+        trivial_numeric_casts, unsafe_code, unstable_features, unused_import_braces,
+        unused_qualifications)]
 
 #[macro_use]
 extern crate error_chain;

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -122,8 +122,7 @@ fn print_upgrade_if_necessary(
         buffer
             .set_color(ColorSpec::new().set_fg(Some(Color::Green)).set_bold(true))
             .chain_err(|| "Failed to set output colour")?;
-        write!(&mut buffer, "Upgrading ")
-            .chain_err(|| "Failed to write upgrade message")?;
+        write!(&mut buffer, "Upgrading ").chain_err(|| "Failed to write upgrade message")?;
         buffer
             .set_color(&ColorSpec::new())
             .chain_err(|| "Failed to clear output colour")?;
@@ -321,17 +320,15 @@ impl Manifest {
             Entry::Vacant(_) => Err(ErrorKind::NonExistentTable(table.into())),
             Entry::Occupied(mut section) => {
                 let result = match *section.get_mut() {
-                    toml::Value::Table(ref mut deps) => {
-                        deps.remove(name).map(|_| ()).ok_or_else(|| {
-                            ErrorKind::NonExistentDependency(name.into(), table.into())
-                        })
-                    }
+                    toml::Value::Table(ref mut deps) => deps.remove(name).map(|_| ()).ok_or_else(
+                        || ErrorKind::NonExistentDependency(name.into(), table.into()),
+                    ),
                     _ => Err(ErrorKind::NonExistentTable(table.into())),
                 };
                 if section.get().as_table().map(|x| x.is_empty()) == Some(true) {
                     section.remove();
                 }
-                result.into()
+                result
             }
         }?;
 

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -12,19 +12,7 @@ use toml;
 use errors::*;
 use dependency::Dependency;
 
-enum CargoFile {
-    Config,
-    Lock,
-}
-
-impl CargoFile {
-    fn name(&self) -> &str {
-        match *self {
-            CargoFile::Config => "Cargo.toml",
-            CargoFile::Lock => "Cargo.lock",
-        }
-    }
-}
+const MANIFEST_FILENAME: &str = "Cargo.toml";
 
 /// A Cargo Manifest
 #[derive(Debug, Clone, PartialEq)]
@@ -50,7 +38,7 @@ fn toml_pretty(value: &toml::Value) -> Result<String> {
 /// If a manifest is specified, return that one. If a path is specified, perform a manifest search
 /// starting from there. If nothing is specified, start searching from the current directory
 /// (`cwd`).
-fn find(specified: &Option<PathBuf>, file: CargoFile) -> Result<PathBuf> {
+fn find(specified: &Option<PathBuf>) -> Result<PathBuf> {
     match *specified {
         Some(ref path)
             if fs::metadata(&path)
@@ -59,25 +47,22 @@ fn find(specified: &Option<PathBuf>, file: CargoFile) -> Result<PathBuf> {
         {
             Ok(path.to_owned())
         }
-        Some(ref path) => search(path, file),
-        None => search(
-            &env::current_dir()
-                .chain_err(|| "Failed to get current directory")?,
-            file,
-        ),
-    }.map_err(From::from)
+        Some(ref path) => search(path),
+        None => search(&env::current_dir()
+            .chain_err(|| "Failed to get current directory")?),
+    }
 }
 
 /// Search for Cargo.toml in this directory and recursively up the tree until one is found.
-fn search(dir: &Path, file: CargoFile) -> Result<PathBuf> {
-    let manifest = dir.join(file.name());
+fn search(dir: &Path) -> Result<PathBuf> {
+    let manifest = dir.join(MANIFEST_FILENAME);
 
     if fs::metadata(&manifest).is_ok() {
         Ok(manifest)
     } else {
         dir.parent()
             .ok_or_else(|| ErrorKind::MissingManifest.into())
-            .and_then(|dir| search(dir, file))
+            .and_then(|dir| search(dir))
     }
 }
 
@@ -162,26 +147,12 @@ impl Manifest {
     /// Starts at the given path an goes into its parent directories until the manifest file is
     /// found. If no path is given, the process's working directory is used as a starting point.
     pub fn find_file(path: &Option<PathBuf>) -> Result<File> {
-        find(path, CargoFile::Config).and_then(|path| {
+        find(path).and_then(|path| {
             OpenOptions::new()
                 .read(true)
                 .write(true)
                 .open(path)
                 .chain_err(|| "Failed to find Cargo.toml")
-        })
-    }
-
-    /// Look for a `Cargo.lock` file
-    ///
-    /// Starts at the given path an goes into its parent directories until the manifest file is
-    /// found. If no path is given, the process' working directory is used as a starting point.
-    pub fn find_lock_file(path: &Option<PathBuf>) -> Result<File> {
-        find(path, CargoFile::Lock).and_then(|path| {
-            OpenOptions::new()
-                .read(true)
-                .write(true)
-                .open(path)
-                .chain_err(|| "Failed to find Cargo.lock")
         })
     }
 
@@ -193,16 +164,6 @@ impl Manifest {
             .chain_err(|| "Failed to read manifest contents")?;
 
         data.parse().chain_err(|| "Unable to parse Cargo.toml")
-    }
-
-    /// Open the `Cargo.lock` for a path (or the process' `cwd`)
-    pub fn open_lock_file(path: &Option<PathBuf>) -> Result<Manifest> {
-        let mut file = Manifest::find_lock_file(path)?;
-        let mut data = String::new();
-        file.read_to_string(&mut data)
-            .chain_err(|| "Failed to read lock file contents")?;
-
-        data.parse().chain_err(|| "Unable to parse Cargo.lock")
     }
 
     /// Get the specified table from the manifest.

--- a/tests/cargo-add.rs
+++ b/tests/cargo-add.rs
@@ -19,8 +19,8 @@ fn no_manifest_failures(manifest: &toml::Value) -> bool {
             .map(|m| m.get(BOGUS_CRATE_NAME).is_none())
             .unwrap_or(true)
     };
-    no_failure_key_in("dependencies") && no_failure_key_in("dev-dependencies") &&
-        no_failure_key_in("build-dependencies")
+    no_failure_key_in("dependencies") && no_failure_key_in("dev-dependencies")
+        && no_failure_key_in("build-dependencies")
 }
 
 #[test]

--- a/tests/cargo-upgrade.rs
+++ b/tests/cargo-upgrade.rs
@@ -200,9 +200,7 @@ fn invalid_root_manifest() {
         "--manifest-path",
         &manifest,
     ]).fails_with(1)
-        .prints_error(
-            "Command failed due to unhandled error: Failed to get metadata",
-        )
+        .prints_error("Command failed due to unhandled error: Failed to get metadata")
         .unwrap();
 }
 


### PR DESCRIPTION
Now that we use cargo_metadata, we no longer need to be able to parse
the lock file.

Also, update to the latest releases of rustfmt and clippy