### PR TITLE
[Merged by Bors] - feat: --skip-compatible to avoid churn

### DIFF
--- a/src/bin/upgrade/main.rs
+++ b/src/bin/upgrade/main.rs
@@ -87,7 +87,7 @@ struct Args {
     dry_run: bool,
 
     /// Only update a dependency if the new version is semver incompatible.
-    #[structopt(long = "skip-compatible")]
+    #[structopt(long = "skip-compatible", conflicts_with = "to_lockfile")]
     skip_compatible: bool,
 
     /// Run without accessing the network

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -69,5 +69,10 @@ error_chain! {
         NoSuchRegistryFound(name: String) {
             display("The registry '{}' could not be found", name)
         }
+        /// Failed to parse a version for a dependency
+        ParseVersion(version: String, dep: String) {
+            description("Failed to parse a version for a dependency")
+            display("The version `{}` for the dependency `{}` couldn't be parsed", version, dep)
+        }
     }
 }

--- a/src/fetch.rs
+++ b/src/fetch.rs
@@ -42,12 +42,10 @@ pub fn get_latest_dependency(
         let new_version = if flag_allow_prerelease {
             format!("{}--PRERELEASE_VERSION_TEST", crate_name)
         } else {
-            if crate_name == "test_breaking" {
-                "0.2.0".to_string()
-            } else if crate_name == "test_nonbreaking" {
-                "0.1.1".to_string()
-            } else {
-                format!("{}--CURRENT_VERSION_TEST", crate_name)
+            match crate_name {
+                "test_breaking" => "0.2.0".to_string(),
+                "test_nonbreaking" => "0.1.1".to_string(),
+                other => format!("{}--CURRENT_VERSION_TEST", other),
             }
         };
 

--- a/src/fetch.rs
+++ b/src/fetch.rs
@@ -42,7 +42,13 @@ pub fn get_latest_dependency(
         let new_version = if flag_allow_prerelease {
             format!("{}--PRERELEASE_VERSION_TEST", crate_name)
         } else {
-            format!("{}--CURRENT_VERSION_TEST", crate_name)
+            if crate_name == "test_breaking" {
+                "0.2.0".to_string()
+            } else if crate_name == "test_nonbreaking" {
+                "0.1.1".to_string()
+            } else {
+                format!("{}--CURRENT_VERSION_TEST", crate_name)
+            }
         };
 
         return Ok(Dependency::new(crate_name).set_version(&new_version));

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -433,7 +433,7 @@ impl LocalManifest {
         &mut self,
         dependency: &Dependency,
         dry_run: bool,
-        only_breaking: bool,
+        skip_compatible: bool,
     ) -> Result<()> {
         for (table_path, table) in self.get_sections() {
             let table_like = table.as_table_like().expect("Unexpected non-table");
@@ -445,7 +445,7 @@ impl LocalManifest {
                 if dep_name == dependency.name {
                     let old_version = get_old_version(toml_item);
                     if let Some(old_version) = old_version {
-                        if only_breaking
+                        if skip_compatible
                             && VersionReq::parse(&old_version)
                                 .chain_err(|| ErrorKind::ParseVersion(name.into(), old_version))?
                                 .matches(

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -553,4 +553,29 @@ mod tests {
             .remove_from_table("dependencies", &dep.name)
             .is_err());
     }
+
+    #[test]
+    fn old_version_is_compatible() -> Result<()> {
+        let with_version = Dependency::new("foo").set_version("2.3.4");
+        assert!(!old_version_compatible(&with_version, "1")?);
+        assert!(old_version_compatible(&with_version, "2")?);
+        assert!(!old_version_compatible(&with_version, "3")?);
+        Ok(())
+    }
+
+    #[test]
+    fn old_incompatible_with_missing_new_version() -> Result<()> {
+        let no_version = Dependency::new("foo");
+        assert!(!old_version_compatible(&no_version, "1")?);
+        assert!(!old_version_compatible(&no_version, "2")?);
+        Ok(())
+    }
+
+    #[test]
+    fn old_incompatible_with_invalid() {
+        let bad_version = Dependency::new("foo").set_version("CAKE CAKE");
+        let good_version = Dependency::new("foo").set_version("1.2.3");
+        assert!(old_version_compatible(&bad_version, "1").is_err());
+        assert!(old_version_compatible(&good_version, "CAKE CAKE").is_err());
+    }
 }

--- a/tests/cargo-upgrade.rs
+++ b/tests/cargo-upgrade.rs
@@ -200,13 +200,13 @@ fn upgrade_specified_only() {
 }
 
 #[test]
-fn upgrade_major_only() {
+fn upgrade_skip_compatible() {
     let (_tmpdir, manifest) = clone_out_test("tests/fixtures/add/Cargo.toml.sample");
 
     execute_command(&["add", "test_breaking", "--vers", "0.1"], &manifest);
     execute_command(&["add", "test_nonbreaking", "--vers", "0.1"], &manifest);
 
-    execute_command(&["upgrade", "--major-only"], &manifest);
+    execute_command(&["upgrade", "--skip-compatible"], &manifest);
 
     // Verify that `docopt` was upgraded, but not `env_proxy`
     let dependencies = &get_toml(&manifest)["dependencies"];

--- a/tests/cargo-upgrade.rs
+++ b/tests/cargo-upgrade.rs
@@ -208,7 +208,7 @@ fn upgrade_skip_compatible() {
 
     execute_command(&["upgrade", "--skip-compatible"], &manifest);
 
-    // Verify that `docopt` was upgraded, but not `env_proxy`
+    // Verify that `test_breaking` was upgraded, but not `test_nonbreaking`
     let dependencies = &get_toml(&manifest)["dependencies"];
     assert_eq!(dependencies["test_breaking"].as_str(), Some("0.2.0"));
     assert_eq!(dependencies["test_nonbreaking"].as_str(), Some("0.1"));

--- a/tests/cargo-upgrade.rs
+++ b/tests/cargo-upgrade.rs
@@ -200,6 +200,21 @@ fn upgrade_specified_only() {
 }
 
 #[test]
+fn upgrade_major_only() {
+    let (_tmpdir, manifest) = clone_out_test("tests/fixtures/add/Cargo.toml.sample");
+
+    execute_command(&["add", "test_breaking", "--vers", "0.1"], &manifest);
+    execute_command(&["add", "test_nonbreaking", "--vers", "0.1"], &manifest);
+
+    execute_command(&["upgrade", "--major-only"], &manifest);
+
+    // Verify that `docopt` was upgraded, but not `env_proxy`
+    let dependencies = &get_toml(&manifest)["dependencies"];
+    assert_eq!(dependencies["test_breaking"].as_str(), Some("0.2.0"));
+    assert_eq!(dependencies["test_nonbreaking"].as_str(), Some("0.1"));
+}
+
+#[test]
 fn fails_to_upgrade_missing_dependency() {
     let (_tmpdir, manifest) = clone_out_test("tests/fixtures/add/Cargo.toml.sample");
 


### PR DESCRIPTION
This is a re-up of the abandoned #219 (a non-trivial merge) with the review comments addressed.

Original description:

Add a `--skip-compatible` flag to cargo upgrade

This flag will make `cargo upgrade` ignore upgrades where the old
version is semver compatible with the new one. This is useful in cases
where you don't want to churn the Cargo.toml files in the whole project
knowing that the lockfile is already forcing the versions to be up to
date.

To test that I had to cheat a little bit and hardcode two different fake
dependencies in `get_latest_dependency` which is unfortunate but
necessary as there's no way currently to mock answers from crates.io.
