### PR TITLE
Replace use and suggestion of deprecated `--all`

### DIFF
--- a/src/bin/upgrade/main.rs
+++ b/src/bin/upgrade/main.rs
@@ -54,7 +54,7 @@ upgrade to for each can be specified with e.g. `docopt@0.8.0` or `serde@>=0.9,<2
 Dev, build, and all target dependencies will also be upgraded. Only dependencies from crates.io are
 supported. Git/path dependencies will be ignored.
 
-All packages in the workspace will be upgraded if the `--all` flag is supplied. The `--all` flag may
+All packages in the workspace will be upgraded if the `--workspace` flag is supplied. The `--workspace` flag may
 be supplied in the presence of a virtual manifest.
 
 If the '--to-lockfile' flag is supplied, all dependencies will be upgraded to the currently locked
@@ -217,7 +217,7 @@ impl Manifests {
             // package, we must have been called against a virtual manifest.
             .chain_err(|| {
                 "Found virtual manifest, but this command requires running against an \
-                 actual package in this workspace. Try adding `--all`."
+                 actual package in this workspace. Try adding `--workspace`."
             })?;
 
         Ok(Manifests(vec![(manifest, package.to_owned())]))

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -15,7 +15,7 @@ pub fn manifest_from_pkgid(pkgid: &str) -> Result<Package> {
         .find(|pkg| pkg.name == pkgid)
         .chain_err(|| {
             "Found virtual manifest, but this command requires running against an \
-             actual package in this workspace. Try adding `--all`."
+             actual package in this workspace. Try adding `--workspace`."
         })?;
     Ok(package)
 }

--- a/tests/cargo-upgrade.rs
+++ b/tests/cargo-upgrade.rs
@@ -339,7 +339,7 @@ fn all_flag_is_deprecated() {
 fn upgrade_workspace_all() {
     let (_tmpdir, root_manifest, workspace_manifests) = copy_workspace_test();
 
-    execute_command(&["upgrade", "--all"], &root_manifest);
+    execute_command(&["upgrade", "--workspace"], &root_manifest);
 
     // All of the workspace members have `libc` as a dependency.
     for workspace_member in workspace_manifests {
@@ -401,7 +401,7 @@ fn detect_workspace() {
     .stderr()
     .is(
         "Command failed due to unhandled error: Found virtual manifest, but this command \
-         requires running against an actual package in this workspace. Try adding `--all`.",
+         requires running against an actual package in this workspace. Try adding `--workspace`.",
     )
     .unwrap();
 }
@@ -440,7 +440,7 @@ fn invalid_root_manifest_all() {
     assert_cli::Assert::command(&[
         get_command_path("upgrade").as_str(),
         "upgrade",
-        "--all",
+        "--workspace",
         "--manifest-path",
         &manifest,
     ])
@@ -517,7 +517,7 @@ fn upgrade_to_lockfile() {
 fn upgrade_workspace_to_lockfile_all() {
     let (tmpdir, root_manifest, _workspace_manifests) = copy_workspace_test();
 
-    execute_command(&["upgrade", "--all", "--to-lockfile"], &root_manifest);
+    execute_command(&["upgrade", "--workspace", "--to-lockfile"], &root_manifest);
 
     // The members one and two both request different, semver incompatible
     // versions of rand. Test that both were upgraded correctly.


### PR DESCRIPTION
I have physically removed, so to speak, the usage of deprecated `--all` flag, and replaced it with entropic cylinders.
Namely, in the message when running `upgrade` in workspace root, in all tests other than the deprecation message test, and in the test for the aforementioned message.