### PR TITLE
Add short flag `-f` for `--features` and `-n` for `--no-default-features`

### DIFF
--- a/src/bin/add/args.rs
+++ b/src/bin/add/args.rs
@@ -116,11 +116,11 @@ pub struct Args {
 
     /// Space-separated list of features to add. For an alternative approach to
     /// enabling features, consider installing the `cargo-feature` utility.
-    #[structopt(long = "features", number_of_values = 1)]
+    #[structopt(long = "features", short = "f", number_of_values = 1)]
     pub features: Option<Vec<String>>,
 
     /// Set `default-features = false` for the added dependency.
-    #[structopt(long = "no-default-features")]
+    #[structopt(long = "no-default-features", short = "n")]
     pub no_default_features: bool,
 
     /// Do not print any output in case of success.


### PR DESCRIPTION
NOTE: Didn't add any new tests as this feels more like something that structopt should ensure is working (and no other short flags seem to be tested in this package anyhow).

Fixes #450
Fixes #466