### PR TITLE
Dependency support for git branches

### DIFF
--- a/src/bin/add/args.rs
+++ b/src/bin/add/args.rs
@@ -269,6 +269,7 @@ impl Default for Args {
             build: false,
             vers: None,
             git: None,
+            branch: None,
             path: None,
             target: None,
             optional: false,

--- a/src/bin/add/args.rs
+++ b/src/bin/add/args.rs
@@ -61,6 +61,15 @@ pub struct Args {
     )]
     pub git: Option<String>,
 
+    /// Specify a git branch to download the crate from.
+    #[structopt(
+        long = "branch",
+        value_name = "branch",
+        conflicts_with = "vers",
+        conflicts_with = "path"
+    )]
+    pub branch: Option<String>,
+
     /// Specify the path the crate should be loaded from.
     #[structopt(long = "path", conflicts_with = "git")]
     pub path: Option<PathBuf>,
@@ -169,7 +178,8 @@ impl Args {
             let mut dependency = Dependency::new(crate_name.name());
 
             if let Some(repo) = &self.git {
-                dependency = dependency.set_git(repo);
+                dependency = dependency.set_git(repo,
+                    self.branch.clone());
             }
             if let Some(path) = &self.path {
                 dependency = dependency.set_path(path.to_str().unwrap());
@@ -303,7 +313,7 @@ mod tests {
         };
         assert_eq!(
             args_github.parse_dependencies().unwrap(),
-            vec![Dependency::new("cargo-edit").set_git(github_url)]
+            vec![Dependency::new("cargo-edit").set_git(github_url, None)]
         );
 
         let gitlab_url = "https://gitlab.com/Polly-lang/Polly.git";
@@ -313,7 +323,7 @@ mod tests {
         };
         assert_eq!(
             args_gitlab.parse_dependencies().unwrap(),
-            vec![Dependency::new("polly").set_git(gitlab_url)]
+            vec![Dependency::new("polly").set_git(gitlab_url, None)]
         );
     }
 

--- a/src/bin/add/args.rs
+++ b/src/bin/add/args.rs
@@ -178,8 +178,7 @@ impl Args {
             let mut dependency = Dependency::new(crate_name.name());
 
             if let Some(repo) = &self.git {
-                dependency = dependency.set_git(repo,
-                    self.branch.clone());
+                dependency = dependency.set_git(repo, self.branch.clone());
             }
             if let Some(path) = &self.path {
                 dependency = dependency.set_path(path.to_str().unwrap());

--- a/src/crate_name.rs
+++ b/src/crate_name.rs
@@ -62,11 +62,11 @@ impl<'a> CrateName<'a> {
     pub fn parse_crate_name_from_uri(&self) -> Result<Dependency> {
         if self.is_github_url() {
             if let Ok(ref crate_name) = get_crate_name_from_github(self.0) {
-                return Ok(Dependency::new(crate_name).set_git(self.0));
+                return Ok(Dependency::new(crate_name).set_git(self.0, None));
             }
         } else if self.is_gitlab_url() {
             if let Ok(ref crate_name) = get_crate_name_from_gitlab(self.0) {
-                return Ok(Dependency::new(crate_name).set_git(self.0));
+                return Ok(Dependency::new(crate_name).set_git(self.0, None));
             }
         } else if self.is_path() {
             if let Ok(ref crate_name) = get_crate_name_from_path(self.0) {

--- a/src/dependency.rs
+++ b/src/dependency.rs
@@ -7,7 +7,10 @@ enum DependencySource {
         path: Option<String>,
         registry: Option<String>,
     },
-    Git { repo:String, branch:Option<String> }
+    Git {
+        repo: String,
+        branch: Option<String>,
+    },
 }
 
 /// A dependency handled by Cargo
@@ -68,8 +71,10 @@ impl Dependency {
 
     /// Set dependency to a given repository
     pub fn set_git(mut self, repo: &str, branch: Option<String>) -> Dependency {
-        self.source = DependencySource::Git
-            {repo: repo.into(), branch };
+        self.source = DependencySource::Git {
+            repo: repo.into(),
+            branch,
+        };
         self
     }
 
@@ -191,10 +196,9 @@ impl Dependency {
                             data.get_or_insert("registry", r);
                         }
                     }
-                    DependencySource::Git { repo, branch} => {
+                    DependencySource::Git { repo, branch } => {
                         data.get_or_insert("git", repo);
-                        branch.map(|branch|
-                            data.get_or_insert("branch", branch));
+                        branch.map(|branch| data.get_or_insert("branch", branch));
                     }
                 }
                 if self.optional {

--- a/src/dependency.rs
+++ b/src/dependency.rs
@@ -7,7 +7,7 @@ enum DependencySource {
         path: Option<String>,
         registry: Option<String>,
     },
-    Git(String),
+    Git { repo:String, branch:Option<String> }
 }
 
 /// A dependency handled by Cargo
@@ -67,8 +67,9 @@ impl Dependency {
     }
 
     /// Set dependency to a given repository
-    pub fn set_git(mut self, repo: &str) -> Dependency {
-        self.source = DependencySource::Git(repo.into());
+    pub fn set_git(mut self, repo: &str, branch: Option<String>) -> Dependency {
+        self.source = DependencySource::Git
+            {repo: repo.into(), branch };
         self
     }
 
@@ -190,8 +191,10 @@ impl Dependency {
                             data.get_or_insert("registry", r);
                         }
                     }
-                    DependencySource::Git(v) => {
-                        data.get_or_insert("git", v);
+                    DependencySource::Git { repo, branch} => {
+                        data.get_or_insert("git", repo);
+                        branch.map(|branch|
+                            data.get_or_insert("branch", branch));
                     }
                 }
                 if self.optional {

--- a/src/dependency.rs
+++ b/src/dependency.rs
@@ -275,7 +275,7 @@ mod tests {
     #[test]
     fn to_toml_dep_with_git_source() {
         let toml = Dependency::new("dep")
-            .set_git("https://foor/bar.git")
+            .set_git("https://foor/bar.git", None)
             .to_toml();
 
         assert_eq!(toml.0, "dep".to_owned());

--- a/tests/cargo-add.rs
+++ b/tests/cargo-add.rs
@@ -389,6 +389,58 @@ fn adds_git_source_using_flag() {
 }
 
 #[test]
+fn adds_git_branch_using_flag() {
+    let (_tmpdir, manifest) = clone_out_test("tests/fixtures/add/Cargo.toml.sample");
+
+    // dependency not present beforehand
+    let toml = get_toml(&manifest);
+    assert!(toml["dependencies"].is_none());
+
+    execute_command(
+        &[
+            "add",
+            "git-package",
+            "--git",
+            "http://localhost/git-package.git",
+            "--branch",
+            "master",
+        ],
+        &manifest,
+    );
+
+    let toml = get_toml(&manifest);
+    let val = &toml["dependencies"]["git-package"];
+    assert_eq!(
+        val["git"].as_str(),
+        Some("http://localhost/git-package.git")
+    );
+
+    assert_eq!(val["branch"].as_str(), Some("master"));
+
+    // check this works with other flags (e.g. --dev) as well
+    let toml = get_toml(&manifest);
+    assert!(toml["dev-dependencies"].is_none());
+
+    execute_command(
+        &[
+            "add",
+            "git-dev-pkg",
+            "--git",
+            "http://site/gp.git",
+            "--branch",
+            "master",
+            "--dev",
+        ],
+        &manifest,
+    );
+
+    let toml = get_toml(&manifest);
+    let val = &toml["dev-dependencies"]["git-dev-pkg"];
+    assert_eq!(val["git"].as_str(), Some("http://site/gp.git"));
+    assert_eq!(val["branch"].as_str(), Some("master"));
+}
+
+#[test]
 fn adds_local_source_using_flag() {
     let (_tmpdir, manifest) = clone_out_test("tests/fixtures/add/Cargo.toml.sample");
 

--- a/tests/cargo-add.rs
+++ b/tests/cargo-add.rs
@@ -373,6 +373,7 @@ fn adds_git_source_using_flag() {
         val["git"].as_str(),
         Some("http://localhost/git-package.git")
     );
+    assert_eq!(val["branch"].as_str(), None);
 
     // check this works with other flags (e.g. --dev) as well
     let toml = get_toml(&manifest);
@@ -386,6 +387,7 @@ fn adds_git_source_using_flag() {
     let toml = get_toml(&manifest);
     let val = &toml["dev-dependencies"]["git-dev-pkg"];
     assert_eq!(val["git"].as_str(), Some("http://site/gp.git"));
+    assert_eq!(val["branch"].as_str(), None);
 }
 
 #[test]


### PR DESCRIPTION
This provides the minimal changes necessary to support the `branch` argument in a `Cargo.toml` dependency. `cargo-add` now accepts `--branch xyz` which when used in concert with `--git` produces

```Toml
my_crate = { git = "https://github.com/my-org/my-crate", branch = "xyz" }
```

A provisional unit test is provided which ensures the branch is present if specified and not present in the original git repo test.

