### PR TITLE
Read config files with  extension that added in version 1.39.

### DIFF
--- a/src/registry.rs
+++ b/src/registry.rs
@@ -80,12 +80,22 @@ pub fn registry_url(manifest_path: &Path, registry: Option<&str>) -> Result<Url>
         let config_path = work_dir.join(".cargo").join("config");
         if config_path.is_file() {
             read_config(&mut registries, config_path)?;
+        } else {
+            let config_path = work_dir.join(".cargo").join("config.toml");
+            if config_path.is_file() {
+                read_config(&mut registries, config_path)?;
+            }
         }
     }
 
     let default_config_path = cargo_home()?.join("config");
     if default_config_path.is_file() {
         read_config(&mut registries, default_config_path)?;
+    } else {
+        let default_config_path = cargo_home()?.join("config.toml");
+        if default_config_path.is_file() {
+            read_config(&mut registries, default_config_path)?;
+        }
     }
 
     // find head of the relevant linked list

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -77,22 +77,24 @@ pub fn registry_url(manifest_path: &Path, registry: Option<&str>) -> Result<Url>
         .expect("there must be a parent directory")
         .ancestors()
     {
-        let config_path = work_dir.join(".cargo").join("config");
+        let work_cargo_dir = work_dir.join(".cargo");
+        let config_path = work_cargo_dir.join("config");
         if config_path.is_file() {
             read_config(&mut registries, config_path)?;
         } else {
-            let config_path = work_dir.join(".cargo").join("config.toml");
+            let config_path = work_cargo_dir.join("config.toml");
             if config_path.is_file() {
                 read_config(&mut registries, config_path)?;
             }
         }
     }
 
-    let default_config_path = cargo_home()?.join("config");
+    let default_cargo_home = cargo_home()?;
+    let default_config_path = default_cargo_home.join("config");
     if default_config_path.is_file() {
         read_config(&mut registries, default_config_path)?;
     } else {
-        let default_config_path = cargo_home()?.join("config.toml");
+        let default_config_path = default_cargo_home.join("config.toml");
         if default_config_path.is_file() {
             read_config(&mut registries, default_config_path)?;
         }


### PR DESCRIPTION
Fix `Command failed due to unhandled error: No such file or directory (os error 2)`, when config file without extension dose not exists.

If both files exist, will use the file without the extension, as same as cargo.

> Cargo also reads config files without the .toml extension, such as .cargo/config. Support for the .toml extension was added in version 1.39 and is the preferred form. If both files exist, Cargo will use the file without the extension.
[Configuration](https://doc.rust-lang.org/cargo/reference/config.html)