### PR TITLE
fix tests for stdout messages of cargo add/rm

### DIFF
--- a/tests/cargo-add.rs
+++ b/tests/cargo-add.rs
@@ -778,11 +778,10 @@ fn add_prints_message() {
         "target/debug/cargo-add",
         "add",
         "docopt",
+        "--vers=0.6.0",
         &format!("--manifest-path={}", manifest),
     ]).succeeds()
-        .prints("Adding").and()
-        .prints("docopt v").and()
-        .prints("to dependencies")
+        .prints_exactly("Adding docopt v0.6.0 to dependencies")
         .unwrap();
 }
 
@@ -793,14 +792,13 @@ fn add_prints_message_with_section() {
     assert_cli::Assert::command(&[
         "target/debug/cargo-add",
         "add",
-        "docopt",
+        "clap",
         "--optional",
         "--target=mytarget",
+        "--vers=0.1.0",
         &format!("--manifest-path={}", manifest),
     ]).succeeds()
-        .prints("Adding").and()
-        .prints("docopt v").and()
-        .prints("to optional dependencies for target `mytarget`")
+        .prints_exactly("Adding clap v0.1.0 to optional dependencies for target `mytarget`")
         .unwrap();
 }
 
@@ -813,11 +811,11 @@ fn add_prints_message_for_dev_deps() {
         "add",
         "docopt",
         "--dev",
+        "--vers",
+        "0.8.0",
         &format!("--manifest-path={}", manifest),
     ]).succeeds()
-        .prints("Adding").and()
-        .prints("docopt v").and()
-        .prints("to dev-dependencies")
+        .prints_exactly("Adding docopt v0.8.0 to dev-dependencies")
         .unwrap();
 }
 
@@ -828,12 +826,12 @@ fn add_prints_message_for_build_deps() {
     assert_cli::Assert::command(&[
         "target/debug/cargo-add",
         "add",
-        "docopt",
+        "hello-world",
         "--build",
+        "--vers",
+        "0.1.0",
         &format!("--manifest-path={}", manifest),
     ]).succeeds()
-        .prints("Adding").and()
-        .prints("docopt v").and()
-        .prints("to build-dependencies")
+        .prints_exactly("Adding hello-world v0.1.0 to build-dependencies")
         .unwrap();
 }

--- a/tests/cargo-rm.rs
+++ b/tests/cargo-rm.rs
@@ -164,7 +164,6 @@ fn rm_prints_message() {
         "semver",
         &format!("--manifest-path={}", manifest),
     ]).succeeds()
-        .prints("Removing").and()
-        .prints("semver from dependencies")
+        .prints_exactly("Removing semver from dependencies")
         .unwrap();
 }


### PR DESCRIPTION
The tests I added for the newly merged stdout messages are flawed.
Because of how assert_cli 0.4 works, putting several `.prints()` calls on a single Assertion will only evaluate the one added last. Therefore, my tests can succeed even if there is very different stdout output in the beginning.

Luckily, since colored output is disabled in tests, we can instead use `prints_exactly()` and assert the entire output. This PR does that.
In order to be able to assert the full output, the tests now also ask for a specific version of the crates they're adding.