### PR TITLE
Use toml_edit's to_string_in_original_order()

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -141,7 +141,7 @@ dependencies = [
  "structopt 0.2.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempdir 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "termcolor 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "toml_edit 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "toml_edit 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1497,7 +1497,7 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1863,7 +1863,7 @@ dependencies = [
 "checksum tokio-threadpool 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)" = "72558af20be886ea124595ea0f806dd5703b8958e4705429dd58b3d8231f72f2"
 "checksum tokio-timer 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "f2106812d500ed25a4f38235b9cae8f78a09edf43203e16e59c3b769a342a60e"
 "checksum tokio-trace-core 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a9c8a256d6956f7cb5e2bdfe8b1e8022f1a09206c6c2b1ba00f3b746b260c613"
-"checksum toml_edit 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "49f417ffef0480dcd2db983b67b4d07c49147da72b4c3b65db0348f5cfccb929"
+"checksum toml_edit 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "c1f834d9d6a654ddfbfbe9445d321b524063cfa7182a7f375cc1310df430f540"
 "checksum try-lock 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e604eb7b43c06650e854be16a2a03155743d3752dd1c943f6829e26b7a36e382"
 "checksum try_from 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "283d3b89e1368717881a9d51dad843cc435380d8109c9e47d38780a324698d8b"
 "checksum ucd-util 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "535c204ee4d8434478593480b8f86ab45ec9aae0e83c568ca81abf0fd0e88f86"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,7 +60,7 @@ serde = "1.0.91"
 serde_derive = "1.0.91"
 serde_json = "1.0.39"
 termcolor = "1.0.4"
-toml_edit = "0.1.3"
+toml_edit = "0.1.4"
 atty = "0.2.11"
 structopt = "0.2.15"
 

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -237,7 +237,7 @@ impl Manifest {
             }
         }
 
-        let s = self.data.to_string();
+        let s = self.data.to_string_in_original_order();
         let new_contents_bytes = s.as_bytes();
 
         // We need to truncate the file, otherwise the new contents


### PR DESCRIPTION
uses toml_edit from this PR: https://github.com/ordian/toml_edit/pull/63

solves https://github.com/killercup/cargo-edit/issues/218 pretty convincingly 

previously it was:
> 1457 (2%) also did something else (mostly moving sections of the file around, but ~10 also made whitespace changes, like removing spaces from section headers)

Now it is:
> 13 (0.02%) also did something else (mostly removing whitespace from section headers but a handful also fixed unix/windows line endings that I failed to clean up properly before starting).