### PR TITLE
upgrade cargo_metadata to 0.8.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -127,9 +127,10 @@ version = "0.3.2"
 dependencies = [
  "assert_cli 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "atty 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "cargo_metadata 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cargo_metadata 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_proxy 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "error-chain 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "pretty_assertions 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "reqwest 0.9.17 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -145,10 +146,10 @@ dependencies = [
 
 [[package]]
 name = "cargo_metadata"
-version = "0.6.4"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "error-chain 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.92 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.92 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1713,7 +1714,7 @@ dependencies = [
 "checksum build_const 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "39092a32794787acd8525ee150305ff051b0aa6cc2abaf193924f5ab05425f39"
 "checksum byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a019b10a2a7cdeb292db131fc8113e57ea2a908f6e7894b0c3c671893b65dbeb"
 "checksum bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)" = "206fdffcfa2df7cbe15601ef46c813fce0965eb3286db6b56c583b814b51c81c"
-"checksum cargo_metadata 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)" = "e5d1b4d380e1bab994591a24c2bdd1b054f64b60bef483a8c598c7c345bc3bbe"
+"checksum cargo_metadata 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "929766d993a2fde7a0ae962ee82429069cd7b68839cd9375b98efd719df65d3a"
 "checksum cc 1.0.37 (registry+https://github.com/rust-lang/crates.io-index)" = "39f75544d7bbaf57560d2168f28fd649ff9c76153874db88bdbdfd839b1a7e7d"
 "checksum cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "b486ce3ccf7ffd79fdeb678eac06a9e6c09fc88d33836340becb8fffe87c5e33"
 "checksum cgmath 0.16.1 (registry+https://github.com/rust-lang/crates.io-index)" = "64a4b57c8f4e3a2e9ac07e0f6abc9c24b6fc9e1b54c3478cfb598f3d0023e51c"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,9 +50,10 @@ repository = "killercup/cargo-edit"
 repository = "killercup/cargo-edit"
 
 [dependencies]
-cargo_metadata = "0.6.4"
+cargo_metadata = "0.8.0"
 env_proxy = "0.3.1"
 error-chain = "0.12.1"
+failure = "0.1.5"
 regex = "1.1.6"
 reqwest = "0.9.17"
 serde = "1.0.91"

--- a/src/bin/upgrade/main.rs
+++ b/src/bin/upgrade/main.rs
@@ -91,7 +91,7 @@ impl Manifests {
         }
         let result = cmd
             .exec()
-            .map_err(|e| Error::from(e.compat()).chain_err(|| "Invalid manifest"))?;
+            .map_err(|e| Error::from(e.compat()).chain_err(|| "Failed to get workspace metadata"))?;
         result
             .packages
             .into_iter()

--- a/src/bin/upgrade/main.rs
+++ b/src/bin/upgrade/main.rs
@@ -85,6 +85,7 @@ impl Manifests {
     /// Get all manifests in the workspace.
     fn get_all(manifest_path: &Option<PathBuf>) -> Result<Self> {
         let mut cmd = cargo_metadata::MetadataCommand::new();
+        cmd.no_deps();
         if let Some(path) = manifest_path {
             cmd.manifest_path(path);
         }
@@ -114,6 +115,7 @@ impl Manifests {
         let manifest = LocalManifest::find(&manifest_path)?;
 
         let mut cmd = cargo_metadata::MetadataCommand::new();
+        cmd.no_deps();
         if let Some(path) = manifest_path {
             cmd.manifest_path(path);
         }

--- a/src/bin/upgrade/main.rs
+++ b/src/bin/upgrade/main.rs
@@ -89,12 +89,10 @@ impl Manifests {
         if let Some(path) = manifest_path {
             cmd.manifest_path(path);
         }
-        let result = cmd.exec();
-        if let Err(e) = result {
-            return Err(Error::from(e.compat()).chain_err(|| "Failed to get workspace metadata"));
-        }
+        let result = cmd
+            .exec()
+            .map_err(|e| Error::from(e.compat()).chain_err(|| "Invalid manifest"))?;
         result
-            .unwrap()
             .packages
             .into_iter()
             .map(|package| {
@@ -119,11 +117,10 @@ impl Manifests {
         if let Some(path) = manifest_path {
             cmd.manifest_path(path);
         }
-        let result = cmd.exec();
-        if let Err(e) = result {
-            return Err(Error::from(e.compat()).chain_err(|| "Invalid manifest"));
-        }
-        let packages = result.unwrap().packages;
+        let result = cmd
+            .exec()
+            .map_err(|e| Error::from(e.compat()).chain_err(|| "Invalid manifest"))?;
+        let packages = result.packages;
         let package = packages
             .iter()
             .find(|p| p.manifest_path.to_string_lossy() == resolved_manifest_path)

--- a/src/bin/upgrade/main.rs
+++ b/src/bin/upgrade/main.rs
@@ -16,6 +16,7 @@ extern crate error_chain;
 
 use crate::errors::*;
 use cargo_edit::{find, get_latest_dependency, CrateName, Dependency, LocalManifest};
+use failure::Fail;
 use std::collections::HashMap;
 use std::io::Write;
 use std::path::{Path, PathBuf};
@@ -27,7 +28,9 @@ mod errors {
     error_chain! {
         links {
             CargoEditLib(::cargo_edit::Error, ::cargo_edit::ErrorKind);
-            CargoMetadata(::cargo_metadata::Error, ::cargo_metadata::ErrorKind);
+        }
+        foreign_links {
+            CargoMetadata(::failure::Compat<::cargo_metadata::Error>);
         }
     }
 }
@@ -81,8 +84,16 @@ struct Manifests(Vec<(LocalManifest, cargo_metadata::Package)>);
 impl Manifests {
     /// Get all manifests in the workspace.
     fn get_all(manifest_path: &Option<PathBuf>) -> Result<Self> {
-        cargo_metadata::metadata(manifest_path.as_ref().map(Path::new))
-            .chain_err(|| "Failed to get workspace metadata")?
+        let mut cmd = cargo_metadata::MetadataCommand::new();
+        if let Some(path) = manifest_path {
+            cmd.manifest_path(path);
+        }
+        let result = cmd.exec();
+        if let Err(e) = result {
+            return Err(Error::from(e.compat()).chain_err(|| "Failed to get workspace metadata"));
+        }
+        result
+            .unwrap()
             .packages
             .into_iter()
             .map(|package| {
@@ -102,12 +113,18 @@ impl Manifests {
 
         let manifest = LocalManifest::find(&manifest_path)?;
 
-        let packages = cargo_metadata::metadata(manifest_path.as_ref().map(Path::new))
-            .chain_err(|| "Invalid manifest")?
-            .packages;
+        let mut cmd = cargo_metadata::MetadataCommand::new();
+        if let Some(path) = manifest_path {
+            cmd.manifest_path(path);
+        }
+        let result = cmd.exec();
+        if let Err(e) = result {
+            return Err(Error::from(e.compat()).chain_err(|| "Invalid manifest"));
+        }
+        let packages = result.unwrap().packages;
         let package = packages
             .iter()
-            .find(|p| p.manifest_path == resolved_manifest_path)
+            .find(|p| p.manifest_path.to_string_lossy() == resolved_manifest_path)
             // If we have successfully got metadata, but our manifest path does not correspond to a
             // package, we must have been called against a virtual manifest.
             .chain_err(|| {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,6 +17,8 @@ extern crate error_chain;
 #[macro_use]
 extern crate serde_derive;
 
+extern crate failure;
+
 mod crate_name;
 mod dependency;
 mod errors;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,8 +17,6 @@ extern crate error_chain;
 #[macro_use]
 extern crate serde_derive;
 
-extern crate failure;
-
 mod crate_name;
 mod dependency;
 mod errors;


### PR DESCRIPTION
resolve #307

Updated cargo_metadata from 0.6 to 0.8.

The major changes from the update are:

1. Since the error management crate was changed from error-chain to failure, the error handling point was corrected.
2. Metadata acquisition processing was changed from metadata function to MetadataCommand :: exec.