### PR TITLE
tests: slash is not valid

### DIFF
--- a/tests/cargo-add.rs
+++ b/tests/cargo-add.rs
@@ -891,14 +891,14 @@ fn adds_dependency_with_custom_target() {
     let (_tmpdir, manifest) = clone_out_test("tests/fixtures/add/Cargo.toml.sample");
 
     execute_command(
-        &["add", "--target", "x86_64/windows.json", "my-package1"],
+        &["add", "--target", "windows.json", "my-package1"],
         &manifest,
     );
 
     // dependencies present afterwards
     let toml = get_toml(&manifest);
     // Get package by hand because toml-rs does not currently handle escaping dots in get()
-    let val = &toml["target"]["x86_64/windows.json"]["dependencies"]["my-package1"];
+    let val = &toml["target"]["windows.json"]["dependencies"]["my-package1"];
     assert_eq!(val.as_str(), Some("my-package1--CURRENT_VERSION_TEST"));
 }
 

--- a/tests/fixtures/upgrade/Cargo.toml.source
+++ b/tests/fixtures/upgrade/Cargo.toml.source
@@ -32,7 +32,7 @@ serde = { version = "1.0", git= "https://github.com/serde-rs/serde.git" }
 [target.'cfg(unix)'.dependencies]
 openssl = "0.9"
 
-[target."x86_64/windows.json"]
+[target."windows.json"]
 # let's make it an inline table
 dependencies = { rget = "0.3.0" }
 

--- a/tests/fixtures/upgrade/Cargo.toml.target
+++ b/tests/fixtures/upgrade/Cargo.toml.target
@@ -32,7 +32,7 @@ serde = { version = "1.0", git= "https://github.com/serde-rs/serde.git" }
 [target.'cfg(unix)'.dependencies]
 openssl = "openssl--CURRENT_VERSION_TEST"
 
-[target."x86_64/windows.json"]
+[target."windows.json"]
 # let's make it an inline table
 dependencies = { rget = "rget--CURRENT_VERSION_TEST" }
 


### PR DESCRIPTION
This was a documentation bug https://github.com/rust-lang/cargo/issues/7613#issuecomment-557150300.

Fixes CI failures on beta and nightly channels.