### PR TITLE
Support of bare repositories of crates' registry

### DIFF
--- a/src/bin/upgrade/main.rs
+++ b/src/bin/upgrade/main.rs
@@ -315,10 +315,9 @@ impl Manifests {
         // Get locked dependencies. For workspaces with multiple Cargo.toml
         // files, there is only a single lockfile, so it suffices to get
         // metadata for any one of Cargo.toml files.
-        let (manifest, _package) = self
-            .0
-            .get(0)
-            .ok_or_else(|| ErrorKind::CargoEditLib(::cargo_edit::ErrorKind::InvalidCargoConfig))?;
+        let (manifest, _package) = self.0.get(0).ok_or(ErrorKind::CargoEditLib(
+            ::cargo_edit::ErrorKind::InvalidCargoConfig,
+        ))?;
         let mut cmd = cargo_metadata::MetadataCommand::new();
         cmd.manifest_path(manifest.path.clone());
         cmd.features(cargo_metadata::CargoOpt::AllFeatures);

--- a/src/fetch.rs
+++ b/src/fetch.rs
@@ -273,7 +273,7 @@ fn get_checkout_name(registry_path: impl AsRef<Path>) -> Result<String> {
         .read_dir() // .git repo
         .or_else(|_| bare_checkout_dir.read_dir())? // there's no .git, it's bare one
         .next() //Is there always only one branch? (expecting either master og HEAD)
-        .ok_or_else(|| ErrorKind::MissingRegistraryCheckout(checkout_dir))??
+        .ok_or(ErrorKind::MissingRegistraryCheckout(checkout_dir))??
         .file_name()
         .into_string()
         .map_err(|_| ErrorKind::NonUnicodeGitPath)?)
@@ -292,7 +292,7 @@ fn fuzzy_query_registry_index(
             remotes
                 .join(get_checkout_name(&registry_path)?)
                 .to_str()
-                .ok_or_else(|| ErrorKind::NonUnicodeGitPath)?,
+                .ok_or(ErrorKind::NonUnicodeGitPath)?,
         )?
         .peel_to_tree()?;
 


### PR DESCRIPTION
On my PC I spot an error there's no `.cargo/registry/index/*/.git/` directory. Diving into problem shows me that it's bare repo so it doesn't have such directory. I added code will switch to bare repo in case of an error with `.git` directory. 