### PR TITLE
[Cargo.toml] bump version to 0.3.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -123,7 +123,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-edit"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "assert_cli 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "atty 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ license = "Apache-2.0/MIT"
 name = "cargo-edit"
 readme = "README.md"
 repository = "https://github.com/killercup/cargo-edit"
-version = "0.3.1"
+version = "0.3.2"
 edition = "2018"
 
 [[bin]]


### PR DESCRIPTION
https://github.com/killercup/cargo-edit/releases/tag/v0.3.2