### PR TITLE
Fix to allow any remote name to be used

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,3 +1,5 @@
+use std::path::PathBuf;
+
 error_chain! {
     foreign_links {
         Io(::std::io::Error) #[doc = "An error from the std::io module"];
@@ -74,6 +76,16 @@ error_chain! {
         ParseVersion(version: String, dep: String) {
             description("Failed to parse a version for a dependency")
             display("The version `{}` for the dependency `{}` couldn't be parsed", version, dep)
+        }
+        /// Missing registrary checkout in the cargo registrary
+        MissingRegistraryCheckout(path: PathBuf) {
+            description("Missing registrary checkout in the cargo registrary")
+            display("Looks like ({}) is empty", path.display())
+        }
+        /// Non Unicode git path
+        NonUnicodeGitPath {
+            // this is because git2 function takes &str insted of something like AsRef<Path>
+            description("Path to cargos registrary contains non unicode characters")
         }
     }
 }

--- a/src/fetch.rs
+++ b/src/fetch.rs
@@ -272,12 +272,12 @@ fn fuzzy_query_registry_index(
         .read_dir()?
         .next() // Is there always only one branch? (expecting either master og HEAD)
         .ok_or_else(|| ErrorKind::MissingRegistraryCheckout(checkout_dir))??
-        .path();
+        .file_name();
     let repo = git2::Repository::open(registry_path)?;
     let tree = repo
         .find_reference(
             remotes
-                .join(checkout.file_name().unwrap()) //unwrap here is ok as we have know there is a file there
+                .join(checkout)
                 .to_str()
                 .ok_or_else(|| ErrorKind::NonUnicodeGitPath)?,
         )?

--- a/src/fetch.rs
+++ b/src/fetch.rs
@@ -123,8 +123,8 @@ pub fn update_registry_index(registry: &Url) -> Result<()> {
     output.reset()?;
     writeln!(output, " '{}' index", registry)?;
 
-    let refspec = "refs/heads/master:refs/remotes/origin/master";
-    fetch_with_cli(&repo, registry.as_str(), refspec)?;
+    let refspec = format!("refs/heads/{0}:refs/remotes/origin/{0}", get_checkout_name(registry_path)?);
+    fetch_with_cli(&repo, registry.as_str(), &refspec)?;
 
     Ok(())
 }
@@ -260,6 +260,18 @@ fn get_no_latest_version_from_json_when_all_are_yanked() {
     assert!(read_latest_version(&versions, false).is_err());
 }
 
+/// Gets the checkedout branch name of .cargo/registry/index/github.com-*/.git/refs
+fn get_checkout_name(registry_path: impl AsRef<Path>) -> Result<String> {
+    let checkout_dir = registry_path.as_ref().join(".git").join("refs/remotes/origin/");
+    Ok(checkout_dir
+        .read_dir()?
+        .next() //Is there always only one branch? (expecting either master og HEAD)
+        .ok_or_else(|| ErrorKind::MissingRegistraryCheckout(checkout_dir))??
+        .file_name()
+        .into_string()
+        .map_err(|_| ErrorKind::NonUnicodeGitPath)?)
+}
+
 /// Fuzzy query crate from registry index
 fn fuzzy_query_registry_index(
     crate_name: impl Into<String>,
@@ -267,17 +279,11 @@ fn fuzzy_query_registry_index(
 ) -> Result<Vec<CrateVersion>> {
     let crate_name = crate_name.into();
     let remotes = PathBuf::from("refs/remotes/origin/");
-    let checkout_dir = registry_path.as_ref().join(".git").join(&remotes);
-    let checkout = checkout_dir
-        .read_dir()?
-        .next() // Is there always only one branch? (expecting either master og HEAD)
-        .ok_or_else(|| ErrorKind::MissingRegistraryCheckout(checkout_dir))??
-        .file_name();
-    let repo = git2::Repository::open(registry_path)?;
+    let repo = git2::Repository::open(&registry_path)?;
     let tree = repo
         .find_reference(
             remotes
-                .join(checkout)
+                .join(get_checkout_name(&registry_path)?)
                 .to_str()
                 .ok_or_else(|| ErrorKind::NonUnicodeGitPath)?,
         )?


### PR DESCRIPTION
Fixes #411

TODO: Is it ok if we take the first one we find. Are there any examples
of having more than one file in `refs/remotes/origin/`?.