### PR TITLE
Add specific error for a missing crate

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,9 @@ rust:
 - stable
 matrix:
   include:
-  - rust: "1.24.0"
+  - rust: "1.25.0"
     before_script:
-    - rustup component add rustfmt-preview --toolchain 1.24.0
+    - rustup component add rustfmt-preview --toolchain 1.25.0
     script:
     - rustfmt -V
     - cargo fmt -- --write-mode diff

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -8,6 +8,11 @@ error_chain!{
         InvalidCratesIoJson {
             description("Invalid JSON (the crate may not exist)")
         }
+        /// No crate by that name exists
+        NoCrate(name: String) {
+            description("The crate could not be found on crates.io.")
+            display("The crate `{}` could not be found on crates.io.", name)
+        }
         /// No versions available
         NoVersionsAvailable {
             description("No available versions exist. Either all were yanked \

--- a/tests/cargo-add.rs
+++ b/tests/cargo-add.rs
@@ -599,7 +599,6 @@ fn fails_to_add_multiple_optional_dev_dependencies() {
     // dependencies not present beforehand
     let toml = get_toml(&manifest);
     assert!(toml["dependencies"].is_none());
-    assert!(toml["dependencies"].is_none());
 
     // Fails because optional dependencies must be in `dependencies` table.
     execute_command(
@@ -818,5 +817,22 @@ fn add_prints_message_for_build_deps() {
         &format!("--manifest-path={}", manifest),
     ]).succeeds()
         .prints_exactly("Adding hello-world v0.1.0 to build-dependencies")
+        .unwrap();
+}
+
+#[test]
+fn add_typo() {
+    let (_tmpdir, manifest) = clone_out_test("tests/fixtures/add/Cargo.toml.sample");
+
+    assert_cli::Assert::command(&[
+        "target/debug/cargo-add",
+        "add",
+        "lets_hope_nobody_ever_publishes_this_crate",
+        &format!("--manifest-path={}", manifest),
+    ]).fails_with(1)
+        .prints_error(
+            "The crate `lets_hope_nobody_ever_publishes_this_crate` could not be found \
+             on crates.io.",
+        )
         .unwrap();
 }


### PR DESCRIPTION
The new error message is:

```
$ cargo add lets_hope_nobody_ever_publishes_a_crate_with_this_name
Command failed due to unhandled error: The crate `lets_hope_nobody_ever_publishes_a_crate_with_this_name` could not be found on crates.io.

Caused by: https://crates.io/api/v1/crates/lets_hope_nobody_ever_publishes_a_crate_with_this_name: Client Error: 404 Not Found
```

This is a partial fix for #209 (doesn't sort out the backtrace issue).

This PR also ensures that we catch errors when fetching from crates.io correctly. Previously, we only noticed if the JSON was in an unexpected format. Now, we check the status of the response first.

Also bumps the rustfmt version to the version shipped with stable 1.25.0.