### PR TITLE
Update git2 dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,7 +56,7 @@ dirs = "3.0.1"
 env_proxy = "0.4.1"
 error-chain = "0.12.4"
 failure = "0.1.8"
-git2 = "0.13.11"
+git2 = "0.13.12"
 hex = "0.4.2"
 regex = "1.3.9"
 reqwest = { version = "0.10.8", features = ["blocking"] }


### PR DESCRIPTION
This add support to libgit2 v1.1 which is required for arch-linux for example

https://github.com/rust-lang/git2-rs/commit/68805637017da2fb59bc7dc600e89614db016c32