### PR TITLE
Disable autocrlf for Cargo.toml fixtures

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+tests/fixtures/*/Cargo.toml.* -text

--- a/tests/cargo-add.rs
+++ b/tests/cargo-add.rs
@@ -1036,8 +1036,6 @@ your-face = { version = "your-face--CURRENT_VERSION_TEST", features = ["mouth", 
 
 #[test]
 fn forbids_multiple_crates_with_features_option() {
-    let (_tmpdir, manifest) = clone_out_test("tests/fixtures/add/Cargo.toml.sample");
-
     assert_cli::Assert::command(&[
         get_command_path("add").as_str(),
         "add",


### PR DESCRIPTION
This should fix CI errors of this form on windows:

    with: Unexpected stderr

    with: Didn't match.
    diff=
    ...
    -6 | key = invalid-value
    +6 | key = invalid-value
    ...

Git defaults to setting autocrlf to true. If you want to override
this for CI, one suggested approach is to use gitattributes.

See here for details:
https://github.community/t5/GitHub-Actions/git-config-core-autocrlf-should-default-to-false/td-p/30445

(Thanks to @frigus02 for helping me test this out on Windows, and pointing me to the above link)