### PR TITLE
Beautify help messages

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -203,6 +203,7 @@ dependencies = [
  "atty",
  "bitflags",
  "strsim",
+ "term_size",
  "textwrap",
  "unicode-width",
  "vec_map",
@@ -954,6 +955,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "term_size"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e4129646ca0ed8f45d09b929036bafad5377103edd06e50bf574b353d2b08d9"
+dependencies = [
+ "libc",
+ "winapi 0.3.9",
+]
+
+[[package]]
 name = "termcolor"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -968,6 +979,7 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
 dependencies = [
+ "term_size",
  "unicode-width",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,7 +62,7 @@ regex = "1.3.9"
 serde = "1.0.116"
 serde_derive = "1.0.116"
 serde_json = "1.0.58"
-structopt = { version = "0.3.18", optional = true }
+structopt = { version = "0.3.18", features = ["wrap_help"], optional = true }
 subprocess = "0.2.6"
 termcolor = "1.1.0"
 toml = "0.5.6"

--- a/src/bin/add/args.rs
+++ b/src/bin/add/args.rs
@@ -3,7 +3,7 @@
 use cargo_edit::{find, registry_url, Dependency};
 use cargo_edit::{get_latest_dependency, CrateName};
 use std::path::PathBuf;
-use structopt::StructOpt;
+use structopt::{clap::AppSettings, StructOpt};
 
 use crate::errors::*;
 
@@ -12,27 +12,27 @@ use crate::errors::*;
 pub enum Command {
     /// Add dependency to a Cargo.toml manifest file.
     #[structopt(name = "add")]
-    #[structopt(
-        after_help = "This command allows you to add a dependency to a Cargo.toml manifest file. If <crate> is a github
-or gitlab repository URL, or a local path, `cargo add` will try to automatically get the crate name
-and set the appropriate `--git` or `--path` value.
+    #[structopt(after_help = "\
+This command allows you to add a dependency to a Cargo.toml manifest file. If <crate> is a github \
+or gitlab repository URL, or a local path, `cargo add` will try to automatically get the crate \
+name and set the appropriate `--git` or `--path` value.
 
-Please note that Cargo treats versions like '1.2.3' as '^1.2.3' (and that '^1.2.3' is specified
-as '>=1.2.3 and <2.0.0'). By default, `cargo add` will use this format, as it is the one that the
-crates.io registry suggests. One goal of `cargo add` is to prevent you from using wildcard
-dependencies (version set to '*')."
-    )]
+Please note that Cargo treats versions like '1.2.3' as '^1.2.3' (and that '^1.2.3' is specified \
+as '>=1.2.3 and <2.0.0'). By default, `cargo add` will use this format, as it is the one that the \
+crates.io registry suggests. One goal of `cargo add` is to prevent you from using wildcard \
+dependencies (version set to '*').")]
     Add(Args),
 }
 
 #[derive(Debug, StructOpt)]
+#[structopt(setting = AppSettings::ColoredHelp)]
 pub struct Args {
     /// Crates to be added.
     #[structopt(name = "crate", required = true)]
     pub crates: Vec<String>,
 
     /// Rename a dependency in Cargo.toml,
-    /// https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#renaming-dependencies-in-cargotoml
+    /// https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#renaming-dependencies-in-cargotoml.
     /// Only works when specifying a single dependency.
     #[structopt(long = "rename", short = "r")]
     pub rename: Option<String>,

--- a/src/bin/rm/main.rs
+++ b/src/bin/rm/main.rs
@@ -19,7 +19,7 @@ use std::borrow::Cow;
 use std::io::Write;
 use std::path::PathBuf;
 use std::process;
-use structopt::StructOpt;
+use structopt::{clap::AppSettings, StructOpt};
 use termcolor::{Color, ColorChoice, ColorSpec, StandardStream, WriteColor};
 
 mod errors {
@@ -43,6 +43,7 @@ enum Command {
 }
 
 #[derive(Debug, StructOpt)]
+#[structopt(setting = AppSettings::ColoredHelp)]
 struct Args {
     /// Crates to be removed.
     #[structopt(name = "crates", required = true)]

--- a/src/bin/upgrade/main.rs
+++ b/src/bin/upgrade/main.rs
@@ -24,7 +24,7 @@ use std::collections::{HashMap, HashSet};
 use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::process;
-use structopt::StructOpt;
+use structopt::{clap::AppSettings, StructOpt};
 use termcolor::{BufferWriter, Color, ColorChoice, ColorSpec, WriteColor};
 use url::Url;
 
@@ -44,28 +44,28 @@ mod errors {
 enum Command {
     /// Upgrade dependencies as specified in the local manifest file (i.e. Cargo.toml).
     #[structopt(name = "upgrade")]
-    #[structopt(
-        after_help = "This command differs from `cargo update`, which updates the dependency versions recorded in the
+    #[structopt(after_help = "\
+This command differs from `cargo update`, which updates the dependency versions recorded in the \
 local lock file (Cargo.lock).
 
-If `<dependency>`(s) are provided, only the specified dependencies will be upgraded. The version to
-upgrade to for each can be specified with e.g. `docopt@0.8.0` or `serde@>=0.9,<2.0`.
+If `<dependency>`(s) are provided, only the specified dependencies will be upgraded. The version \
+to upgrade to for each can be specified with e.g. `docopt@0.8.0` or `serde@>=0.9,<2.0`.
 
-Dev, build, and all target dependencies will also be upgraded. Only dependencies from crates.io are
-supported. Git/path dependencies will be ignored.
+Dev, build, and all target dependencies will also be upgraded. Only dependencies from crates.io \
+are supported. Git/path dependencies will be ignored.
 
-All packages in the workspace will be upgraded if the `--workspace` flag is supplied. The `--workspace` flag may
-be supplied in the presence of a virtual manifest.
+All packages in the workspace will be upgraded if the `--workspace` flag is supplied. The \
+`--workspace` flag may be supplied in the presence of a virtual manifest.
 
-If the '--to-lockfile' flag is supplied, all dependencies will be upgraded to the currently locked
-version as recorded in the Cargo.lock file. This flag requires that the Cargo.lock file is
-up-to-date. If the lock file is missing, or it needs to be updated, cargo-upgrade will exit with an
-error. If the '--to-lockfile' flag is supplied then the network won't be accessed."
-    )]
+If the '--to-lockfile' flag is supplied, all dependencies will be upgraded to the currently locked \
+version as recorded in the Cargo.lock file. This flag requires that the Cargo.lock file is \
+up-to-date. If the lock file is missing, or it needs to be updated, cargo-upgrade will exit with \
+an error. If the '--to-lockfile' flag is supplied then the network won't be accessed.")]
     Upgrade(Args),
 }
 
 #[derive(Debug, StructOpt)]
+#[structopt(setting = AppSettings::ColoredHelp)]
 struct Args {
     /// Crates to be upgraded.
     dependency: Vec<String>,


### PR DESCRIPTION
1. Add `wrap_help` feature to clap
2. Enable `AppSettings::ColoredHelp`
3. Reorganize `after_help` messages

Before:

![image](https://user-images.githubusercontent.com/70888415/120805524-7daa6b00-c578-11eb-84dc-a76a99971033.png)

After:

![image](https://user-images.githubusercontent.com/70888415/120808161-5bfeb300-c57b-11eb-8c46-e581a0a73557.png)

There is still a line display incorrectly. That may due to some bugs of structopt or old version clap. Clap 3.0.0-beta.2 (which embeds the functionality of structopt) can display it correctly:

![image](https://user-images.githubusercontent.com/70888415/120808775-f9f27d80-c57b-11eb-9115-7228bf076374.png)
