### PR TITLE
fix(add): Lookup dep versions *after* updating

### DIFF
--- a/src/bin/add/main.rs
+++ b/src/bin/add/main.rs
@@ -121,7 +121,6 @@ fn handle_add(args: &Args) -> Result<()> {
         Cow::Borrowed(&args.manifest_path)
     };
     let mut manifest = Manifest::open(&manifest_path)?;
-    let deps = &args.parse_dependencies()?;
 
     if !args.offline && std::env::var("CARGO_IS_TEST").is_err() {
         let url = registry_url(
@@ -130,6 +129,7 @@ fn handle_add(args: &Args) -> Result<()> {
         )?;
         update_registry_index(&url, args.quiet)?;
     }
+    let deps = &args.parse_dependencies()?;
 
     let was_sorted = manifest
         .get_table(&args.get_section())


### PR DESCRIPTION
I got a report of `cargo add inquire` not adding the latest version.
Each of us was getting a different version.  I suspect this is a bug in
the crates-index logic and want to port to `crates-index` to reduce the
chance of problems.

However, while looking at that, I found this problem.
`args.parse_dependencies` looks in the registry but we call it
**before** updating it.  This can lead us to reading stale data that, if
undid, the next call would get the latest.  So swapping the order of
operations to make sure we are reading the latest version of the index.