### PR TITLE
quieted cargo add Update message when --quiet

### DIFF
--- a/src/bin/add/main.rs
+++ b/src/bin/add/main.rs
@@ -128,7 +128,7 @@ fn handle_add(args: &Args) -> Result<()> {
             &find(&manifest_path)?,
             args.registry.as_ref().map(String::as_ref),
         )?;
-        update_registry_index(&url)?;
+        update_registry_index(&url, args.quiet)?;
     }
 
     let was_sorted = manifest

--- a/src/bin/upgrade/main.rs
+++ b/src/bin/upgrade/main.rs
@@ -477,7 +477,7 @@ fn process(args: Args) -> Result<()> {
 
     if !args.offline && !to_lockfile && std::env::var("CARGO_IS_TEST").is_err() {
         let url = registry_url(&find(&manifest_path)?, None)?;
-        update_registry_index(&url)?;
+        update_registry_index(&url, false)?;
     }
 
     let manifests = if all {
@@ -502,9 +502,12 @@ fn process(args: Args) -> Result<()> {
                 .filter_map(|UpgradeMetadata { registry, .. }| registry.as_ref())
                 .collect::<HashSet<_>>()
             {
-                update_registry_index(&Url::parse(registry_url).map_err(|_| {
-                    ErrorKind::CargoEditLib(::cargo_edit::ErrorKind::InvalidCargoConfig)
-                })?)?;
+                update_registry_index(
+                    &Url::parse(registry_url).map_err(|_| {
+                        ErrorKind::CargoEditLib(::cargo_edit::ErrorKind::InvalidCargoConfig)
+                    })?,
+                    false,
+                )?;
             }
         }
 

--- a/src/dependency.rs
+++ b/src/dependency.rs
@@ -160,10 +160,7 @@ impl Dependency {
 
     /// Get the alias for the dependency (if any)
     pub fn rename(&self) -> Option<&str> {
-        match &self.rename {
-            Some(rename) => Some(&rename),
-            None => None,
-        }
+        self.rename.as_deref()
     }
 
     /// Convert dependency to TOML

--- a/src/fetch.rs
+++ b/src/fetch.rs
@@ -92,7 +92,7 @@ fn read_latest_version(
 }
 
 /// update registry index for given project
-pub fn update_registry_index(registry: &Url) -> Result<()> {
+pub fn update_registry_index(registry: &Url, quiet: bool) -> Result<()> {
     let registry_path = registry_path_from_url(registry)?;
 
     let colorchoice = if atty::is(atty::Stream::Stdout) {
@@ -115,10 +115,12 @@ pub fn update_registry_index(registry: &Url) -> Result<()> {
     }
 
     let repo = git2::Repository::open(&registry_path)?;
-    output.set_color(ColorSpec::new().set_fg(Some(Color::Green)).set_bold(true))?;
-    write!(output, "{:>12}", "Updating")?;
-    output.reset()?;
-    writeln!(output, " '{}' index", registry)?;
+    if !quiet {
+        output.set_color(ColorSpec::new().set_fg(Some(Color::Green)).set_bold(true))?;
+        write!(output, "{:>12}", "Updating")?;
+        output.reset()?;
+        writeln!(output, " '{}' index", registry)?;
+    }
 
     let refspec = format!(
         "refs/heads/{0}:refs/remotes/origin/{0}",


### PR DESCRIPTION
Makes fetching of the remote index quiet when `cargo add --quiet` is performed. Closes #461.