### PR TITLE
Input validation

### DIFF
--- a/src/bin/add/args.rs
+++ b/src/bin/add/args.rs
@@ -167,6 +167,10 @@ impl Args {
     }
 
     fn parse_single_dependency(&self, crate_name: &str) -> Result<Dependency> {
+        if crate_name == "." {
+            return Err(ErrorKind::AttemptedCreatingCircularDependency.into());
+        }
+
         let crate_name = CrateName::new(crate_name);
 
         if let Some(mut dependency) = crate_name.parse_as_version()? {
@@ -183,6 +187,7 @@ impl Args {
 
             Ok(dependency)
         } else if crate_name.is_url_or_path() {
+            println!("hello");
             Ok(crate_name.parse_crate_name_from_uri()?)
         } else {
             assert_eq!(self.git.is_some() && self.vers.is_some(), false);
@@ -191,6 +196,7 @@ impl Args {
             assert_eq!(self.path.is_some() && self.registry.is_some(), false);
 
             let mut dependency = Dependency::new(crate_name.name());
+            dbg!(&dependency);
 
             if let Some(repo) = &self.git {
                 dependency = dependency.set_git(repo, self.branch.clone());

--- a/src/bin/add/main.rs
+++ b/src/bin/add/main.rs
@@ -30,6 +30,10 @@ mod args;
 mod errors {
     error_chain! {
         errors {
+            /// Running `cargo-add .` would create a create circular dependency, this error prevents it
+            AttemptedCreatingCircularDependency {
+                description("Attempting to create circular dependency by specifying crate name `.`")
+            }
             /// Specified a dependency with both a git URL and a version.
             GitUrlWithVersion(git: String, version: String) {
                 description("Specified git URL with version")

--- a/src/crate_name.rs
+++ b/src/crate_name.rs
@@ -77,6 +77,8 @@ impl<'a> CrateName<'a> {
             let (name, version) = (xs[0], xs[1]);
             semver::VersionReq::parse(version).chain_err(|| "Invalid crate version requirement")?;
 
+            self.validate_name()?;
+            
             Ok(Some(Dependency::new(name).set_version(version)))
         } else {
             Ok(None)

--- a/src/crate_name.rs
+++ b/src/crate_name.rs
@@ -42,6 +42,33 @@ impl<'a> CrateName<'a> {
         self.0.contains('.') || self.0.contains('/') || self.0.contains('\\')
     }
 
+    /// Checks is the specified crate name is a valid, non-empty name for a crates.io crate,
+    /// meaning it contains only a-zA-Z, dashes, and underscores.
+    /// expected to be usually called as validate_name()?;
+    pub fn validate_name(&self) -> Result<()> {
+        if self.name().is_empty() {
+            return Err(ErrorKind::EmptyCrateName.into());
+        }
+
+
+        let mut invalid_char = 'a';
+        let contains_only_valid_characters = self.name().chars().all(|c| {
+            let is_valid = c.is_alphanumeric() || c == '-' || c == '_';
+
+            if !is_valid {
+                invalid_char = c;
+            }
+            is_valid
+        });
+
+        if !contains_only_valid_characters {
+            assert_ne!(invalid_char, 'a');
+            return Err(ErrorKind::CrateNameContainsInvalidCharacter(self.name().to_string(), invalid_char).into());
+        }
+
+        Ok(())
+    }
+
     /// If this crate specifier includes a version (e.g. `docopt@0.8`), extract the name and
     /// version.
     pub fn parse_as_version(&self) -> Result<Option<Dependency>> {

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -8,6 +8,11 @@ error_chain! {
     }
 
     errors {
+        /// A crate contains invalid symbol
+        CrateNameContainsInvalidCharacter(crate_name: String, symbol: char) {
+            description("Specified crate name(s) contains invalid symbol(s)")
+            display("Crate name \"{}\" is invalid, contains symbol '{}' (byte values: {})", crate_name, &symbol, symbol.escape_unicode())
+        }
         /// Failed to read home directory
         ReadHomeDirFailure {
             description("Failed to read home directory")

--- a/src/fetch.rs
+++ b/src/fetch.rs
@@ -49,9 +49,7 @@ pub fn get_latest_dependency(
         return Ok(Dependency::new(crate_name).set_version(&new_version));
     }
 
-    if crate_name.is_empty() {
-        return Err(ErrorKind::EmptyCrateName.into());
-    }
+    crate::CrateName::new(crate_name).validate_name()?;
 
     let registry_path = match registry {
         Some(url) => registry_path_from_url(url)?,


### PR DESCRIPTION
Add some checks when parsing crate names passed as arguments:

1. Check whether the name starts with a letter and contains only letters, numbers, dashes and hyphens (same requirements as crates.io has).
2. Disallow passing '.' as path to crate to prevent accidental creation of circular dependencies.