### PR TITLE
Detect when running against a virtual manifest

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -23,6 +23,15 @@ error_chain!{
         MissingManifest {
             description("Unable to find Cargo.toml")
         }
+        /// Cargo.toml is valid toml, but doesn't contain the expected fields
+        InvalidManifest {
+            description("Cargo.toml missing expected `package` or `project` fields")
+        }
+        /// Found a workspace manifest when expecting a normal manifest
+        UnexpectedRootManifest {
+            description("Found virtual manifest, but this command requires running against an \
+                         actual package in this workspace.")
+        }
         /// The TOML table could not be found.
         NonExistentTable(table: String) {
             description("non existent table")

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -240,12 +240,10 @@ impl Manifest {
         let (proj_header, proj_data) = toml.remove("package")
             .map(|data| ("package", data))
             .or_else(|| toml.remove("project").map(|data| ("project", data)))
-            .ok_or_else(|| {
-                if toml.contains_key("workspace") {
-                    ErrorKind::UnexpectedRootManifest
-                } else {
-                    ErrorKind::InvalidManifest
-                }
+            .ok_or_else(|| if toml.contains_key("workspace") {
+                ErrorKind::UnexpectedRootManifest
+            } else {
+                ErrorKind::InvalidManifest
             })?;
 
         let new_contents = format!(

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -240,7 +240,13 @@ impl Manifest {
         let (proj_header, proj_data) = toml.remove("package")
             .map(|data| ("package", data))
             .or_else(|| toml.remove("project").map(|data| ("project", data)))
-            .ok_or_else(|| ErrorKind::MissingManifest)?;
+            .ok_or_else(|| {
+                if toml.contains_key("workspace") {
+                    ErrorKind::UnexpectedRootManifest
+                } else {
+                    ErrorKind::InvalidManifest
+                }
+            })?;
 
         let new_contents = format!(
             "[{}]\n{}\n{}",

--- a/tests/cargo-upgrade.rs
+++ b/tests/cargo-upgrade.rs
@@ -170,6 +170,26 @@ fn upgrade_workspace() {
     }
 }
 
+/// Detect if attempting to run against a workspace root and give a helpful warning.
+#[test]
+fn detect_workspace() {
+    let (_tmpdir, manifest) = clone_out_test("tests/fixtures/workspace/Cargo.toml");
+
+    assert_cli::Assert::command(&[
+        "target/debug/cargo-upgrade",
+        "upgrade",
+        "--manifest-path",
+        &manifest,
+    ]).fails_with(1)
+        .prints_error_exactly(
+            "Command failed due to unhandled error: Failed to write new manifest contents
+
+Caused by: Found virtual manifest, but this command requires running against an actual package in \
+this workspace.",
+        )
+        .unwrap();
+}
+
 #[test]
 fn invalid_manifest() {
     let (_tmpdir, manifest) = clone_out_test("tests/fixtures/upgrade/Cargo.toml.invalid");
@@ -181,7 +201,7 @@ fn invalid_manifest() {
         &manifest,
     ]).fails_with(1)
         .prints_error_exactly(
-            r"Command failed due to unhandled error: Unable to parse Cargo.toml
+            "Command failed due to unhandled error: Unable to parse Cargo.toml
 
 Caused by: Manifest not valid TOML
 Caused by: expected an equals, found an identifier at line 1",
@@ -209,7 +229,7 @@ fn unknown_flags() {
     assert_cli::Assert::command(&["target/debug/cargo-upgrade", "upgrade", "foo", "--flag"])
         .fails_with(1)
         .prints_error_exactly(
-            r"Unknown flag: '--flag'
+            "Unknown flag: '--flag'
 
 Usage:
     cargo upgrade [--all] [--dependency <dep>...] [--manifest-path <path>] [options]


### PR DESCRIPTION
We now provide a similar error message to `Cargo`.

It would be nice to have context-specific information depending on whether this is being called from `upgrade`, which supports `--all` or `add`/`rm`, which don't. However, this is probably good enough for now.

Solves #157 
