### PR TITLE
Flag one more test as requiring external APIs

### DIFF
--- a/tests/cargo-upgrade.rs
+++ b/tests/cargo-upgrade.rs
@@ -305,6 +305,7 @@ For more information try --help ",
 }
 
 #[test]
+#[cfg(feature = "test-external-apis")]
 fn upgrade_prints_messages() {
     let (_tmpdir, manifest) = clone_out_test("tests/fixtures/upgrade/Cargo.toml.source");
 


### PR DESCRIPTION
Flag one more test as requiring external APIs 