### PR TITLE
Migrate to 2018 edition

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ name = "cargo-edit"
 readme = "README.md"
 repository = "https://github.com/killercup/cargo-edit"
 version = "0.3.1"
+edition = "2018"
 
 [[bin]]
 name = "cargo-add"

--- a/src/bin/add/args.rs
+++ b/src/bin/add/args.rs
@@ -71,7 +71,8 @@ impl Args {
     /// Build dependencies from arguments
     pub fn parse_dependencies(&self) -> Result<Vec<Dependency>> {
         if !self.arg_crates.is_empty() {
-            return self.arg_crates
+            return self
+                .arg_crates
                 .iter()
                 .map(|crate_name| {
                     Ok(

--- a/src/bin/add/args.rs
+++ b/src/bin/add/args.rs
@@ -5,7 +5,7 @@ use cargo_edit::{get_latest_dependency, CrateName};
 use semver;
 use std::path::PathBuf;
 
-use errors::*;
+use crate::errors::*;
 
 #[derive(Debug, Deserialize)]
 /// Docopts input args.

--- a/src/bin/add/main.rs
+++ b/src/bin/add/main.rs
@@ -28,7 +28,7 @@ extern crate cargo_edit;
 use cargo_edit::{Dependency, Manifest};
 
 mod args;
-use args::Args;
+use crate::args::Args;
 
 mod errors {
     error_chain! {
@@ -52,7 +52,7 @@ mod errors {
         }
     }
 }
-use errors::*;
+use crate::errors::*;
 
 static USAGE: &'static str = r#"
 Usage:

--- a/src/bin/add/main.rs
+++ b/src/bin/add/main.rs
@@ -11,24 +11,18 @@
     unused_qualifications
 )]
 
-extern crate atty;
-extern crate docopt;
 #[macro_use]
 extern crate error_chain;
-extern crate semver;
 #[macro_use]
 extern crate serde_derive;
-extern crate termcolor;
 
+use crate::args::Args;
+use cargo_edit::{Dependency, Manifest};
 use std::io::Write;
 use std::process;
 use termcolor::{Color, ColorChoice, ColorSpec, StandardStream, WriteColor};
 
-extern crate cargo_edit;
-use cargo_edit::{Dependency, Manifest};
-
 mod args;
-use crate::args::Args;
 
 mod errors {
     error_chain! {

--- a/src/bin/rm/args.rs
+++ b/src/bin/rm/args.rs
@@ -1,6 +1,6 @@
 //! Handle `cargo rm` arguments
 
-use errors::*;
+use crate::errors::*;
 
 #[derive(Debug, Deserialize)]
 /// Docopts input args.

--- a/src/bin/rm/main.rs
+++ b/src/bin/rm/main.rs
@@ -27,7 +27,7 @@ extern crate cargo_edit;
 use cargo_edit::Manifest;
 
 mod args;
-use args::Args;
+use crate::args::Args;
 
 mod errors {
     error_chain! {
@@ -39,7 +39,7 @@ mod errors {
         }
     }
 }
-use errors::*;
+use crate::errors::*;
 
 static USAGE: &'static str = r"
 Usage:

--- a/src/bin/rm/main.rs
+++ b/src/bin/rm/main.rs
@@ -11,23 +11,18 @@
     unused_qualifications
 )]
 
-extern crate atty;
-extern crate docopt;
 #[macro_use]
 extern crate error_chain;
 #[macro_use]
 extern crate serde_derive;
-extern crate termcolor;
 
+use crate::args::Args;
+use cargo_edit::Manifest;
 use std::io::Write;
 use std::process;
 use termcolor::{Color, ColorChoice, ColorSpec, StandardStream, WriteColor};
 
-extern crate cargo_edit;
-use cargo_edit::Manifest;
-
 mod args;
-use crate::args::Args;
 
 mod errors {
     error_chain! {

--- a/src/bin/upgrade/main.rs
+++ b/src/bin/upgrade/main.rs
@@ -11,23 +11,17 @@
     unused_qualifications
 )]
 
-extern crate cargo_metadata;
-extern crate docopt;
 #[macro_use]
 extern crate error_chain;
 #[macro_use]
 extern crate serde_derive;
-extern crate toml_edit;
 
+use crate::errors::*;
+use cargo_edit::{find, get_latest_dependency, CrateName, Dependency, LocalManifest};
 use std::collections::HashMap;
 use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::process;
-
-extern crate cargo_edit;
-use cargo_edit::{find, get_latest_dependency, CrateName, Dependency, LocalManifest};
-
-extern crate termcolor;
 use termcolor::{BufferWriter, Color, ColorChoice, ColorSpec, WriteColor};
 
 mod errors {
@@ -38,7 +32,6 @@ mod errors {
         }
     }
 }
-use crate::errors::*;
 
 static USAGE: &'static str = r"
 Upgrade dependencies as specified in the local manifest file (i.e. Cargo.toml).

--- a/src/bin/upgrade/main.rs
+++ b/src/bin/upgrade/main.rs
@@ -32,7 +32,7 @@ mod errors {
         }
     }
 }
-use errors::*;
+use crate::errors::*;
 
 static USAGE: &'static str = r"
 Upgrade dependencies as specified in the local manifest file (i.e. Cargo.toml).

--- a/src/bin/upgrade/main.rs
+++ b/src/bin/upgrade/main.rs
@@ -1,7 +1,13 @@
 //! `cargo upgrade`
 #![warn(
-    missing_docs, missing_debug_implementations, missing_copy_implementations, trivial_casts,
-    trivial_numeric_casts, unsafe_code, unstable_features, unused_import_braces,
+    missing_docs,
+    missing_debug_implementations,
+    missing_copy_implementations,
+    trivial_casts,
+    trivial_numeric_casts,
+    unsafe_code,
+    unstable_features,
+    unused_import_braces,
     unused_qualifications
 )]
 
@@ -25,7 +31,7 @@ extern crate termcolor;
 use termcolor::{BufferWriter, Color, ColorChoice, ColorSpec, WriteColor};
 
 mod errors {
-    error_chain!{
+    error_chain! {
         links {
             CargoEditLib(::cargo_edit::Error, ::cargo_edit::ErrorKind);
             CargoMetadata(::cargo_metadata::Error, ::cargo_metadata::ErrorKind);
@@ -119,8 +125,10 @@ impl Manifests {
             .find(|p| p.manifest_path == resolved_manifest_path)
             // If we have successfully got metadata, but our manifest path does not correspond to a
             // package, we must have been called against a virtual manifest.
-            .chain_err(|| "Found virtual manifest, but this command requires running against an \
-                           actual package in this workspace. Try adding `--all`.")?;
+            .chain_err(|| {
+                "Found virtual manifest, but this command requires running against an \
+                 actual package in this workspace. Try adding `--all`."
+            })?;
 
         Ok(Manifests(vec![(manifest, package.to_owned())]))
     }

--- a/src/crate_name.rs
+++ b/src/crate_name.rs
@@ -1,9 +1,9 @@
 //! Crate name parsing.
 use semver;
 
-use errors::*;
-use Dependency;
-use {get_crate_name_from_github, get_crate_name_from_gitlab, get_crate_name_from_path};
+use crate::errors::*;
+use crate::Dependency;
+use crate::{get_crate_name_from_github, get_crate_name_from_gitlab, get_crate_name_from_path};
 
 /// A crate specifier. This can be a plain name (e.g. `docopt`), a name and a versionreq (e.g.
 /// `docopt@^0.8`), a URL, or a path.

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,4 +1,4 @@
-error_chain!{
+error_chain! {
     errors {
         /// Failed to fetch crate from crates.io
         FetchVersionFailure {

--- a/src/fetch.rs
+++ b/src/fetch.rs
@@ -1,3 +1,4 @@
+use crate::{Dependency, Manifest};
 use env_proxy;
 use regex::Regex;
 use reqwest;
@@ -7,7 +8,6 @@ use std::env;
 use std::io::Read;
 use std::path::Path;
 use std::time::Duration;
-use crate::{Dependency, Manifest};
 
 use crate::errors::*;
 
@@ -97,7 +97,8 @@ fn get_latest_stable_version_from_json() {
         }
       ]
     }"#,
-    ).expect("crate version is correctly parsed");
+    )
+    .expect("crate version is correctly parsed");
 
     assert_eq!(
         read_latest_version(&versions, false)
@@ -125,7 +126,8 @@ fn get_latest_unstable_or_stable_version_from_json() {
         }
       ]
     }"#,
-    ).expect("crate version is correctly parsed");
+    )
+    .expect("crate version is correctly parsed");
 
     assert_eq!(
         read_latest_version(&versions, true)
@@ -153,7 +155,8 @@ fn get_latest_version_from_json_test() {
         }
       ]
     }"#,
-    ).expect("crate version is correctly parsed");
+    )
+    .expect("crate version is correctly parsed");
 
     assert_eq!(
         read_latest_version(&versions, false)
@@ -181,7 +184,8 @@ fn get_no_latest_version_from_json_when_all_are_yanked() {
         }
       ]
     }"#,
-    ).expect("crate version is correctly parsed");
+    )
+    .expect("crate version is correctly parsed");
 
     assert!(read_latest_version(&versions, false).is_err());
 }

--- a/src/fetch.rs
+++ b/src/fetch.rs
@@ -7,9 +7,9 @@ use std::env;
 use std::io::Read;
 use std::path::Path;
 use std::time::Duration;
-use {Dependency, Manifest};
+use crate::{Dependency, Manifest};
 
-use errors::*;
+use crate::errors::*;
 
 const REGISTRY_HOST: &str = "https://crates.io";
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,9 +26,9 @@ mod errors;
 mod fetch;
 mod manifest;
 
-pub use crate_name::CrateName;
-pub use dependency::Dependency;
-pub use errors::*;
-pub use fetch::{get_crate_name_from_github, get_crate_name_from_gitlab, get_crate_name_from_path,
+pub use crate::crate_name::CrateName;
+pub use crate::dependency::Dependency;
+pub use crate::errors::*;
+pub use crate::fetch::{get_crate_name_from_github, get_crate_name_from_gitlab, get_crate_name_from_path,
                 get_latest_dependency};
-pub use manifest::{find, LocalManifest, Manifest};
+pub use crate::manifest::{find, LocalManifest, Manifest};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,19 +12,10 @@
     unused_qualifications
 )]
 
-extern crate cargo_metadata;
-extern crate env_proxy;
 #[macro_use]
 extern crate error_chain;
-extern crate regex;
-extern crate reqwest;
-extern crate semver;
-extern crate serde;
 #[macro_use]
 extern crate serde_derive;
-extern crate serde_json;
-extern crate termcolor;
-extern crate toml_edit;
 
 mod crate_name;
 mod dependency;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,14 @@
 //! Show and Edit Cargo's Manifest Files
 #![cfg_attr(test, allow(dead_code))]
 #![warn(
-    missing_docs, missing_debug_implementations, missing_copy_implementations, trivial_casts,
-    trivial_numeric_casts, unsafe_code, unstable_features, unused_import_braces,
+    missing_docs,
+    missing_debug_implementations,
+    missing_copy_implementations,
+    trivial_casts,
+    trivial_numeric_casts,
+    unsafe_code,
+    unstable_features,
+    unused_import_braces,
     unused_qualifications
 )]
 
@@ -29,6 +35,8 @@ mod manifest;
 pub use crate::crate_name::CrateName;
 pub use crate::dependency::Dependency;
 pub use crate::errors::*;
-pub use crate::fetch::{get_crate_name_from_github, get_crate_name_from_gitlab, get_crate_name_from_path,
-                get_latest_dependency};
+pub use crate::fetch::{
+    get_crate_name_from_github, get_crate_name_from_gitlab, get_crate_name_from_path,
+    get_latest_dependency,
+};
 pub use crate::manifest::{find, LocalManifest, Manifest};

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -297,8 +297,6 @@ impl Manifest {
     /// # Examples
     ///
     /// ```
-    /// # extern crate cargo_edit;
-    /// # extern crate toml_edit;
     /// # fn main() {
     ///     use cargo_edit::{Dependency, Manifest};
     ///     use toml_edit;

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -52,7 +52,8 @@ fn search(dir: &Path) -> Result<PathBuf> {
 }
 
 fn merge_inline_table(old_dep: &mut toml_edit::Item, new: &toml_edit::Item) {
-    for (k, v) in new.as_inline_table()
+    for (k, v) in new
+        .as_inline_table()
         .expect("expected an inline table")
         .iter()
     {
@@ -127,7 +128,8 @@ fn print_upgrade_if_necessary(
             &mut buffer,
             "{} v{} -> v{}",
             crate_name, old_version, new_version,
-        ).chain_err(|| "Failed to write upgrade versions")?;
+        )
+        .chain_err(|| "Failed to write upgrade versions")?;
         bufwtr
             .print(&buffer)
             .chain_err(|| "Failed to print upgrade message")?;
@@ -198,7 +200,8 @@ impl Manifest {
             }
 
             // ... and in `target.<target>.(build-/dev-)dependencies`.
-            let target_sections = self.data
+            let target_sections = self
+                .data
                 .as_table()
                 .get("target")
                 .and_then(toml_edit::Item::as_table_like)
@@ -422,11 +425,9 @@ mod tests {
         let clone = manifest.clone();
         let dep = Dependency::new("cargo-edit").set_version("0.1.0");
         let _ = manifest.insert_into_table(&["dependencies".to_owned()], &dep);
-        assert!(
-            manifest
-                .remove_from_table("dependencies", &dep.name)
-                .is_ok()
-        );
+        assert!(manifest
+            .remove_from_table("dependencies", &dep.name)
+            .is_ok());
         assert_eq!(manifest.data.to_string(), clone.data.to_string());
     }
 
@@ -471,11 +472,9 @@ mod tests {
             data: toml_edit::Document::new(),
         };
         let dep = Dependency::new("cargo-edit").set_version("0.1.0");
-        assert!(
-            manifest
-                .remove_from_table("dependencies", &dep.name)
-                .is_err()
-        );
+        assert!(manifest
+            .remove_from_table("dependencies", &dep.name)
+            .is_err());
     }
 
     #[test]
@@ -486,10 +485,8 @@ mod tests {
         let dep = Dependency::new("cargo-edit").set_version("0.1.0");
         let other_dep = Dependency::new("other-dep").set_version("0.1.0");
         let _ = manifest.insert_into_table(&["dependencies".to_owned()], &other_dep);
-        assert!(
-            manifest
-                .remove_from_table("dependencies", &dep.name)
-                .is_err()
-        );
+        assert!(manifest
+            .remove_from_table("dependencies", &dep.name)
+            .is_err());
     }
 }

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -7,8 +7,8 @@ use std::{env, str};
 use termcolor::{BufferWriter, Color, ColorChoice, ColorSpec, WriteColor};
 use toml_edit;
 
-use dependency::Dependency;
-use errors::*;
+use crate::dependency::Dependency;
+use crate::errors::*;
 
 const MANIFEST_FILENAME: &str = "Cargo.toml";
 
@@ -411,7 +411,7 @@ impl LocalManifest {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use dependency::Dependency;
+    use crate::dependency::Dependency;
     use toml_edit;
 
     #[test]

--- a/tests/cargo-add.rs
+++ b/tests/cargo-add.rs
@@ -1,7 +1,5 @@
-extern crate assert_cli;
 #[macro_use]
 extern crate pretty_assertions;
-extern crate toml_edit;
 
 use std::process;
 mod utils;

--- a/tests/cargo-add.rs
+++ b/tests/cargo-add.rs
@@ -14,7 +14,8 @@ const BOGUS_CRATE_NAME: &str = "tests-will-break-if-there-is-ever-a-real-package
 /// Check 'failure' deps are not present
 fn no_manifest_failures(manifest: &toml_edit::Item) -> bool {
     let no_failure_key_in = |section| manifest[section][BOGUS_CRATE_NAME].is_none();
-    no_failure_key_in("dependencies") && no_failure_key_in("dev-dependencies")
+    no_failure_key_in("dependencies")
+        && no_failure_key_in("dev-dependencies")
         && no_failure_key_in("build-dependencies")
 }
 
@@ -705,11 +706,12 @@ fn adds_dependency_normalized_name() {
         "add",
         "linked_hash_map",
         &format!("--manifest-path={}", manifest),
-    ]).succeeds()
-        .and()
-        .stdout()
-        .contains("WARN: Added `linked-hash-map` instead of `linked_hash_map`")
-        .unwrap();
+    ])
+    .succeeds()
+    .and()
+    .stdout()
+    .contains("WARN: Added `linked-hash-map` instead of `linked_hash_map`")
+    .unwrap();
 
     // dependency present afterwards
     let toml = get_toml(&manifest);
@@ -808,7 +810,9 @@ version = "0.0.0"
 
 [lib]
 path = "dummy.rs"
-"#.to_string() + expected;
+"#
+    .to_string()
+        + expected;
     let expected_dep: toml_edit::Document = expected.parse().expect("toml parse error");
     assert_eq!(expected_dep.to_string(), toml.to_string());
 }
@@ -921,11 +925,12 @@ fn add_prints_message() {
         "docopt",
         "--vers=0.6.0",
         &format!("--manifest-path={}", manifest),
-    ]).succeeds()
-        .and()
-        .stdout()
-        .is("Adding docopt v0.6.0 to dependencies")
-        .unwrap();
+    ])
+    .succeeds()
+    .and()
+    .stdout()
+    .is("Adding docopt v0.6.0 to dependencies")
+    .unwrap();
 }
 
 #[test]
@@ -940,11 +945,12 @@ fn add_prints_message_with_section() {
         "--target=mytarget",
         "--vers=0.1.0",
         &format!("--manifest-path={}", manifest),
-    ]).succeeds()
-        .and()
-        .stdout()
-        .is("Adding clap v0.1.0 to optional dependencies for target `mytarget`")
-        .unwrap();
+    ])
+    .succeeds()
+    .and()
+    .stdout()
+    .is("Adding clap v0.1.0 to optional dependencies for target `mytarget`")
+    .unwrap();
 }
 
 #[test]
@@ -959,11 +965,12 @@ fn add_prints_message_for_dev_deps() {
         "--vers",
         "0.8.0",
         &format!("--manifest-path={}", manifest),
-    ]).succeeds()
-        .and()
-        .stdout()
-        .is("Adding docopt v0.8.0 to dev-dependencies")
-        .unwrap();
+    ])
+    .succeeds()
+    .and()
+    .stdout()
+    .is("Adding docopt v0.8.0 to dev-dependencies")
+    .unwrap();
 }
 
 #[test]
@@ -978,11 +985,12 @@ fn add_prints_message_for_build_deps() {
         "--vers",
         "0.1.0",
         &format!("--manifest-path={}", manifest),
-    ]).succeeds()
-        .and()
-        .stdout()
-        .is("Adding hello-world v0.1.0 to build-dependencies")
-        .unwrap();
+    ])
+    .succeeds()
+    .and()
+    .stdout()
+    .is("Adding hello-world v0.1.0 to build-dependencies")
+    .unwrap();
 }
 
 #[test]
@@ -995,12 +1003,13 @@ fn add_typo() {
         "add",
         "lets_hope_nobody_ever_publishes_this_crate",
         &format!("--manifest-path={}", manifest),
-    ]).fails_with(1)
-        .and()
-        .stderr()
-        .contains(
-            "The crate `lets_hope_nobody_ever_publishes_this_crate` could not be found \
-             on crates.io.",
-        )
-        .unwrap();
+    ])
+    .fails_with(1)
+    .and()
+    .stderr()
+    .contains(
+        "The crate `lets_hope_nobody_ever_publishes_this_crate` could not be found \
+         on crates.io.",
+    )
+    .unwrap();
 }

--- a/tests/cargo-add.rs
+++ b/tests/cargo-add.rs
@@ -5,7 +5,7 @@ extern crate toml_edit;
 
 use std::process;
 mod utils;
-use utils::{clone_out_test, execute_command, get_toml};
+use crate::utils::{clone_out_test, execute_command, get_toml};
 
 /// Some of the tests need to have a crate name that does not exist on crates.io. Hence this rather
 /// silly constant. Tests _will_ fail, though, if a crate is ever published with this name.

--- a/tests/cargo-rm.rs
+++ b/tests/cargo-rm.rs
@@ -1,5 +1,3 @@
-extern crate assert_cli;
-
 mod utils;
 use crate::utils::{clone_out_test, execute_command, get_toml};
 

--- a/tests/cargo-rm.rs
+++ b/tests/cargo-rm.rs
@@ -1,7 +1,7 @@
 extern crate assert_cli;
 
 mod utils;
-use utils::{clone_out_test, execute_command, get_toml};
+use crate::utils::{clone_out_test, execute_command, get_toml};
 
 #[test]
 fn remove_existing_dependency() {

--- a/tests/cargo-upgrade.rs
+++ b/tests/cargo-upgrade.rs
@@ -33,7 +33,8 @@ pub fn copy_workspace_test() -> (tempdir::TempDir, String, Vec<String>) {
             fs::copy(
                 format!("tests/fixtures/workspace/{}/{}", dir, file),
                 &file_path,
-            ).unwrap_or_else(|err| panic!("could not copy test file: {}", err));
+            )
+            .unwrap_or_else(|err| panic!("could not copy test file: {}", err));
 
             file_path
         };
@@ -233,14 +234,15 @@ fn detect_workspace() {
         "upgrade",
         "--manifest-path",
         &root_manifest,
-    ]).fails_with(1)
-        .and()
-        .stderr()
-        .is(
-            "Command failed due to unhandled error: Found virtual manifest, but this command \
-             requires running against an actual package in this workspace. Try adding `--all`.",
-        )
-        .unwrap();
+    ])
+    .fails_with(1)
+    .and()
+    .stderr()
+    .is(
+        "Command failed due to unhandled error: Found virtual manifest, but this command \
+         requires running against an actual package in this workspace. Try adding `--all`.",
+    )
+    .unwrap();
 }
 
 #[test]
@@ -252,11 +254,12 @@ fn invalid_manifest() {
         "upgrade",
         "--manifest-path",
         &manifest,
-    ]).fails_with(1)
-        .and()
-        .stderr()
-        .is(
-            "Command failed due to unhandled error: Unable to parse Cargo.toml
+    ])
+    .fails_with(1)
+    .and()
+    .stderr()
+    .is(
+        "Command failed due to unhandled error: Unable to parse Cargo.toml
 
 Caused by: Manifest not valid TOML
 Caused by: TOML parse error at line 1, column 6
@@ -265,8 +268,8 @@ Caused by: TOML parse error at line 1, column 6
   |      ^
 Unexpected `i`
 Expected `=`",
-        )
-        .unwrap();
+    )
+    .unwrap();
 }
 
 #[test]
@@ -279,11 +282,12 @@ fn invalid_root_manifest() {
         "--all",
         "--manifest-path",
         &manifest,
-    ]).fails_with(1)
-        .and()
-        .stderr()
-        .contains("Command failed due to unhandled error: Failed to get workspace metadata")
-        .unwrap();
+    ])
+    .fails_with(1)
+    .and()
+    .stderr()
+    .contains("Command failed due to unhandled error: Failed to get workspace metadata")
+    .unwrap();
 }
 
 #[test]
@@ -310,9 +314,10 @@ fn upgrade_prints_messages() {
         "upgrade",
         "docopt",
         &format!("--manifest-path={}", manifest),
-    ]).succeeds()
-        .and()
-        .stdout()
-        .contains("docopt v0.8 -> v")
-        .unwrap();
+    ])
+    .succeeds()
+    .and()
+    .stdout()
+    .contains("docopt v0.8 -> v")
+    .unwrap();
 }

--- a/tests/cargo-upgrade.rs
+++ b/tests/cargo-upgrade.rs
@@ -7,7 +7,7 @@ extern crate toml_edit;
 use std::fs;
 
 mod utils;
-use utils::{clone_out_test, execute_command, get_toml};
+use crate::utils::{clone_out_test, execute_command, get_toml};
 
 /// Helper function that copies the workspace test into a temporary directory.
 pub fn copy_workspace_test() -> (tempdir::TempDir, String, Vec<String>) {

--- a/tests/cargo-upgrade.rs
+++ b/tests/cargo-upgrade.rs
@@ -1,8 +1,5 @@
-extern crate assert_cli;
 #[macro_use]
 extern crate pretty_assertions;
-extern crate tempdir;
-extern crate toml_edit;
 
 use std::fs;
 

--- a/tests/test_manifest.rs
+++ b/tests/test_manifest.rs
@@ -1,5 +1,3 @@
-extern crate assert_cli;
-
 #[test]
 fn invalid_manifest() {
     assert_cli::Assert::command(&[

--- a/tests/test_manifest.rs
+++ b/tests/test_manifest.rs
@@ -7,11 +7,12 @@ fn invalid_manifest() {
         "add",
         "foo",
         "--manifest-path=tests/fixtures/manifest-invalid/Cargo.toml.sample",
-    ]).fails_with(1)
-        .and()
-        .stderr()
-        .is(
-            r#"Command failed due to unhandled error: Unable to parse Cargo.toml
+    ])
+    .fails_with(1)
+    .and()
+    .stderr()
+    .is(
+        r#"Command failed due to unhandled error: Unable to parse Cargo.toml
 
 Caused by: Manifest not valid TOML
 Caused by: TOML parse error at line 6, column 7
@@ -26,6 +27,6 @@ While parsing a Time
 While parsing a Date-Time
 While parsing a Float
 While parsing an Integer"#,
-        )
-        .unwrap();
+    )
+    .unwrap();
 }

--- a/tests/utils.rs
+++ b/tests/utils.rs
@@ -1,6 +1,3 @@
-extern crate tempdir;
-extern crate toml_edit;
-
 use std::ffi::OsStr;
 use std::io::prelude::*;
 use std::{fs, process};


### PR DESCRIPTION
There was function `get_with_timeout`, re-create a client each time this function is called, and "timeout" always 'default', I merged these two functions and reuse reqwest::Client to reuse TCP connection.

Other mirror change:

+ move to 2018 edition
+ work with rustfmt

Recommended review way: commit by commit.