### PR TITLE
Use before_script instead of after_script for linter checks on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ matrix:
     script:
     - rustup component add rustfmt
     - rustup component add clippy
-    - cargo fmt --all -- --write-mode=diff
+    - cargo fmt --all -- --check
     - cargo clippy -- -D warnings -A deprecated
   allow_failures:
   - rust: nightly

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ rust:
 matrix:
   include:
   - rust: stable
-    after_script:
+    script:
     - rustup component add rustfmt
     - rustup component add clippy
     - cargo fmt --all -- --write-mode=diff

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,11 +6,7 @@ rust:
 matrix:
   include:
   - rust: stable
-    script:
-    - rustup component add rustfmt
-    - rustup component add clippy
-    - cargo fmt --all -- --check
-    - cargo clippy -- -D warnings -A deprecated
+    env: LINT=true
   allow_failures:
   - rust: nightly
 before_script:
@@ -24,6 +20,14 @@ script:
   travis-cargo bench &&
   travis-cargo --only stable doc
 - git diff --exit-code
+- |
+  if [[ "$TRAVIS_RUST_VERSION" == "stable" ]]; then
+    rustup component add rustfmt
+    rustup component add clippy
+    set -x
+    cargo fmt --all -- --check
+    cargo clippy -- -D warnings -A deprecated
+  fi
 addons:
   apt:
     packages:


### PR DESCRIPTION
`.travis.yml` uses `before_script` for running litners. However, `before_script` ignores non-zero exit status. From https://docs.travis-ci.com/user/job-lifecycle/#breaking-the-build,

> The exit code of after_success, after_failure, after_script, after_deploy and subsequent stages do not affect the build result. However, if one of these stages times out, the build is marked as failed.

This is why linter failures (#422) was overlooked. Travis CI ran linters but did not report the failure.

While confirming the result, I mark this PR as draft.