### PR TITLE
Abstract over finding binaries in tests

### DIFF
--- a/tests/cargo-add.rs
+++ b/tests/cargo-add.rs
@@ -3,7 +3,9 @@ extern crate pretty_assertions;
 
 use std::process;
 mod utils;
-use crate::utils::{clone_out_test, execute_bad_command, execute_command, get_toml};
+use crate::utils::{
+    clone_out_test, execute_bad_command, execute_command, get_command_path, get_toml,
+};
 
 /// Some of the tests need to have a crate name that does not exist on crates.io. Hence this rather
 /// silly constant. Tests _will_ fail, though, if a crate is ever published with this name.
@@ -169,7 +171,7 @@ fn adds_dev_build_dependency() {
     );
 
     // cannot run with both --dev and --build at the same time
-    let call = process::Command::new("target/debug/cargo-add")
+    let call = process::Command::new(get_command_path("add").as_str())
         .args(&["add", BOGUS_CRATE_NAME, "--dev", "--build"])
         .arg(format!("--manifest-path={}", &manifest))
         .output()
@@ -242,7 +244,7 @@ fn adds_specified_version() {
     assert_eq!(val.as_str().expect("not string"), ">=0.1.1");
 
     // cannot run with both --dev and --build at the same time
-    let call = process::Command::new("target/debug/cargo-add")
+    let call = process::Command::new(get_command_path("add").as_str())
         .args(&["add", BOGUS_CRATE_NAME, "--vers", "invalid version string"])
         .arg(format!("--manifest-path={}", &manifest))
         .output()
@@ -502,7 +504,14 @@ fn adds_local_source_with_version_flag_and_semver_metadata() {
     assert!(toml["dependencies"].is_none());
 
     execute_command(
-        &["add", "local", "--vers", "0.4.3+useless-metadata.1.0.0", "--path", "/path/to/pkg"],
+        &[
+            "add",
+            "local",
+            "--vers",
+            "0.4.3+useless-metadata.1.0.0",
+            "--path",
+            "/path/to/pkg",
+        ],
         &manifest,
     );
 
@@ -574,7 +583,7 @@ fn adds_local_source_with_inline_version_notation() {
 fn git_and_version_flags_are_mutually_exclusive() {
     let (_tmpdir, manifest) = clone_out_test("tests/fixtures/add/Cargo.toml.sample");
 
-    let call = process::Command::new("target/debug/cargo-add")
+    let call = process::Command::new(get_command_path("add").as_str())
         .args(&["add", BOGUS_CRATE_NAME])
         .args(&["--vers", "0.4.3"])
         .args(&["--git", "git://git.git"])
@@ -590,7 +599,7 @@ fn git_and_version_flags_are_mutually_exclusive() {
 fn git_flag_and_inline_version_are_mutually_exclusive() {
     let (_tmpdir, manifest) = clone_out_test("tests/fixtures/add/Cargo.toml.sample");
 
-    let call = process::Command::new("target/debug/cargo-add")
+    let call = process::Command::new(get_command_path("add").as_str())
         .args(&["add", &format!("{}@0.4.3", BOGUS_CRATE_NAME)])
         .args(&["--git", "git://git.git"])
         .arg(format!("--manifest-path={}", &manifest))
@@ -605,7 +614,7 @@ fn git_flag_and_inline_version_are_mutually_exclusive() {
 fn git_and_path_are_mutually_exclusive() {
     let (_tmpdir, manifest) = clone_out_test("tests/fixtures/add/Cargo.toml.sample");
 
-    let call = process::Command::new("target/debug/cargo-add")
+    let call = process::Command::new(get_command_path("add").as_str())
         .args(&["add", BOGUS_CRATE_NAME])
         .args(&["--git", "git://git.git"])
         .args(&["--path", "/path/here"])
@@ -776,7 +785,7 @@ fn adds_dependency_normalized_name() {
     assert!(toml["dependencies"].is_none());
 
     assert_cli::Assert::command(&[
-        "target/debug/cargo-add",
+        get_command_path("add").as_str(),
         "add",
         "linked_hash_map",
         &format!("--manifest-path={}", manifest),
@@ -954,7 +963,7 @@ versioned-package = "versioned-package--CURRENT_VERSION_TEST"
 
 #[test]
 fn no_argument() {
-    assert_cli::Assert::command(&["target/debug/cargo-add", "add"])
+    assert_cli::Assert::command(&[get_command_path("add").as_str(), "add"])
         .fails_with(1)
         .and()
         .stderr()
@@ -970,7 +979,7 @@ For more information try --help")
 
 #[test]
 fn unknown_flags() {
-    assert_cli::Assert::command(&["target/debug/cargo-add", "add", "foo", "--flag"])
+    assert_cli::Assert::command(&[get_command_path("add").as_str(), "add", "foo", "--flag"])
         .fails_with(1)
         .and()
         .stderr()
@@ -990,7 +999,7 @@ fn add_prints_message() {
     let (_tmpdir, manifest) = clone_out_test("tests/fixtures/add/Cargo.toml.sample");
 
     assert_cli::Assert::command(&[
-        "target/debug/cargo-add",
+        get_command_path("add").as_str(),
         "add",
         "docopt",
         "--vers=0.6.0",
@@ -1008,7 +1017,7 @@ fn add_prints_message_with_section() {
     let (_tmpdir, manifest) = clone_out_test("tests/fixtures/add/Cargo.toml.sample");
 
     assert_cli::Assert::command(&[
-        "target/debug/cargo-add",
+        get_command_path("add").as_str(),
         "add",
         "clap",
         "--optional",
@@ -1028,7 +1037,7 @@ fn add_prints_message_for_dev_deps() {
     let (_tmpdir, manifest) = clone_out_test("tests/fixtures/add/Cargo.toml.sample");
 
     assert_cli::Assert::command(&[
-        "target/debug/cargo-add",
+        get_command_path("add").as_str(),
         "add",
         "docopt",
         "--dev",
@@ -1048,7 +1057,7 @@ fn add_prints_message_for_build_deps() {
     let (_tmpdir, manifest) = clone_out_test("tests/fixtures/add/Cargo.toml.sample");
 
     assert_cli::Assert::command(&[
-        "target/debug/cargo-add",
+        get_command_path("add").as_str(),
         "add",
         "hello-world",
         "--build",
@@ -1069,7 +1078,7 @@ fn add_typo() {
     let (_tmpdir, manifest) = clone_out_test("tests/fixtures/add/Cargo.toml.sample");
 
     assert_cli::Assert::command(&[
-        "target/debug/cargo-add",
+        get_command_path("add").as_str(),
         "add",
         "lets_hope_nobody_ever_publishes_this_crate",
         &format!("--manifest-path={}", manifest),

--- a/tests/cargo-rm.rs
+++ b/tests/cargo-rm.rs
@@ -1,5 +1,5 @@
 mod utils;
-use crate::utils::{clone_out_test, execute_command, get_toml};
+use crate::utils::{clone_out_test, execute_command, get_command_path, get_toml};
 
 #[test]
 fn remove_existing_dependency() {
@@ -99,7 +99,7 @@ fn invalid_dependency() {
     let (_tmpdir, manifest) = clone_out_test("tests/fixtures/rm/Cargo.toml.sample");
 
     assert_cli::Assert::command(&[
-        "target/debug/cargo-rm",
+        get_command_path("rm").as_str(),
         "rm",
         "invalid_dependency_name",
         &format!("--manifest-path={}", manifest),
@@ -120,7 +120,7 @@ fn invalid_section() {
 
     execute_command(&["rm", "semver", "--build"], &manifest);
     assert_cli::Assert::command(&[
-        "target/debug/cargo-rm",
+        get_command_path("rm").as_str(),
         "rm",
         "semver",
         "--build",
@@ -141,7 +141,7 @@ fn invalid_dependency_in_section() {
     let (_tmpdir, manifest) = clone_out_test("tests/fixtures/rm/Cargo.toml.sample");
 
     assert_cli::Assert::command(&[
-        "target/debug/cargo-rm",
+        get_command_path("rm").as_str(),
         "rm",
         "semver",
         "regex",
@@ -160,7 +160,7 @@ fn invalid_dependency_in_section() {
 
 #[test]
 fn no_argument() {
-    assert_cli::Assert::command(&["target/debug/cargo-rm", "rm"])
+    assert_cli::Assert::command(&[get_command_path("rm").as_str(), "rm"])
         .fails_with(1)
         .and()
         .stderr()
@@ -176,7 +176,7 @@ For more information try --help")
 
 #[test]
 fn unknown_flags() {
-    assert_cli::Assert::command(&["target/debug/cargo-rm", "rm", "foo", "--flag"])
+    assert_cli::Assert::command(&[get_command_path("rm").as_str(), "rm", "foo", "--flag"])
         .fails_with(1)
         .and()
         .stderr()
@@ -196,7 +196,7 @@ fn rm_prints_message() {
     let (_tmpdir, manifest) = clone_out_test("tests/fixtures/rm/Cargo.toml.sample");
 
     assert_cli::Assert::command(&[
-        "target/debug/cargo-rm",
+        get_command_path("rm").as_str(),
         "rm",
         "semver",
         &format!("--manifest-path={}", manifest),
@@ -213,7 +213,7 @@ fn rm_prints_messages_for_multiple() {
     let (_tmpdir, manifest) = clone_out_test("tests/fixtures/rm/Cargo.toml.sample");
 
     assert_cli::Assert::command(&[
-        "target/debug/cargo-rm",
+        get_command_path("rm").as_str(),
         "rm",
         "semver",
         "docopt",

--- a/tests/cargo-upgrade.rs
+++ b/tests/cargo-upgrade.rs
@@ -4,7 +4,7 @@ extern crate pretty_assertions;
 use std::fs;
 
 mod utils;
-use crate::utils::{clone_out_test, execute_command, get_toml};
+use crate::utils::{clone_out_test, execute_command, get_command_path, get_toml};
 
 /// Helper function that copies the workspace test into a temporary directory.
 pub fn copy_workspace_test() -> (tempdir::TempDir, String, Vec<String>) {
@@ -227,7 +227,7 @@ fn detect_workspace() {
     let (_tmpdir, root_manifest, _workspace_manifests) = copy_workspace_test();
 
     assert_cli::Assert::command(&[
-        "target/debug/cargo-upgrade",
+        get_command_path("upgrade").as_str(),
         "upgrade",
         "--manifest-path",
         &root_manifest,
@@ -247,7 +247,7 @@ fn invalid_manifest() {
     let (_tmpdir, manifest) = clone_out_test("tests/fixtures/upgrade/Cargo.toml.invalid");
 
     assert_cli::Assert::command(&[
-        "target/debug/cargo-upgrade",
+        get_command_path("upgrade").as_str(),
         "upgrade",
         "--manifest-path",
         &manifest,
@@ -274,7 +274,7 @@ fn invalid_root_manifest() {
     let (_tmpdir, manifest) = clone_out_test("tests/fixtures/upgrade/Cargo.toml.invalid");
 
     assert_cli::Assert::command(&[
-        "target/debug/cargo-upgrade",
+        get_command_path("upgrade").as_str(),
         "upgrade",
         "--all",
         "--manifest-path",
@@ -289,19 +289,24 @@ fn invalid_root_manifest() {
 
 #[test]
 fn unknown_flags() {
-    assert_cli::Assert::command(&["target/debug/cargo-upgrade", "upgrade", "foo", "--flag"])
-        .fails_with(1)
-        .and()
-        .stderr()
-        .is(
-            "error: Found argument '--flag' which wasn't expected, or isn't valid in this context
+    assert_cli::Assert::command(&[
+        get_command_path("upgrade").as_str(),
+        "upgrade",
+        "foo",
+        "--flag",
+    ])
+    .fails_with(1)
+    .and()
+    .stderr()
+    .is(
+        "error: Found argument '--flag' which wasn't expected, or isn't valid in this context
 
 USAGE:
     cargo upgrade [FLAGS] [OPTIONS] [dependency]...
 
 For more information try --help ",
-        )
-        .unwrap();
+    )
+    .unwrap();
 }
 
 #[test]
@@ -309,7 +314,7 @@ fn upgrade_prints_messages() {
     let (_tmpdir, manifest) = clone_out_test("tests/fixtures/upgrade/Cargo.toml.source");
 
     assert_cli::Assert::command(&[
-        "target/debug/cargo-upgrade",
+        get_command_path("upgrade").as_str(),
         "upgrade",
         "docopt",
         &format!("--manifest-path={}", manifest),

--- a/tests/test_manifest.rs
+++ b/tests/test_manifest.rs
@@ -1,7 +1,10 @@
+mod utils;
+use crate::utils::get_command_path;
+
 #[test]
 fn invalid_manifest() {
     assert_cli::Assert::command(&[
-        "target/debug/cargo-add",
+        get_command_path("add").as_str(),
         "add",
         "foo",
         "--manifest-path=tests/fixtures/manifest-invalid/Cargo.toml.sample",


### PR DESCRIPTION
I set `CARGO_TARGET_DIR` locally (as well as on newer CI setups) so this
was required to make tests pass for me.