### PR TITLE
[upgrade] `all` doens't conflict with `dependency`

### DIFF
--- a/src/bin/upgrade/main.rs
+++ b/src/bin/upgrade/main.rs
@@ -56,7 +56,6 @@ be supplied in the presence of a virtual manifest."
 #[derive(Debug, StructOpt)]
 struct Args {
     /// Crates to be upgraded.
-    #[structopt(conflicts_with = "all")]
     dependency: Vec<String>,
 
     /// Path to the manifest to upgrade


### PR DESCRIPTION
Follow up to #295.