### PR TITLE
chore: Upgrade cargo-metadata to 0.14

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -111,6 +111,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae44d1a3d5a19df61dd0c8beb138458ac2a53a7ac09eba97d55592540004306b"
 
 [[package]]
+name = "camino"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52d74260d9bf6944e2208aa46841b4b8f0d7ffc0849a06837b2f510337f86b2b"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "cargo-edit"
 version = "0.7.0"
 dependencies = [
@@ -125,7 +134,7 @@ dependencies = [
  "hex",
  "pretty_assertions",
  "regex",
- "semver 1.0.4",
+ "semver",
  "serde",
  "serde_derive",
  "serde_json",
@@ -150,13 +159,13 @@ dependencies = [
 
 [[package]]
 name = "cargo_metadata"
-version = "0.12.3"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7714a157da7991e23d90686b9524b9e12e0407a108647f52e9328f4b3d51ac7f"
+checksum = "c297bd3135f558552f99a0daa180876984ea2c4ffa7470314540dff8c654109a"
 dependencies = [
+ "camino",
  "cargo-platform",
- "semver 0.11.0",
- "semver-parser",
+ "semver",
  "serde",
  "serde_json",
 ]
@@ -592,15 +601,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
 
 [[package]]
-name = "pest"
-version = "2.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10f4872ae94d7b90ae48754df22fd42ad52ce740b8f370b03da4835417403e53"
-dependencies = [
- "ucd-trie",
-]
-
-[[package]]
 name = "pkg-config"
 version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -813,30 +813,11 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f301af10236f6df4160f7c3f04eec6dbc70ace82d23326abad5edee88801c6b6"
-dependencies = [
- "semver-parser",
- "serde",
-]
-
-[[package]]
-name = "semver"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "568a8e6258aa33c13358f81fd834adb854c6f7c9468520910a9b1e8fac068012"
 dependencies = [
  "serde",
-]
-
-[[package]]
-name = "semver-parser"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b0bef5b7f9e0df16536d3961cfb6e84331c065b4066afb39768d0e319411f7"
-dependencies = [
- "pest",
 ]
 
 [[package]]
@@ -1047,12 +1028,6 @@ dependencies = [
  "combine",
  "linked-hash-map",
 ]
-
-[[package]]
-name = "ucd-trie"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56dee185309b50d1f11bfedef0fe6d036842e3fb77413abef29f8f8d1c5d4c1c"
 
 [[package]]
 name = "unicode-bidi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,7 +51,7 @@ repository = "killercup/cargo-edit"
 
 [dependencies]
 atty = { version = "0.2.14", optional = true }
-cargo_metadata = "0.12.0"
+cargo_metadata = "0.14.0"
 dirs-next = "2.0.0"
 env_proxy = "0.4.1"
 error-chain = "0.12.4"

--- a/src/bin/add/main.rs
+++ b/src/bin/add/main.rs
@@ -116,7 +116,7 @@ fn is_sorted(mut it: impl Iterator<Item = impl PartialOrd>) -> bool {
 fn handle_add(args: &Args) -> Result<()> {
     let manifest_path = if let Some(ref pkgid) = args.pkgid {
         let pkg = manifest_from_pkgid(pkgid)?;
-        Cow::Owned(Some(pkg.manifest_path))
+        Cow::Owned(Some(pkg.manifest_path.into_std_path_buf()))
     } else {
         Cow::Borrowed(&args.manifest_path)
     };

--- a/src/bin/rm/main.rs
+++ b/src/bin/rm/main.rs
@@ -105,7 +105,7 @@ fn print_msg(name: &str, section: &str) -> Result<()> {
 fn handle_rm(args: &Args) -> Result<()> {
     let manifest_path = if let Some(ref pkgid) = args.pkgid {
         let pkg = manifest_from_pkgid(pkgid)?;
-        Cow::Owned(Some(pkg.manifest_path))
+        Cow::Owned(Some(pkg.manifest_path.into_std_path_buf()))
     } else {
         Cow::Borrowed(&args.manifest_path)
     };

--- a/src/bin/upgrade/main.rs
+++ b/src/bin/upgrade/main.rs
@@ -216,7 +216,7 @@ impl Manifests {
         let packages = result.packages;
         let package = packages
             .iter()
-            .find(|p| p.manifest_path.to_string_lossy() == resolved_manifest_path)
+            .find(|p| p.manifest_path == resolved_manifest_path)
             // If we have successfully got metadata, but our manifest path does not correspond to a
             // package, we must have been called against a virtual manifest.
             .chain_err(|| {


### PR DESCRIPTION
This is prep for `cargo set-version` (#338)

The biggest change with this upgrade is they switched from `std::path`
to `camino` which requires UTF-8 paths.