### PR TITLE
Pass --all-features to `cargo metadata` when using `cargo upgrade --to-lockfile`

### DIFF
--- a/src/bin/upgrade/main.rs
+++ b/src/bin/upgrade/main.rs
@@ -321,6 +321,7 @@ impl Manifests {
             .ok_or_else(|| ErrorKind::CargoEditLib(::cargo_edit::ErrorKind::InvalidCargoConfig))?;
         let mut cmd = cargo_metadata::MetadataCommand::new();
         cmd.manifest_path(manifest.path.clone());
+        cmd.features(cargo_metadata::CargoOpt::AllFeatures);
         cmd.other_options(vec!["--locked".to_string()]);
 
         let result = cmd

--- a/tests/fixtures/upgrade/Cargo.toml.lockfile_source
+++ b/tests/fixtures/upgrade/Cargo.toml.lockfile_source
@@ -6,5 +6,5 @@ version = "0.1.0"
 path = "../dummy.rs"
 
 [dependencies]
-libc = "0.2.28"
+libc = { version = "0.2.28", optional = true }
 rand = "0.3"

--- a/tests/fixtures/upgrade/Cargo.toml.lockfile_target
+++ b/tests/fixtures/upgrade/Cargo.toml.lockfile_target
@@ -6,5 +6,5 @@ version = "0.1.0"
 path = "../dummy.rs"
 
 [dependencies]
-libc = "0.2.65"
+libc = { version = "0.2.65", optional = true }
 rand = "0.3.10"


### PR DESCRIPTION
Previously `cargo upgrade --to-lockfile` does not update optional dependencies that are not enabled by default because `cargo metadata` only enables the `default` feature and does not report these dependencies. This PR changes `cargo upgrade --to-lockfile` to pass `--all-features` to `cargo metadata`, so it will report them and `cargo upgrade --to-lockfile` will update them.