### PR TITLE
cargo-upgrade prints manifests

### DIFF
--- a/src/bin/upgrade/main.rs
+++ b/src/bin/upgrade/main.rs
@@ -182,7 +182,9 @@ impl Manifests {
                 .chain_err(|| "Failed to print dry run message")?;
         }
 
-        for (mut manifest, _) in self.0 {
+        for (mut manifest, package) in self.0 {
+            println!("{}:", package.name);
+
             for (name, version) in &upgraded_deps.0 {
                 manifest.upgrade(&Dependency::new(name).set_version(version), dry_run)?;
             }

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -117,7 +117,7 @@ fn print_upgrade_if_necessary(
         buffer
             .set_color(ColorSpec::new().set_fg(Some(Color::Green)).set_bold(true))
             .chain_err(|| "Failed to set output colour")?;
-        write!(&mut buffer, "Upgrading ").chain_err(|| "Failed to write upgrade message")?;
+        write!(&mut buffer, "    Upgrading ").chain_err(|| "Failed to write upgrade message")?;
         buffer
             .set_color(&ColorSpec::new())
             .chain_err(|| "Failed to clear output colour")?;


### PR DESCRIPTION
A simple change to get `cargo-upgrade` to print the name of the package we're about to upgrade.