### PR TITLE
[Merged by Bors] - Avoid updating registry index in tests by default

### DIFF
--- a/src/bin/add/main.rs
+++ b/src/bin/add/main.rs
@@ -87,7 +87,7 @@ fn handle_add(args: &Args) -> Result<()> {
     let mut manifest = Manifest::open(manifest_path)?;
     let deps = &args.parse_dependencies()?;
 
-    if !args.offline {
+    if !args.offline && std::env::var("CARGO_IS_TEST").is_err() {
         let url = registry_url(
             &find(&manifest_path)?,
             args.registry.as_ref().map(String::as_ref),

--- a/src/bin/upgrade/main.rs
+++ b/src/bin/upgrade/main.rs
@@ -409,7 +409,7 @@ fn process(args: Args) -> Result<()> {
         ..
     } = args;
 
-    if !args.offline && !to_lockfile {
+    if !args.offline && !to_lockfile && std::env::var("CARGO_IS_TEST").is_err() {
         let url = registry_url(&find(&manifest_path)?, None)?;
         update_registry_index(&url)?;
     }
@@ -427,7 +427,7 @@ fn process(args: Args) -> Result<()> {
 
         // Update indices for any alternative registries, unless
         // we're offline.
-        if !args.offline {
+        if !args.offline && std::env::var("CARGO_IS_TEST").is_err() {
             for registry_url in existing_dependencies
                 .0
                 .values()

--- a/tests/cargo-add.rs
+++ b/tests/cargo-add.rs
@@ -1184,6 +1184,7 @@ fn add_prints_message() {
         "--vers=0.6.0",
         &format!("--manifest-path={}", manifest),
     ])
+    .with_env(&[("CARGO_IS_TEST", "1")])
     .succeeds()
     .and()
     .stdout()
@@ -1204,6 +1205,7 @@ fn add_prints_message_with_section() {
         "--vers=0.1.0",
         &format!("--manifest-path={}", manifest),
     ])
+    .with_env(&[("CARGO_IS_TEST", "1")])
     .succeeds()
     .and()
     .stdout()
@@ -1224,6 +1226,7 @@ fn add_prints_message_for_dev_deps() {
         "0.8.0",
         &format!("--manifest-path={}", manifest),
     ])
+    .with_env(&[("CARGO_IS_TEST", "1")])
     .succeeds()
     .and()
     .stdout()
@@ -1244,6 +1247,7 @@ fn add_prints_message_for_build_deps() {
         "0.1.0",
         &format!("--manifest-path={}", manifest),
     ])
+    .with_env(&[("CARGO_IS_TEST", "1")])
     .succeeds()
     .and()
     .stdout()

--- a/tests/cargo-upgrade.rs
+++ b/tests/cargo-upgrade.rs
@@ -385,6 +385,7 @@ fn upgrade_workspace() {
 
 /// Detect if attempting to run against a workspace root and give a helpful warning.
 #[test]
+#[ignore]
 fn detect_workspace() {
     let (_tmpdir, root_manifest, _workspace_manifests) = copy_workspace_test();
 
@@ -414,6 +415,7 @@ fn invalid_manifest() {
         "--manifest-path",
         &manifest,
     ])
+    .with_env(&[("CARGO_IS_TEST", "1")])
     .fails_with(1)
     .and()
     .stderr()
@@ -442,6 +444,7 @@ fn invalid_root_manifest() {
         "--manifest-path",
         &manifest,
     ])
+    .with_env(&[("CARGO_IS_TEST", "1")])
     .fails_with(1)
     .and()
     .stderr()
@@ -457,6 +460,7 @@ fn unknown_flags() {
         "foo",
         "--flag",
     ])
+    .with_env(&[("CARGO_IS_TEST", "1")])
     .fails_with(1)
     .and()
     .stderr()
@@ -473,6 +477,7 @@ For more information try --help ",
 
 // Verify that an upgraded Cargo.toml matches what we expect.
 #[test]
+#[ignore]
 fn upgrade_to_lockfile() {
     let (tmpdir, manifest) = clone_out_test("tests/fixtures/upgrade/Cargo.toml.lockfile_source");
     fs::copy(
@@ -489,6 +494,7 @@ fn upgrade_to_lockfile() {
 }
 
 #[test]
+#[ignore]
 fn upgrade_workspace_to_lockfile() {
     let (tmpdir, root_manifest, _workspace_manifests) = copy_workspace_test();
 
@@ -516,6 +522,7 @@ fn upgrade_prints_messages() {
         "docopt",
         &format!("--manifest-path={}", manifest),
     ])
+    .with_env(&[("CARGO_IS_TEST", "1")])
     .succeeds()
     .and()
     .stdout()

--- a/tests/cargo-upgrade.rs
+++ b/tests/cargo-upgrade.rs
@@ -385,7 +385,7 @@ fn upgrade_workspace() {
 
 /// Detect if attempting to run against a workspace root and give a helpful warning.
 #[test]
-#[ignore]
+#[cfg(feature = "test-external-apis")]
 fn detect_workspace() {
     let (_tmpdir, root_manifest, _workspace_manifests) = copy_workspace_test();
 
@@ -477,7 +477,7 @@ For more information try --help ",
 
 // Verify that an upgraded Cargo.toml matches what we expect.
 #[test]
-#[ignore]
+#[cfg(feature = "test-external-apis")]
 fn upgrade_to_lockfile() {
     let (tmpdir, manifest) = clone_out_test("tests/fixtures/upgrade/Cargo.toml.lockfile_source");
     fs::copy(
@@ -494,7 +494,7 @@ fn upgrade_to_lockfile() {
 }
 
 #[test]
-#[ignore]
+#[cfg(feature = "test-external-apis")]
 fn upgrade_workspace_to_lockfile() {
     let (tmpdir, root_manifest, _workspace_manifests) = copy_workspace_test();
 
@@ -522,7 +522,6 @@ fn upgrade_prints_messages() {
         "docopt",
         &format!("--manifest-path={}", manifest),
     ])
-    .with_env(&[("CARGO_IS_TEST", "1")])
     .succeeds()
     .and()
     .stdout()


### PR DESCRIPTION
Currently, some tests fails on vendor-ed and locked registry, due to the requirement of updating it.

This PR makes environment variable `CARGO_IS_TEST` used in tests to behave as argument `--offline` to avoid network access.
Also, some tests invoking `cargo metadata`, which may fail on partial or outdated registry, are guarded under feature `test-external-apis`.
