### PR TITLE
Fix all clippy warnings

### DIFF
--- a/src/bin/add/args.rs
+++ b/src/bin/add/args.rs
@@ -2,7 +2,6 @@
 
 use cargo_edit::{find, registry_url, Dependency};
 use cargo_edit::{get_latest_dependency, CrateName};
-use semver;
 use std::path::PathBuf;
 use structopt::StructOpt;
 

--- a/src/bin/add/main.rs
+++ b/src/bin/add/main.rs
@@ -103,7 +103,7 @@ fn is_sorted(mut it: impl Iterator<Item = impl PartialOrd>) -> bool {
         None => return true,
     };
 
-    while let Some(curr) = it.next() {
+    for curr in it {
         if curr < last {
             return false;
         }

--- a/src/bin/upgrade/main.rs
+++ b/src/bin/upgrade/main.rs
@@ -230,7 +230,7 @@ impl Manifests {
         let selected_dependencies = only_update
             .into_iter()
             .map(|name| {
-                if let Some(dependency) = CrateName::new(&name.clone()).parse_as_version()? {
+                if let Some(dependency) = CrateName::new(&name).parse_as_version()? {
                     Ok((
                         dependency.name.clone(),
                         dependency.version().map(String::from),
@@ -315,10 +315,10 @@ impl Manifests {
         // Get locked dependencies. For workspaces with multiple Cargo.toml
         // files, there is only a single lockfile, so it suffices to get
         // metadata for any one of Cargo.toml files.
-        let (manifest, _package) =
-            self.0.iter().next().ok_or_else(|| {
-                ErrorKind::CargoEditLib(::cargo_edit::ErrorKind::InvalidCargoConfig)
-            })?;
+        let (manifest, _package) = self
+            .0
+            .get(0)
+            .ok_or_else(|| ErrorKind::CargoEditLib(::cargo_edit::ErrorKind::InvalidCargoConfig))?;
         let mut cmd = cargo_metadata::MetadataCommand::new();
         cmd.manifest_path(manifest.path.clone());
         cmd.other_options(vec!["--locked".to_string()]);

--- a/src/crate_name.rs
+++ b/src/crate_name.rs
@@ -1,6 +1,4 @@
 //! Crate name parsing.
-use semver;
-
 use crate::errors::*;
 use crate::Dependency;
 use crate::{get_crate_name_from_github, get_crate_name_from_gitlab, get_crate_name_from_path};

--- a/src/dependency.rs
+++ b/src/dependency.rs
@@ -1,5 +1,4 @@
 use std::iter::FromIterator;
-use toml_edit;
 
 #[derive(Debug, Hash, PartialEq, Eq, Clone)]
 enum DependencySource {

--- a/src/fetch.rs
+++ b/src/fetch.rs
@@ -1,10 +1,7 @@
 use crate::errors::*;
 use crate::registry::{registry_path, registry_path_from_url};
 use crate::{Dependency, Manifest};
-use env_proxy;
 use regex::Regex;
-use reqwest;
-use semver;
 use std::env;
 use std::io::{Read, Write};
 use std::path::{Path, PathBuf};
@@ -123,7 +120,10 @@ pub fn update_registry_index(registry: &Url) -> Result<()> {
     output.reset()?;
     writeln!(output, " '{}' index", registry)?;
 
-    let refspec = format!("refs/heads/{0}:refs/remotes/origin/{0}", get_checkout_name(registry_path)?);
+    let refspec = format!(
+        "refs/heads/{0}:refs/remotes/origin/{0}",
+        get_checkout_name(registry_path)?
+    );
     fetch_with_cli(&repo, registry.as_str(), &refspec)?;
 
     Ok(())
@@ -262,7 +262,10 @@ fn get_no_latest_version_from_json_when_all_are_yanked() {
 
 /// Gets the checkedout branch name of .cargo/registry/index/github.com-*/.git/refs
 fn get_checkout_name(registry_path: impl AsRef<Path>) -> Result<String> {
-    let checkout_dir = registry_path.as_ref().join(".git").join("refs/remotes/origin/");
+    let checkout_dir = registry_path
+        .as_ref()
+        .join(".git")
+        .join("refs/remotes/origin/");
     Ok(checkout_dir
         .read_dir()?
         .next() //Is there always only one branch? (expecting either master og HEAD)

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -4,13 +4,11 @@ use std::ops::Deref;
 use std::path::{Path, PathBuf};
 use std::{env, str};
 
+use semver::{Version, VersionReq};
 use termcolor::{BufferWriter, Color, ColorChoice, ColorSpec, WriteColor};
-use toml_edit;
 
 use crate::dependency::Dependency;
 use crate::errors::*;
-
-use semver::{Version, VersionReq};
 
 const MANIFEST_FILENAME: &str = "Cargo.toml";
 


### PR DESCRIPTION
This PR fixes all warnings from `cargo clippy` and `cargo fmt -- --check`.