### PR TITLE
Explicitly mention `Cargo.toml`

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,9 @@ Remove a dependency from a Cargo.toml manifest file.
 
 Upgrade dependencies in your `Cargo.toml` to their latest versions.
 
+This command differs from `cargo update`, which updates the dependency versions recorded in the
+local lock file (Cargo.lock).
+
 #### Examples
 
 ```sh
@@ -154,7 +157,7 @@ $ cargo upgrade -d regex --all
 #### Usage
 
 ```plain
-Upgrade dependencies in the manifest file (i.e. Cargo.toml) to the latest versions.
+Upgrade dependencies as specified in the local manifest file (i.e. Cargo.toml).
 
 Usage:
     cargo upgrade [--all] [--dependency <dep>...] [--manifest-path <path>] [options]
@@ -170,6 +173,9 @@ Options:
                                 '0.6.0-alpha'). Defaults to false.
     -h --help                   Show this help page.
     -V --version                Show version.
+
+This command differs from `cargo update`, which updates the dependency versions recorded in the
+local lock file (Cargo.lock).
 
 Dev, build, and all target dependencies will also be upgraded. Only dependencies from crates.io are
 supported. Git/path dependencies will be ignored.

--- a/README.md
+++ b/README.md
@@ -154,10 +154,10 @@ $ cargo upgrade -d regex --all
 #### Usage
 
 ```plain
-Upgrade all dependencies in a manifest file to the latest version.
+Upgrade dependencies in the manifest file (i.e. Cargo.toml) to the latest versions.
 
 Usage:
-    cargo upgrade [--all] [--dependency <dep>...] [--manifest-path <path>]
+    cargo upgrade [--all] [--dependency <dep>...] [--manifest-path <path>] [options]
     cargo upgrade (-h | --help)
     cargo upgrade (-V | --version)
 

--- a/src/bin/upgrade/main.rs
+++ b/src/bin/upgrade/main.rs
@@ -33,7 +33,7 @@ mod errors {
 use errors::*;
 
 static USAGE: &'static str = r"
-Upgrade dependencies in the manifest file (i.e. Cargo.toml) to the latest versions.
+Upgrade dependencies as specified in the local manifest file (i.e. Cargo.toml).
 
 Usage:
     cargo upgrade [--all] [--dependency <dep>...] [--manifest-path <path>] [options]
@@ -49,6 +49,9 @@ Options:
                                 '0.6.0-alpha'). Defaults to false.
     -h --help                   Show this help page.
     -V --version                Show version.
+
+This command differs from `cargo update`, which updates the dependency versions recorded in the
+local lock file (Cargo.lock).
 
 Dev, build, and all target dependencies will also be upgraded. Only dependencies from crates.io are
 supported. Git/path dependencies will be ignored.

--- a/src/bin/upgrade/main.rs
+++ b/src/bin/upgrade/main.rs
@@ -33,7 +33,7 @@ mod errors {
 use errors::*;
 
 static USAGE: &'static str = r"
-Upgrade all dependencies in a manifest file to the latest version.
+Upgrade dependencies in the manifest file (i.e. Cargo.toml) to the latest versions.
 
 Usage:
     cargo upgrade [--all] [--dependency <dep>...] [--manifest-path <path>] [options]


### PR DESCRIPTION
Not everyone automatically knows what a manifest is.

Solves #195. 