### PR TITLE
Fix clippy warnings and some errors on Windows

### DIFF
--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -277,13 +277,8 @@ impl Manifest {
         let table = self.get_table(table_path)?;
 
         let existing_dep = Self::find_dep(table, &dep.name);
-        if existing_dep.is_none() {
-            // insert a new entry
-            let (ref name, ref mut new_dependency) = dep.to_toml();
-            table[name] = new_dependency.clone();
-        } else {
+        if let Some((mut dep_name, dep_item)) = existing_dep {
             // update an existing entry
-            let (mut dep_name, dep_item) = existing_dep.unwrap();
 
             // if the `dep` is renamed in the `add` command,
             // but was present before, then we need to remove
@@ -313,6 +308,10 @@ impl Manifest {
             if let Some(t) = table.as_inline_table_mut() {
                 t.fmt()
             }
+        } else {
+            // insert a new entry
+            let (ref name, ref mut new_dependency) = dep.to_toml();
+            table[name] = new_dependency.clone();
         }
         Ok(())
     }
@@ -422,7 +421,7 @@ impl Manifest {
                 }
                 _ => false,
             })
-            .and_then(|dep| Some((dep.0.into(), dep.1)))
+            .map(|dep| (dep.0.into(), dep.1))
     }
 }
 

--- a/tests/cargo-add.rs
+++ b/tests/cargo-add.rs
@@ -1076,7 +1076,10 @@ path = "dummy.rs"
     .to_string()
         + expected;
     let expected_dep: toml_edit::Document = expected.parse().expect("toml parse error");
-    assert_eq!(expected_dep.to_string(), toml.to_string());
+    assert_eq!(
+        expected_dep.to_string(),
+        toml.to_string().replace("\r\n", "\n"),
+    );
 }
 
 #[test]
@@ -1338,7 +1341,7 @@ fn adds_sorted_dependencies() {
     // and all the dependencies in the output get sorted
     let toml = get_toml(&manifest);
     assert_eq!(
-        toml.to_string(),
+        toml.to_string().replace("\r\n", "\n"),
         r#"[package]
 name = "cargo-list-test-fixture"
 version = "0.0.0"

--- a/tests/cargo-upgrade.rs
+++ b/tests/cargo-upgrade.rs
@@ -418,8 +418,8 @@ fn invalid_manifest() {
     .fails_with(1)
     .and()
     .stderr()
-    .is(
-        "Command failed due to unhandled error: Unable to parse Cargo.toml
+    .is("\
+Command failed due to unhandled error: Unable to parse Cargo.toml
 
 Caused by: Manifest not valid TOML
 Caused by: TOML parse error at line 1, column 6
@@ -427,8 +427,7 @@ Caused by: TOML parse error at line 1, column 6
 1 | This is clearly not a valid Cargo.toml.
   |      ^
 Unexpected `i`
-Expected `=`",
-    )
+Expected `=`")
     .unwrap();
 }
 


### PR DESCRIPTION
This PR clippy warnings found at:

https://github.com/killercup/cargo-edit/runs/417584635?check_suite_focus=true

and several Windows errors found at:

https://github.com/killercup/cargo-edit/runs/417584722?check_suite_focus=true

I confirmed all warnings and errors except for one were fixed on my fork repository:

https://github.com/rhysd/cargo-edit/actions/runs/35804962

1 error is remaining on Windows node. But I could not find the reason since it was not reproducible on my local Windows machine. This PR does not fix it.

```
failures:

---- invalid_manifest stdout ----
thread 'invalid_manifest' panicked at 'Assertion failed for `D:\a\cargo-edit\cargo-edit\target\debug\cargo-upgrade upgrade --manifest-path C:\Users\RUNNER~1\AppData\Local\Temp\.tmpl9pxgX\Cargo.toml`
with: Unexpected stderr

with: Didn't match.
diff=
`` Command failed due to unhandled error: Unable to parse Cargo.toml

Caused by: Manifest not valid TOML
Caused by: TOML parse error at line 1, column 6
  |
-1 | This is clearly not a valid Cargo.toml.
+1 | This is clearly not a valid Cargo.toml.
 
   |      ^
Unexpected `i`
Expected `=`
```', C:\Users\runneradmin\.cargo\registry\src\github.com-1ecc6299db9ec823\assert_cli-0.6.3\src\assert.rs:441:13
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace.
```