### PR TITLE
Bump version to 0.3.0-beta.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -99,7 +99,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-edit"
-version = "0.3.0-alpha.1"
+version = "0.3.0-beta.1"
 dependencies = [
  "assert_cli 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "cargo_metadata 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ license = "Apache-2.0/MIT"
 name = "cargo-edit"
 readme = "README.md"
 repository = "https://github.com/killercup/cargo-edit"
-version = "0.3.0-alpha.1"
+version = "0.3.0-beta.1"
 
 [[bin]]
 name = "cargo-add"


### PR DESCRIPTION
Contains these PRs: https://github.com/killercup/cargo-edit/pulls?utf8=✓&q=merged%3A2017-08-16..2017-12-19