### PR TITLE
Keep dependencies in sorted order if they were already sorted

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ FLAGS:
         --offline                Run without accessing the network
         --optional               Add as an optional dependency (for use in features)
     -q, --quiet                  Do not print any output in case of success
-    -s, --sort                   Keep dependencies sorted
+    -s, --sort                   Sort dependencies even if currently unsorted
     -V, --version                Prints version information
 
 OPTIONS:

--- a/src/bin/add/args.rs
+++ b/src/bin/add/args.rs
@@ -132,7 +132,7 @@ pub struct Args {
     #[structopt(long = "offline")]
     pub offline: bool,
 
-    /// Keep dependencies sorted
+    /// Sort dependencies even if currently unsorted
     #[structopt(long = "sort", short = "s")]
     pub sort: bool,
 

--- a/tests/cargo-add.rs
+++ b/tests/cargo-add.rs
@@ -1444,11 +1444,57 @@ fn add_typo() {
 }
 
 #[test]
-fn adds_sorted_dependencies() {
+fn sorts_unsorted_dependencies() {
     let (_tmpdir, manifest) = clone_out_test("tests/fixtures/add/Cargo.toml.unsorted");
 
     // adds one dependency
     execute_command(&["add", "--sort", "toml"], &manifest);
+
+    // and all the dependencies in the output get sorted
+    let toml = get_toml(&manifest);
+    assert_eq!(
+        toml.to_string().replace("\r\n", "\n"),
+        r#"[package]
+name = "cargo-list-test-fixture"
+version = "0.0.0"
+
+[dependencies]
+atty = "0.2.13"
+toml = "toml--CURRENT_VERSION_TEST"
+toml_edit = "0.1.5"
+"#
+    );
+}
+
+#[test]
+fn adds_unsorted_dependencies() {
+    let (_tmpdir, manifest) = clone_out_test("tests/fixtures/add/Cargo.toml.unsorted");
+
+    // adds one dependency
+    execute_command(&["add", "toml"], &manifest);
+
+    // and unsorted dependencies stay unsorted
+    let toml = get_toml(&manifest);
+    assert_eq!(
+        toml.to_string().replace("\r\n", "\n"),
+        r#"[package]
+name = "cargo-list-test-fixture"
+version = "0.0.0"
+
+[dependencies]
+toml_edit = "0.1.5"
+atty = "0.2.13"
+toml = "toml--CURRENT_VERSION_TEST"
+"#
+    );
+}
+
+#[test]
+fn keeps_sorted_dependencies_sorted() {
+    let (_tmpdir, manifest) = clone_out_test("tests/fixtures/add/Cargo.toml.sorted");
+
+    // adds one dependency
+    execute_command(&["add", "toml"], &manifest);
 
     // and all the dependencies in the output get sorted
     let toml = get_toml(&manifest);

--- a/tests/fixtures/add/Cargo.toml.sorted
+++ b/tests/fixtures/add/Cargo.toml.sorted
@@ -1,0 +1,7 @@
+[package]
+name = "cargo-list-test-fixture"
+version = "0.0.0"
+
+[dependencies]
+atty = "0.2.13"
+toml_edit = "0.1.5"


### PR DESCRIPTION
This should avoid the need to pass the `-s` option, except to sort
dependencies that are currently unsorted. Adjust the documentation of
that option accordingly.