### PR TITLE
 Add a `--major-only` flag to cargo upgrade

### DIFF
--- a/src/bin/add/main.rs
+++ b/src/bin/add/main.rs
@@ -1,9 +1,7 @@
 //! `cargo add`
-#![warn(
-    missing_docs, missing_debug_implementations, missing_copy_implementations, trivial_casts,
-    trivial_numeric_casts, unsafe_code, unstable_features, unused_import_braces,
-    unused_qualifications
-)]
+#![warn(missing_docs, missing_debug_implementations, missing_copy_implementations, trivial_casts,
+        trivial_numeric_casts, unsafe_code, unstable_features, unused_import_braces,
+        unused_qualifications)]
 
 extern crate atty;
 extern crate docopt;

--- a/src/bin/rm/main.rs
+++ b/src/bin/rm/main.rs
@@ -1,9 +1,7 @@
 //! `cargo rm`
-#![warn(
-    missing_docs, missing_debug_implementations, missing_copy_implementations, trivial_casts,
-    trivial_numeric_casts, unsafe_code, unstable_features, unused_import_braces,
-    unused_qualifications
-)]
+#![warn(missing_docs, missing_debug_implementations, missing_copy_implementations, trivial_casts,
+        trivial_numeric_casts, unsafe_code, unstable_features, unused_import_braces,
+        unused_qualifications)]
 
 extern crate atty;
 extern crate docopt;

--- a/src/bin/upgrade/main.rs
+++ b/src/bin/upgrade/main.rs
@@ -1,9 +1,7 @@
 //! `cargo upgrade`
-#![warn(
-    missing_docs, missing_debug_implementations, missing_copy_implementations, trivial_casts,
-    trivial_numeric_casts, unsafe_code, unstable_features, unused_import_braces,
-    unused_qualifications
-)]
+#![warn(missing_docs, missing_debug_implementations, missing_copy_implementations, trivial_casts,
+        trivial_numeric_casts, unsafe_code, unstable_features, unused_import_braces,
+        unused_qualifications)]
 
 extern crate cargo_metadata;
 extern crate docopt;
@@ -81,7 +79,7 @@ struct Args {
     /// `--version`
     flag_version: bool,
     /// `--major-only`
-    flag_major_only: bool
+    flag_major_only: bool,
 }
 
 /// A collection of manifests.
@@ -168,7 +166,12 @@ impl Manifests {
     }
 
     /// Upgrade the manifests on disk following the previously-determined upgrade schema.
-    fn upgrade(self, upgraded_deps: &ActualUpgrades, dry_run: bool, flag_major_only: bool) -> Result<()> {
+    fn upgrade(
+        self,
+        upgraded_deps: &ActualUpgrades,
+        dry_run: bool,
+        flag_major_only: bool,
+    ) -> Result<()> {
         if dry_run {
             let bufwtr = BufferWriter::stdout(ColorChoice::Always);
             let mut buffer = bufwtr.buffer();
@@ -191,7 +194,11 @@ impl Manifests {
             println!("{}:", package.name);
 
             for (name, version) in &upgraded_deps.0 {
-                manifest.upgrade(&Dependency::new(name).set_version(version), dry_run, flag_major_only)?;
+                manifest.upgrade(
+                    &Dependency::new(name).set_version(version),
+                    dry_run,
+                    flag_major_only,
+                )?;
             }
         }
 

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -47,5 +47,10 @@ error_chain!{
             description("non existent dependency")
             display("The dependency `{}` could not be found in `{}`.", name, table)
         }
+        /// Failed to parse a version for a dependency
+        ParseVersion(version: String, dep: String) {
+            description("Failed to parse a version for a dependency")
+            display("The version `{}` for the dependency `{}` couldn't be parsed", version, dep)
+        }
     }
 }

--- a/src/fetch.rs
+++ b/src/fetch.rs
@@ -41,7 +41,13 @@ pub fn get_latest_dependency(crate_name: &str, flag_allow_prerelease: bool) -> R
         let new_version = if flag_allow_prerelease {
             format!("{}--PRERELEASE_VERSION_TEST", crate_name)
         } else {
-            format!("{}--CURRENT_VERSION_TEST", crate_name)
+            if crate_name == "test_breaking" {
+                "0.2.0".to_string()
+            } else if crate_name == "test_nonbreaking" {
+                "0.1.1".to_string()
+            } else {
+                format!("{}--CURRENT_VERSION_TEST", crate_name)
+            }
         };
 
         return Ok(Dependency::new(crate_name).set_version(&new_version));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,10 +1,8 @@
 //! Show and Edit Cargo's Manifest Files
 #![cfg_attr(test, allow(dead_code))]
-#![warn(
-    missing_docs, missing_debug_implementations, missing_copy_implementations, trivial_casts,
-    trivial_numeric_casts, unsafe_code, unstable_features, unused_import_braces,
-    unused_qualifications
-)]
+#![warn(missing_docs, missing_debug_implementations, missing_copy_implementations, trivial_casts,
+        trivial_numeric_casts, unsafe_code, unstable_features, unused_import_braces,
+        unused_qualifications)]
 
 extern crate cargo_metadata;
 extern crate env_proxy;

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -10,6 +10,8 @@ use toml_edit;
 use dependency::Dependency;
 use errors::*;
 
+use semver::{Version, VersionReq};
+
 const MANIFEST_FILENAME: &str = "Cargo.toml";
 
 /// A Cargo manifest
@@ -89,6 +91,19 @@ fn merge_dependencies(old_dep: &mut toml_edit::Item, new: &Dependency) {
 
     if let Some(t) = old_dep.as_inline_table_mut() {
         t.fmt()
+    }
+}
+
+fn get_old_version(old_dep: &toml_edit::Item) -> Option<String> {
+    assert!(!old_dep.is_none());
+
+    if str_or_1_len_table(old_dep) {
+        old_dep.as_str().map(|v| v.to_string())
+    } else if old_dep.is_table_like() {
+        let version = old_dep["version"].clone();
+        version.as_str().map(|v| v.to_string())
+    } else {
+        None
     }
 }
 
@@ -391,11 +406,23 @@ impl LocalManifest {
 
     /// Instruct this manifest to upgrade a single dependency. If this manifest does not have that
     /// dependency, it does nothing.
-    pub fn upgrade(&mut self, dependency: &Dependency, dry_run: bool) -> Result<()> {
+    pub fn upgrade(&mut self, dependency: &Dependency, dry_run: bool, only_breaking: bool) -> Result<()> {
         for (table_path, table) in self.get_sections() {
             let table_like = table.as_table_like().expect("Unexpected non-table");
-            for (name, _old_value) in table_like.iter() {
+            for (name, old_v) in table_like.iter() {
                 if name == dependency.name {
+                    let old_version = get_old_version(old_v);
+                    if let Some(old_version) = old_version {
+                        if only_breaking &&
+                        VersionReq::parse(&old_version)
+                            .chain_err(|| ErrorKind::ParseVersion(name.into(), old_version))?
+                            .matches(
+                                &Version::parse(&dependency.version().unwrap())
+                                .chain_err(|| ErrorKind::ParseVersion(name.into(), dependency.version().unwrap().into()))?)
+                        {
+                            continue;
+                        }
+                    }
                     self.manifest
                         .update_table_entry(&table_path, dependency, dry_run)?;
                 }

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -406,20 +406,28 @@ impl LocalManifest {
 
     /// Instruct this manifest to upgrade a single dependency. If this manifest does not have that
     /// dependency, it does nothing.
-    pub fn upgrade(&mut self, dependency: &Dependency, dry_run: bool, only_breaking: bool) -> Result<()> {
+    pub fn upgrade(
+        &mut self,
+        dependency: &Dependency,
+        dry_run: bool,
+        only_breaking: bool,
+    ) -> Result<()> {
         for (table_path, table) in self.get_sections() {
             let table_like = table.as_table_like().expect("Unexpected non-table");
             for (name, old_v) in table_like.iter() {
                 if name == dependency.name {
                     let old_version = get_old_version(old_v);
                     if let Some(old_version) = old_version {
-                        if only_breaking &&
-                        VersionReq::parse(&old_version)
-                            .chain_err(|| ErrorKind::ParseVersion(name.into(), old_version))?
-                            .matches(
-                                &Version::parse(&dependency.version().unwrap())
-                                .chain_err(|| ErrorKind::ParseVersion(name.into(), dependency.version().unwrap().into()))?)
-                        {
+                        if only_breaking
+                            && VersionReq::parse(&old_version)
+                                .chain_err(|| ErrorKind::ParseVersion(name.into(), old_version))?
+                                .matches(&Version::parse(&dependency.version().unwrap())
+                                    .chain_err(|| {
+                                        ErrorKind::ParseVersion(
+                                            name.into(),
+                                            dependency.version().unwrap().into(),
+                                        )
+                                    })?) {
                             continue;
                         }
                     }

--- a/tests/cargo-upgrade.rs
+++ b/tests/cargo-upgrade.rs
@@ -158,6 +158,27 @@ fn upgrade_specified_only() {
 }
 
 #[test]
+fn upgrade_major_only() {
+    let (_tmpdir, manifest) = clone_out_test("tests/fixtures/add/Cargo.toml.sample");
+
+    execute_command(&["add", "test_breaking", "--vers", "0.1"], &manifest);
+    execute_command(&["add", "test_nonbreaking", "--vers", "0.1"], &manifest);
+
+    execute_command(&["upgrade", "--major-only"], &manifest);
+
+    // Verify that `docopt` was upgraded, but not `env_proxy`
+    let dependencies = &get_toml(&manifest)["dependencies"];
+    assert_eq!(
+        dependencies["test_breaking"].as_str(),
+        Some("0.2.0")
+    );
+    assert_eq!(
+        dependencies["test_nonbreaking"].as_str(),
+        Some("0.1")
+    );
+}
+
+#[test]
 fn fails_to_upgrade_missing_dependency() {
     let (_tmpdir, manifest) = clone_out_test("tests/fixtures/add/Cargo.toml.sample");
 

--- a/tests/cargo-upgrade.rs
+++ b/tests/cargo-upgrade.rs
@@ -168,14 +168,8 @@ fn upgrade_major_only() {
 
     // Verify that `docopt` was upgraded, but not `env_proxy`
     let dependencies = &get_toml(&manifest)["dependencies"];
-    assert_eq!(
-        dependencies["test_breaking"].as_str(),
-        Some("0.2.0")
-    );
-    assert_eq!(
-        dependencies["test_nonbreaking"].as_str(),
-        Some("0.1")
-    );
+    assert_eq!(dependencies["test_breaking"].as_str(), Some("0.2.0"));
+    assert_eq!(dependencies["test_nonbreaking"].as_str(), Some("0.1"));
 }
 
 #[test]


### PR DESCRIPTION
This flag will make `cargo upgrade` ignore upgrades where the old
version is semver compatible with the new one. This is useful in cases
where you don't want to churn the Cargo.toml files in the whole project
knowing that the lockfile is already forcing the versions to be up to
date.

To test that I had to cheat a little bit and hardcode two different fake
dependencies in `get_latest_dependency` which is unfortunate but
necessary as there's no way currently to mock answers from crates.io.