### PR TITLE
"Working with features" updated

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,26 +85,29 @@ FLAGS:
     -V, --version                Prints version information
 
 OPTIONS:
-        --branch <branch>         Specify a git branch to download the crate from
-        --features <features>     Space-separated list of features to add
-        --git <uri>               Specify a git repository to download the crate from
-        --manifest-path <path>    Path to the manifest to add a dependency to
-        --path <path>             Specify the path the crate should be loaded from
-    -p, --package <pkgid>         Package id of the crate to add this dependency to
-        --registry <registry>     Registry to use
-    -r, --rename <rename>         Rename a dependency in Cargo.toml, https://doc.rust-
-                                  lang.org/cargo/reference/specifying-
-                                  dependencies.html#renaming-dependencies-in-cargotoml Only works when
-                                  specifying a single dependency
-        --target <target>         Add as dependency to the given target platform
-        --upgrade <method>        Choose method of semantic version upgrade.  Must be one of "none" (exact version, `=`
-                                  modifier), "patch" (`~` modifier), "minor" (`^` modifier), "all" (`>=`), or "default"
-                                  (no modifier) [default: default]  [possible values: none, patch, minor, all, default]
-        --vers <uri>              Specify the version to grab from the registry(crates.io). You can also specify version
-                                  as part of name, e.g `cargo add bitflags@0.3.2`
+        --branch <branch>           Specify a git branch to download the crate from
+        --features <features>...    Space-separated list of features to add. For an alternative approach to enabling
+                                    features, consider installing the `cargo-feature` utility
+        --git <uri>                 Specify a git repository to download the crate from
+        --manifest-path <path>      Path to the manifest to add a dependency to
+        --path <path>               Specify the path the crate should be loaded from
+    -p, --package <pkgid>           Package id of the crate to add this dependency to
+        --registry <registry>       Registry to use
+    -r, --rename <rename>           Rename a dependency in Cargo.toml, https://doc.rust-
+                                    lang.org/cargo/reference/specifying-
+                                    dependencies.html#renaming-dependencies-in-cargotoml Only works
+                                    when specifying a single dependency
+        --target <target>           Add as dependency to the given target platform
+        --upgrade <method>          Choose method of semantic version upgrade.  Must be one of "none" (exact version,
+                                    `=` modifier), "patch" (`~` modifier), "minor" (`^` modifier), "all" (`>=`), or
+                                    "default" (no modifier) [default: default]  [possible values: none, patch, minor,
+                                    all, default]
+        --vers <uri>                Specify the version to grab from the registry(crates.io). You can also specify
+                                    version as part of name, e.g `cargo add bitflags@0.3.2`
 
 ARGS:
     <crate>...    Crates to be added
+
 
 This command allows you to add a dependency to a Cargo.toml manifest file. If <crate> is a github
 or gitlab repository URL, or a local path, `cargo add` will try to automatically get the crate name

--- a/README.md
+++ b/README.md
@@ -85,10 +85,12 @@ FLAGS:
     -V, --version                Prints version information
 
 OPTIONS:
+        --branch <branch>         Specify a git branch to download the crate from
+        --features <features>     Space-separated list of features to add
         --git <uri>               Specify a git repository to download the crate from
         --manifest-path <path>    Path to the manifest to add a dependency to
-    -p, --package <package>       Specify the package in the workspace to add a dependency to (see `cargo help pkgid`)
         --path <path>             Specify the path the crate should be loaded from
+    -p, --package <pkgid>         Package id of the crate to add this dependency to
         --registry <registry>     Registry to use
     -r, --rename <rename>         Rename a dependency in Cargo.toml, https://doc.rust-
                                   lang.org/cargo/reference/specifying-

--- a/src/bin/add/args.rs
+++ b/src/bin/add/args.rs
@@ -246,6 +246,10 @@ impl Args {
             return Err(ErrorKind::MultipleCratesWithRename.into());
         }
 
+        if self.crates.len() > 1 && self.features.is_some() {
+            return Err(ErrorKind::MultipleCratesWithFeatures.into());
+        }
+
         self.crates
             .iter()
             .map(|crate_name| {

--- a/src/bin/add/args.rs
+++ b/src/bin/add/args.rs
@@ -115,6 +115,10 @@ pub struct Args {
     #[structopt(long = "allow-prerelease")]
     pub allow_prerelease: bool,
 
+    /// Space-separated list of features to add.
+    #[structopt(long = "features", number_of_values = 1)]
+    pub features: Option<Vec<String>>,
+
     /// Set `default-features = false` for the added dependency.
     #[structopt(long = "no-default-features")]
     pub no_default_features: bool,
@@ -225,7 +229,6 @@ impl Args {
             if let Some(registry) = &self.registry {
                 dependency = dependency.set_registry(registry);
             }
-
             Ok(dependency)
         }
     }
@@ -248,6 +251,7 @@ impl Args {
                 self.parse_single_dependency(crate_name).map(|x| {
                     let mut x = x
                         .set_optional(self.optional)
+                        .set_features(self.features.clone())
                         .set_default_features(!self.no_default_features);
                     if let Some(ref rename) = self.rename {
                         x = x.set_rename(rename);
@@ -288,6 +292,7 @@ impl Default for Args {
             pkgid: None,
             upgrade: "minor".to_string(),
             allow_prerelease: false,
+            features: None,
             no_default_features: false,
             quiet: false,
             offline: true,

--- a/src/bin/add/args.rs
+++ b/src/bin/add/args.rs
@@ -115,7 +115,8 @@ pub struct Args {
     #[structopt(long = "allow-prerelease")]
     pub allow_prerelease: bool,
 
-    /// Space-separated list of features to add.
+    /// Space-separated list of features to add. For an alternative approach to
+    /// enabling features, consider installing the `cargo-feature` utility.
     #[structopt(long = "features", number_of_values = 1)]
     pub features: Option<Vec<String>>,
 

--- a/src/bin/add/main.rs
+++ b/src/bin/add/main.rs
@@ -45,6 +45,11 @@ mod errors {
                 description("Specified multiple crates with rename")
                 display("Cannot specify multiple crates with rename")
             }
+            /// Specified multiple crates with features.
+            MultipleCratesWithFeatures {
+                description("Specified multiple crates with features")
+                display("Cannot specify multiple crates with features")
+            }
         }
         links {
             CargoEditLib(::cargo_edit::Error, ::cargo_edit::ErrorKind);

--- a/src/bin/add/main.rs
+++ b/src/bin/add/main.rs
@@ -54,6 +54,7 @@ mod errors {
         }
     }
 }
+
 use crate::errors::*;
 
 fn print_msg(dep: &Dependency, section: &[String], optional: bool) -> Result<()> {
@@ -81,7 +82,12 @@ fn print_msg(dep: &Dependency, section: &[String], optional: bool) -> Result<()>
     } else {
         format!("{} for target `{}`", &section[2], &section[1])
     };
-    writeln!(output, " {}", section)?;
+    write!(output, " {}", section)?;
+    if let Some(f) = &dep.features {
+        writeln!(output, " with features: {:?}", f)?
+    } else {
+        writeln!(output)?
+    }
     Ok(())
 }
 

--- a/src/bin/upgrade/main.rs
+++ b/src/bin/upgrade/main.rs
@@ -191,7 +191,7 @@ impl Manifests {
     fn get_pkgid(pkgid: &str) -> Result<Self> {
         let package = manifest_from_pkgid(pkgid)?;
         let manifest = LocalManifest::try_new(Path::new(&package.manifest_path))?;
-        Ok(Manifests(vec![(manifest, package.to_owned())]))
+        Ok(Manifests(vec![(manifest, package)]))
     }
 
     /// Get the manifest specified by the manifest path. Try to make an educated guess if no path is

--- a/src/fetch.rs
+++ b/src/fetch.rs
@@ -153,9 +153,7 @@ fn fetch_with_cli(repo: &git2::Repository, url: &str, refspec: &str) -> Result<(
 
     let _ = cmd.capture().map_err(|e| match e {
         subprocess::PopenError::IoError(io) => ErrorKind::Io(io),
-        _ => {
-            unreachable!("expected only io error")
-        }
+        _ => unreachable!("expected only io error"),
     })?;
     Ok(())
 }

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -12,7 +12,7 @@ pub fn manifest_from_pkgid(pkgid: &str) -> Result<Package> {
     let packages = result.packages;
     let package = packages
         .into_iter()
-        .find(|pkg| &pkg.name == pkgid)
+        .find(|pkg| pkg.name == pkgid)
         .chain_err(|| {
             "Found virtual manifest, but this command requires running against an \
              actual package in this workspace. Try adding `--all`."

--- a/tests/cargo-add.rs
+++ b/tests/cargo-add.rs
@@ -1035,7 +1035,6 @@ your-face = { version = "your-face--CURRENT_VERSION_TEST", features = ["mouth", 
 }
 
 #[test]
-#[cfg(feature = "test-external-apis")]
 fn forbids_multiple_crates_with_features_option() {
     let (_tmpdir, manifest) = clone_out_test("tests/fixtures/add/Cargo.toml.sample");
 

--- a/tests/cargo-add.rs
+++ b/tests/cargo-add.rs
@@ -944,6 +944,112 @@ fn adds_dependency_with_target_cfg() {
 }
 
 #[test]
+fn adds_features_dependency() {
+    let (_tmpdir, manifest) = clone_out_test("tests/fixtures/add/Cargo.toml.sample");
+
+    // dependency not present beforehand
+    let toml = get_toml(&manifest);
+    assert!(toml["dependencies"].is_none());
+
+    execute_command(
+        &[
+            "add",
+            "https://github.com/killercup/cargo-edit.git",
+            "--features",
+            "jui",
+        ],
+        &manifest,
+    );
+
+    // dependency present afterwards
+    let toml = get_toml(&manifest);
+    let val = toml["dependencies"]["cargo-edit"]["features"][0].as_str();
+    assert_eq!(val, Some("jui"));
+}
+
+#[test]
+fn overrides_existing_features() {
+    overwrite_dependency_test(
+        &["add", "your-face", "--features", "nose"],
+        &["add", "your-face", "--features", "mouth"],
+        r#"
+[dependencies]
+your-face = { version = "your-face--CURRENT_VERSION_TEST", features = ["mouth"] }
+"#,
+    )
+}
+
+#[test]
+fn keeps_existing_features_by_default() {
+    overwrite_dependency_test(
+        &["add", "your-face", "--features", "nose"],
+        &["add", "your-face"],
+        r#"
+[dependencies]
+your-face = { version = "your-face--CURRENT_VERSION_TEST", features = ["nose"] }
+"#,
+    )
+}
+
+#[test]
+fn handles_specifying_features_option_multiple_times() {
+    overwrite_dependency_test(
+        &["add", "your-face"],
+        &[
+            "add",
+            "your-face",
+            "--features",
+            "nose",
+            "--features",
+            "mouth",
+        ],
+        r#"
+[dependencies]
+your-face = { version = "your-face--CURRENT_VERSION_TEST", features = ["nose", "mouth"] }
+"#,
+    )
+}
+
+#[test]
+fn can_be_forced_to_provide_an_empty_features_list() {
+    overwrite_dependency_test(
+        &["add", "your-face"],
+        &["add", "your-face", "--features", ""],
+        r#"
+[dependencies]
+your-face = { version = "your-face--CURRENT_VERSION_TEST", features = [] }
+"#,
+    )
+}
+
+#[test]
+fn parses_space_separated_argument_to_features() {
+    overwrite_dependency_test(
+        &["add", "your-face", "--features", "nose"],
+        &["add", "your-face", "--features", "mouth ears"],
+        r#"
+[dependencies]
+your-face = { version = "your-face--CURRENT_VERSION_TEST", features = ["mouth", "ears"] }
+"#,
+    )
+}
+
+#[test]
+fn only_consumes_one_argument_to_features_option() {
+    // The resulting behaviour is a bit nonsensical.
+    // The alternative would be to force it to explode.
+    overwrite_dependency_test(
+        &["add", "your-face"],
+        &["add", "your-face", "--features", "mouth", "nose"],
+        r#"
+[dependencies]
+your-face = { version = "your-face--CURRENT_VERSION_TEST", features = ["mouth"] }
+nose = { version = "nose--CURRENT_VERSION_TEST", features = ["mouth"] }
+"#,
+    )
+}
+
+#[test]
 fn adds_dependency_with_custom_target() {
     let (_tmpdir, manifest) = clone_out_test("tests/fixtures/add/Cargo.toml.sample");
 
@@ -1371,4 +1477,24 @@ fn add_dependency_to_workspace_member() {
             .expect("toml dependency did not exist"),
         "toml--CURRENT_VERSION_TEST",
     );
+}
+#[test]
+fn add_prints_message_for_features_deps() {
+    let (_tmpdir, manifest) = clone_out_test("tests/fixtures/add/Cargo.toml.sample");
+
+    assert_cli::Assert::command(&[
+        "target/debug/cargo-add",
+        "add",
+        "hello-world",
+        "--vers",
+        "0.1.0",
+        "--features",
+        "jui",
+        &format!("--manifest-path={}", manifest),
+    ])
+    .succeeds()
+    .and()
+    .stdout()
+    .contains(r#"Adding hello-world v0.1.0 to dependencies with features: ["jui"]"#)
+    .unwrap();
 }

--- a/tests/cargo-add.rs
+++ b/tests/cargo-add.rs
@@ -1035,18 +1035,23 @@ your-face = { version = "your-face--CURRENT_VERSION_TEST", features = ["mouth", 
 }
 
 #[test]
-fn only_consumes_one_argument_to_features_option() {
-    // The resulting behaviour is a bit nonsensical.
-    // The alternative would be to force it to explode.
-    overwrite_dependency_test(
-        &["add", "your-face"],
-        &["add", "your-face", "--features", "mouth", "nose"],
-        r#"
-[dependencies]
-your-face = { version = "your-face--CURRENT_VERSION_TEST", features = ["mouth"] }
-nose = { version = "nose--CURRENT_VERSION_TEST", features = ["mouth"] }
-"#,
-    )
+#[cfg(feature = "test-external-apis")]
+fn forbids_multiple_crates_with_features_option() {
+    let (_tmpdir, manifest) = clone_out_test("tests/fixtures/add/Cargo.toml.sample");
+
+    assert_cli::Assert::command(&[
+        get_command_path("add").as_str(),
+        "add",
+        "your-face",
+        "--features",
+        "mouth",
+        "nose",
+    ])
+    .fails_with(1)
+    .and()
+    .stderr()
+    .contains("Cannot specify multiple crates with features")
+    .unwrap();
 }
 
 #[test]

--- a/tests/cargo-upgrade.rs
+++ b/tests/cargo-upgrade.rs
@@ -1,8 +1,6 @@
 #[macro_use]
 extern crate pretty_assertions;
 
-use std::fs;
-
 mod utils;
 use crate::utils::{
     clone_out_test, copy_workspace_test, execute_command, execute_command_for_pkg,
@@ -501,7 +499,7 @@ For more information try --help ",
 #[cfg(feature = "test-external-apis")]
 fn upgrade_to_lockfile() {
     let (tmpdir, manifest) = clone_out_test("tests/fixtures/upgrade/Cargo.toml.lockfile_source");
-    fs::copy(
+    std::fs::copy(
         std::path::Path::new("tests/fixtures/upgrade/Cargo.lock"),
         tmpdir.path().join("Cargo.lock"),
     )


### PR DESCRIPTION
About 15% of all Cargo.toml files that I found in the wild contain something of the form `features = [...`, so I think that this is something that `cargo add` should be able to support somehow.

I agree with everyone that `cargo feature` is a really excellent idea, and provides a really good user experience @Riey has done a really good job. Allowing users to specify features in a single `cargo add` command is also valuable though, because it allows library authors to provide copy-pastable quick-start instructions.

To address some of the recent comments on https://github.com/killercup/cargo-edit/issues/193: when picking syntax for specifying features with `cargo add`, I would err on the side of having a more explicit, verbose syntax, because people will inevitably be pasting `cargo add` commands to each other over the internet, and it should be obvious what's happening. I think that @alanpoon's choice of adding a `--features` flag is a good one, so I will continue with that design.

I have chosen to pick up from where https://github.com/killercup/cargo-edit/pull/194 left off.  I have started by merging with master and fixing conflicts. I will rebase to squash this all into a small number of commits before merging.

I will attempt to address the outstanding comments by the end of next week.

- [x] https://github.com/killercup/cargo-edit/pull/194#discussion_r163911671 explore the difference between specifying `--features ''` and not specifying `--features` at all (I might need someone to explain this one to me)
- [x] Is a space-separated list really the best format? It means that you are forced to write '--features="thing_a thing_b", which feels clunky. Should we change this to accept a comma-separated list or something?
- [x] https://github.com/killercup/cargo-edit/pull/194#issuecomment-362108696
- [ ] Should I add a mention of `cargo feature` in the help-text somewhere?
- [x] Rebase and squash everything into a small number of commits.