### PR TITLE
Only upgrade version dependencies

### DIFF
--- a/src/bin/upgrade/main.rs
+++ b/src/bin/upgrade/main.rs
@@ -1,7 +1,7 @@
 //! `cargo upgrade`
 #![warn(missing_docs, missing_debug_implementations, missing_copy_implementations, trivial_casts,
-       trivial_numeric_casts, unsafe_code, unstable_features, unused_import_braces,
-       unused_qualifications)]
+        trivial_numeric_casts, unsafe_code, unstable_features, unused_import_braces,
+        unused_qualifications)]
 
 extern crate cargo_metadata;
 extern crate docopt;

--- a/src/bin/upgrade/main.rs
+++ b/src/bin/upgrade/main.rs
@@ -1,7 +1,7 @@
 //! `cargo upgrade`
 #![warn(missing_docs, missing_debug_implementations, missing_copy_implementations, trivial_casts,
-        trivial_numeric_casts, unsafe_code, unstable_features, unused_import_braces,
-        unused_qualifications)]
+       trivial_numeric_casts, unsafe_code, unstable_features, unused_import_braces,
+       unused_qualifications)]
 
 extern crate cargo_metadata;
 extern crate docopt;
@@ -73,8 +73,21 @@ struct Args {
     flag_allow_prerelease: bool,
 }
 
-fn is_version_dependency(dep: &toml_edit::Item) -> bool {
-    dep["git"].is_none() && dep["path"].is_none()
+trait PossibleVersionDependency {
+    fn is_version_dependency(&self) -> bool;
+}
+
+impl PossibleVersionDependency for toml_edit::Item {
+    fn is_version_dependency(&self) -> bool {
+        self["git"].is_none() && self["path"].is_none()
+    }
+}
+
+impl PossibleVersionDependency for cargo_metadata::Dependency {
+    fn is_version_dependency(&self) -> bool {
+        self.source.as_ref().map(|x| &**x)
+            == Some("registry+https://github.com/rust-lang/crates.io-index")
+    }
 }
 
 /// Upgrade the specified manifest. Use the closure provided to get the new dependency versions.
@@ -94,7 +107,7 @@ where
         for (name, old_value) in table_like.iter() {
             let owned = name.to_owned();
             if (only_update.is_empty() || only_update.contains(&owned))
-                && is_version_dependency(old_value)
+                && old_value.is_version_dependency()
             {
                 let latest_version = new_dependency(&owned)?;
 
@@ -134,7 +147,7 @@ fn upgrade_manifest_from_cache(
 /// Get a list of the paths of all the (non-virtual) manifests in the workspace.
 fn get_workspace_manifests(manifest_path: &Option<String>) -> Result<Vec<String>> {
     Ok(
-        cargo_metadata::metadata_deps(manifest_path.as_ref().map(Path::new), true)
+        cargo_metadata::metadata(manifest_path.as_ref().map(Path::new))
             .chain_err(|| "Failed to get metadata")?
             .packages
             .iter()
@@ -152,13 +165,14 @@ fn get_new_workspace_deps(
 ) -> Result<HashMap<String, Dependency>> {
     let mut new_deps = HashMap::new();
 
-    cargo_metadata::metadata_deps(manifest_path.as_ref().map(|p| Path::new(p)), true)
+    cargo_metadata::metadata(manifest_path.as_ref().map(|p| Path::new(p)))
         .chain_err(|| "Failed to get metadata")?
         .packages
         .iter()
         .flat_map(|package| package.dependencies.to_owned())
         .filter(|dependency| {
-            only_update.is_empty() || only_update.contains(&dependency.name)
+            (only_update.is_empty() || only_update.contains(&dependency.name))
+                && dependency.is_version_dependency()
         })
         .map(|dependency| {
             if !new_deps.contains_key(&dependency.name) {

--- a/tests/fixtures/workspace/Cargo.toml
+++ b/tests/fixtures/workspace/Cargo.toml
@@ -4,3 +4,5 @@ members = [
     "two",
     "explicit/*"
 ]
+
+exclude = ["not_a_member"]

--- a/tests/fixtures/workspace/Cargo.toml
+++ b/tests/fixtures/workspace/Cargo.toml
@@ -4,5 +4,3 @@ members = [
     "two",
     "explicit/*"
 ]
-
-exclude = ["not_a_member"]

--- a/tests/fixtures/workspace/one/Cargo.toml
+++ b/tests/fixtures/workspace/one/Cargo.toml
@@ -7,6 +7,5 @@ path = "../dummy.rs"
 
 [dependencies]
 libc = "0.2.28"
-three = { path = "../implicit/three"}
-bar = { git = "https://github.com/foo/bar.git", version = "0.10" }
-not_a_member = { path = "not_a_member", version = "0.10" }
+three = { path = "../implicit/three", version = "0.0.1"}
+lazy_static = { git = "https://github.com/rust-lang-nursery/lazy-static.rs.git", tag = "v0.2"}

--- a/tests/fixtures/workspace/one/Cargo.toml
+++ b/tests/fixtures/workspace/one/Cargo.toml
@@ -9,4 +9,4 @@ path = "../dummy.rs"
 libc = "0.2.28"
 three = { path = "../implicit/three"}
 bar = { git = "https://github.com/foo/bar.git", version = "0.10" }
-crates-io = { path = "src/crates-io", version = "0.10" }
+not_a_member = { path = "not_a_member", version = "0.10" }

--- a/tests/fixtures/workspace/one/Cargo.toml
+++ b/tests/fixtures/workspace/one/Cargo.toml
@@ -8,3 +8,5 @@ path = "../dummy.rs"
 [dependencies]
 libc = "0.2.28"
 three = { path = "../implicit/three"}
+bar = { git = "https://github.com/foo/bar.git", version = "0.10" }
+crates-io = { path = "src/crates-io", version = "0.10" }


### PR DESCRIPTION
This will also have the side-effect of preventing us from attempting to upgrade dependencies in registries other than the standard crates.io one.

Fixes #182 
