### PR TITLE
Upgrade Rustfmt + clippy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,14 +6,17 @@ rust:
 - stable
 matrix:
   include:
-  - rust: nightly-2017-12-20
+  - rust: "1.24.0"
     before_script:
-    - rustup component add rustfmt-preview --toolchain nightly-2017-12-20
-    - cargo install clippy --vers 0.0.176
+    - rustup component add rustfmt-preview --toolchain 1.24.0
     script:
-    - cargo clippy -- -D warnings
     - rustfmt -V
     - cargo fmt -- --write-mode diff
+  - rust: nightly-2018-02-14
+    before_script:
+    - cargo install clippy --vers 0.0.186
+    script:
+    - cargo clippy -- -D warnings
   allow_failures:
   - rust: nightly
 before_script:

--- a/src/bin/add/args.rs
+++ b/src/bin/add/args.rs
@@ -84,7 +84,6 @@ impl Args {
             ]);
         }
 
-
         let dependency = if !crate_name_is_url_or_path(&self.arg_crate) {
             let dependency = Dependency::new(&self.arg_crate);
 

--- a/src/bin/rm/main.rs
+++ b/src/bin/rm/main.rs
@@ -3,13 +3,13 @@
         trivial_numeric_casts, unsafe_code, unstable_features, unused_import_braces,
         unused_qualifications)]
 
+extern crate atty;
 extern crate docopt;
 #[macro_use]
 extern crate error_chain;
 #[macro_use]
 extern crate serde_derive;
 extern crate termcolor;
-extern crate atty;
 
 use std::process;
 use std::io::Write;

--- a/src/bin/upgrade/main.rs
+++ b/src/bin/upgrade/main.rs
@@ -105,8 +105,7 @@ where
         buffer
             .set_color(ColorSpec::new().set_fg(Some(Color::Cyan)).set_bold(true))
             .chain_err(|| "Failed to set output colour")?;
-        write!(&mut buffer, "Starting dry run. ")
-            .chain_err(|| "Failed to write dry run message")?;
+        write!(&mut buffer, "Starting dry run. ").chain_err(|| "Failed to write dry run message")?;
         buffer
             .set_color(&ColorSpec::new())
             .chain_err(|| "Failed to clear output colour")?;
@@ -154,12 +153,9 @@ fn upgrade_manifest_from_cache(
     new_deps: &HashMap<String, Dependency>,
     dry_run: bool,
 ) -> Result<()> {
-    upgrade_manifest_using_dependencies(
-        manifest_path,
-        only_update,
-        dry_run,
-        |name| Ok(new_deps[name].clone()),
-    )
+    upgrade_manifest_using_dependencies(manifest_path, only_update, dry_run, |name| {
+        Ok(new_deps[name].clone())
+    })
 }
 
 /// Get a list of the paths of all the (non-virtual) manifests in the workspace.
@@ -188,9 +184,7 @@ fn get_new_workspace_deps(
         .packages
         .iter()
         .flat_map(|package| package.dependencies.to_owned())
-        .filter(|dependency| {
-            only_update.is_empty() || only_update.contains(&dependency.name)
-        })
+        .filter(|dependency| only_update.is_empty() || only_update.contains(&dependency.name))
         .map(|dependency| {
             if !new_deps.contains_key(&dependency.name) {
                 new_deps.insert(

--- a/tests/cargo-add.rs
+++ b/tests/cargo-add.rs
@@ -13,9 +13,7 @@ const BOGUS_CRATE_NAME: &str = "tests-will-break-if-there-is-ever-a-real-package
 
 /// Check 'failure' deps are not present
 fn no_manifest_failures(manifest: &toml_edit::Item) -> bool {
-    let no_failure_key_in = |section| {
-        manifest[section][BOGUS_CRATE_NAME].is_none()
-    };
+    let no_failure_key_in = |section| manifest[section][BOGUS_CRATE_NAME].is_none();
     no_failure_key_in("dependencies") && no_failure_key_in("dev-dependencies")
         && no_failure_key_in("build-dependencies")
 }
@@ -211,12 +209,7 @@ fn adds_specified_version() {
 
     // cannot run with both --dev and --build at the same time
     let call = process::Command::new("target/debug/cargo-add")
-        .args(&[
-            "add",
-            BOGUS_CRATE_NAME,
-            "--vers",
-            "invalid version string",
-        ])
+        .args(&["add", BOGUS_CRATE_NAME, "--vers", "invalid version string"])
         .arg(format!("--manifest-path={}", &manifest))
         .output()
         .unwrap();
@@ -321,10 +314,7 @@ fn adds_git_source_using_flag() {
 
     let toml = get_toml(&manifest);
     let val = &toml["dev-dependencies"]["git-dev-pkg"];
-    assert_eq!(
-        val["git"].as_str(),
-        Some("http://site/gp.git")
-    );
+    assert_eq!(val["git"].as_str(), Some("http://site/gp.git"));
 }
 
 #[test]
@@ -339,10 +329,7 @@ fn adds_local_source_using_flag() {
 
     let toml = get_toml(&manifest);
     let val = &toml["dependencies"]["local"];
-    assert_eq!(
-        val["path"].as_str(),
-        Some("/path/to/pkg")
-    );
+    assert_eq!(val["path"].as_str(), Some("/path/to/pkg"));
 
     // check this works with other flags (e.g. --dev) as well
     let toml = get_toml(&manifest);
@@ -355,10 +342,7 @@ fn adds_local_source_using_flag() {
 
     let toml = get_toml(&manifest);
     let val = &toml["dev-dependencies"]["local-dev"];
-    assert_eq!(
-        val["path"].as_str(),
-        Some("/path/to/pkg-dev")
-    );
+    assert_eq!(val["path"].as_str(), Some("/path/to/pkg-dev"));
 }
 
 #[test]
@@ -552,7 +536,6 @@ fn adds_dependency_with_custom_target() {
     assert_eq!(val.as_str(), Some("my-package1--CURRENT_VERSION_TEST"));
 }
 
-
 #[test]
 #[cfg(feature = "test-external-apis")]
 fn adds_dependency_normalized_name() {
@@ -575,7 +558,6 @@ fn adds_dependency_normalized_name() {
     let toml = get_toml(&manifest);
     assert!(!toml["dependencies"]["linked-hash-map"].is_none());
 }
-
 
 #[test]
 #[should_panic]

--- a/tests/cargo-upgrade.rs
+++ b/tests/cargo-upgrade.rs
@@ -110,10 +110,7 @@ fn upgrade_specified_only() {
         dependencies["versioned-package"].as_str(),
         Some("versioned-package--CURRENT_VERSION_TEST")
     );
-    assert_eq!(
-        dependencies["versioned-package-2"].as_str(),
-        Some("0.1.1")
-    );
+    assert_eq!(dependencies["versioned-package-2"].as_str(), Some("0.1.1"));
 }
 
 #[test]


### PR DESCRIPTION
Use the latest version of nightly clippy (0.0.186) - no new warnings. Also switch to the stable train of rustfmt previews.