### PR TITLE
Fix `cargo test --release` if no debug build is present

### DIFF
--- a/tests/cargo-add.rs
+++ b/tests/cargo-add.rs
@@ -206,7 +206,7 @@ fn adds_dev_build_dependency() {
     );
 
     // cannot run with both --dev and --build at the same time
-    let call = process::Command::new(get_command_path("add").as_str())
+    let call = process::Command::new(get_command_path("add"))
         .args(&["add", BOGUS_CRATE_NAME, "--dev", "--build"])
         .arg(format!("--manifest-path={}", &manifest))
         .output()
@@ -279,7 +279,7 @@ fn adds_specified_version() {
     assert_eq!(val.as_str().expect("not string"), ">=0.1.1");
 
     // cannot run with both --dev and --build at the same time
-    let call = process::Command::new(get_command_path("add").as_str())
+    let call = process::Command::new(get_command_path("add"))
         .args(&["add", BOGUS_CRATE_NAME, "--vers", "invalid version string"])
         .arg(format!("--manifest-path={}", &manifest))
         .output()
@@ -674,7 +674,7 @@ fn adds_local_source_with_inline_version_notation() {
 fn git_and_version_flags_are_mutually_exclusive() {
     let (_tmpdir, manifest) = clone_out_test("tests/fixtures/add/Cargo.toml.sample");
 
-    let call = process::Command::new(get_command_path("add").as_str())
+    let call = process::Command::new(get_command_path("add"))
         .args(&["add", BOGUS_CRATE_NAME])
         .args(&["--vers", "0.4.3"])
         .args(&["--git", "git://git.git"])
@@ -690,7 +690,7 @@ fn git_and_version_flags_are_mutually_exclusive() {
 fn git_flag_and_inline_version_are_mutually_exclusive() {
     let (_tmpdir, manifest) = clone_out_test("tests/fixtures/add/Cargo.toml.sample");
 
-    let call = process::Command::new(get_command_path("add").as_str())
+    let call = process::Command::new(get_command_path("add"))
         .args(&["add", &format!("{}@0.4.3", BOGUS_CRATE_NAME)])
         .args(&["--git", "git://git.git"])
         .arg(format!("--manifest-path={}", &manifest))
@@ -705,7 +705,7 @@ fn git_flag_and_inline_version_are_mutually_exclusive() {
 fn git_and_path_are_mutually_exclusive() {
     let (_tmpdir, manifest) = clone_out_test("tests/fixtures/add/Cargo.toml.sample");
 
-    let call = process::Command::new(get_command_path("add").as_str())
+    let call = process::Command::new(get_command_path("add"))
         .args(&["add", BOGUS_CRATE_NAME])
         .args(&["--git", "git://git.git"])
         .args(&["--path", "/path/here"])
@@ -721,7 +721,7 @@ fn git_and_path_are_mutually_exclusive() {
 fn git_and_registry_are_mutually_exclusive() {
     let (_tmpdir, manifest) = clone_out_test("tests/fixtures/add/Cargo.toml.sample");
 
-    let call = process::Command::new(get_command_path("add").as_str())
+    let call = process::Command::new(get_command_path("add"))
         .args(&["add", BOGUS_CRATE_NAME])
         .args(&["--git", "git://git.git"])
         .args(&["--registry", "alternative"])
@@ -737,7 +737,7 @@ fn git_and_registry_are_mutually_exclusive() {
 fn registry_and_path_are_mutually_exclusive() {
     let (_tmpdir, manifest) = clone_out_test("tests/fixtures/add/Cargo.toml.sample");
 
-    let call = process::Command::new(get_command_path("add").as_str())
+    let call = process::Command::new(get_command_path("add"))
         .args(&["add", BOGUS_CRATE_NAME])
         .args(&["--registry", "alternative"])
         .args(&["--path", "/path/here"])
@@ -1039,7 +1039,7 @@ your-face = { version = "your-face--CURRENT_VERSION_TEST", features = ["mouth", 
 #[test]
 fn forbids_multiple_crates_with_features_option() {
     assert_cli::Assert::command(&[
-        get_command_path("add").as_str(),
+        get_command_path("add"),
         "add",
         "your-face",
         "--features",
@@ -1079,7 +1079,7 @@ fn adds_dependency_normalized_name() {
     assert!(toml["dependencies"].is_none());
 
     assert_cli::Assert::command(&[
-        get_command_path("add").as_str(),
+        get_command_path("add"),
         "add",
         "linked_hash_map",
         "Inflector",
@@ -1309,7 +1309,7 @@ versioned-package = "versioned-package--CURRENT_VERSION_TEST"
 
 #[test]
 fn no_argument() {
-    assert_cli::Assert::command(&[get_command_path("add").as_str(), "add"])
+    assert_cli::Assert::command(&[get_command_path("add"), "add"])
         .fails_with(1)
         .and()
         .stderr()
@@ -1325,7 +1325,7 @@ For more information try --help")
 
 #[test]
 fn unknown_flags() {
-    assert_cli::Assert::command(&[get_command_path("add").as_str(), "add", "foo", "--flag"])
+    assert_cli::Assert::command(&[get_command_path("add"), "add", "foo", "--flag"])
         .fails_with(1)
         .and()
         .stderr()
@@ -1345,7 +1345,7 @@ fn add_prints_message() {
     let (_tmpdir, manifest) = clone_out_test("tests/fixtures/add/Cargo.toml.sample");
 
     assert_cli::Assert::command(&[
-        get_command_path("add").as_str(),
+        get_command_path("add"),
         "add",
         "docopt",
         "--vers=0.6.0",
@@ -1364,7 +1364,7 @@ fn add_prints_message_with_section() {
     let (_tmpdir, manifest) = clone_out_test("tests/fixtures/add/Cargo.toml.sample");
 
     assert_cli::Assert::command(&[
-        get_command_path("add").as_str(),
+        get_command_path("add"),
         "add",
         "clap",
         "--optional",
@@ -1385,7 +1385,7 @@ fn add_prints_message_for_dev_deps() {
     let (_tmpdir, manifest) = clone_out_test("tests/fixtures/add/Cargo.toml.sample");
 
     assert_cli::Assert::command(&[
-        get_command_path("add").as_str(),
+        get_command_path("add"),
         "add",
         "docopt",
         "--dev",
@@ -1406,7 +1406,7 @@ fn add_prints_message_for_build_deps() {
     let (_tmpdir, manifest) = clone_out_test("tests/fixtures/add/Cargo.toml.sample");
 
     assert_cli::Assert::command(&[
-        get_command_path("add").as_str(),
+        get_command_path("add"),
         "add",
         "hello-world",
         "--build",
@@ -1428,7 +1428,7 @@ fn add_typo() {
     let (_tmpdir, manifest) = clone_out_test("tests/fixtures/add/Cargo.toml.sample");
 
     assert_cli::Assert::command(&[
-        get_command_path("add").as_str(),
+        get_command_path("add"),
         "add",
         "lets_hope_nobody_ever_publishes_this_crate",
         &format!("--manifest-path={}", manifest),
@@ -1534,7 +1534,7 @@ fn add_prints_message_for_features_deps() {
     let (_tmpdir, manifest) = clone_out_test("tests/fixtures/add/Cargo.toml.sample");
 
     assert_cli::Assert::command(&[
-        "target/debug/cargo-add",
+        env!("CARGO_BIN_EXE_cargo-add"),
         "add",
         "hello-world",
         "--vers",

--- a/tests/cargo-rm.rs
+++ b/tests/cargo-rm.rs
@@ -102,7 +102,7 @@ fn invalid_dependency() {
     let (_tmpdir, manifest) = clone_out_test("tests/fixtures/rm/Cargo.toml.sample");
 
     assert_cli::Assert::command(&[
-        get_command_path("rm").as_str(),
+        get_command_path("rm"),
         "rm",
         "invalid_dependency_name",
         &format!("--manifest-path={}", manifest),
@@ -123,7 +123,7 @@ fn invalid_section() {
 
     execute_command(&["rm", "semver", "--build"], &manifest);
     assert_cli::Assert::command(&[
-        get_command_path("rm").as_str(),
+        get_command_path("rm"),
         "rm",
         "semver",
         "--build",
@@ -144,7 +144,7 @@ fn invalid_dependency_in_section() {
     let (_tmpdir, manifest) = clone_out_test("tests/fixtures/rm/Cargo.toml.sample");
 
     assert_cli::Assert::command(&[
-        get_command_path("rm").as_str(),
+        get_command_path("rm"),
         "rm",
         "semver",
         "regex",
@@ -163,7 +163,7 @@ fn invalid_dependency_in_section() {
 
 #[test]
 fn no_argument() {
-    assert_cli::Assert::command(&[get_command_path("rm").as_str(), "rm"])
+    assert_cli::Assert::command(&[get_command_path("rm"), "rm"])
         .fails_with(1)
         .and()
         .stderr()
@@ -179,7 +179,7 @@ For more information try --help")
 
 #[test]
 fn unknown_flags() {
-    assert_cli::Assert::command(&[get_command_path("rm").as_str(), "rm", "foo", "--flag"])
+    assert_cli::Assert::command(&[get_command_path("rm"), "rm", "foo", "--flag"])
         .fails_with(1)
         .and()
         .stderr()
@@ -199,7 +199,7 @@ fn rm_prints_message() {
     let (_tmpdir, manifest) = clone_out_test("tests/fixtures/rm/Cargo.toml.sample");
 
     assert_cli::Assert::command(&[
-        get_command_path("rm").as_str(),
+        get_command_path("rm"),
         "rm",
         "semver",
         &format!("--manifest-path={}", manifest),
@@ -216,7 +216,7 @@ fn rm_prints_messages_for_multiple() {
     let (_tmpdir, manifest) = clone_out_test("tests/fixtures/rm/Cargo.toml.sample");
 
     assert_cli::Assert::command(&[
-        get_command_path("rm").as_str(),
+        get_command_path("rm"),
         "rm",
         "semver",
         "docopt",

--- a/tests/cargo-upgrade.rs
+++ b/tests/cargo-upgrade.rs
@@ -353,7 +353,7 @@ fn all_flag_is_deprecated() {
     let (_tmpdir, root_manifest, _workspace_manifests) = copy_workspace_test();
 
     assert_cli::Assert::command(&[
-        get_command_path("upgrade").as_str(),
+        get_command_path("upgrade"),
         "upgrade",
         "--all",
         "--manifest-path",
@@ -442,7 +442,7 @@ fn invalid_manifest() {
     let (_tmpdir, manifest) = clone_out_test("tests/fixtures/upgrade/Cargo.toml.invalid");
 
     assert_cli::Assert::command(&[
-        get_command_path("upgrade").as_str(),
+        get_command_path("upgrade"),
         "upgrade",
         "--manifest-path",
         &manifest,
@@ -469,7 +469,7 @@ fn invalid_root_manifest_all() {
     let (_tmpdir, manifest) = clone_out_test("tests/fixtures/upgrade/Cargo.toml.invalid");
 
     assert_cli::Assert::command(&[
-        get_command_path("upgrade").as_str(),
+        get_command_path("upgrade"),
         "upgrade",
         "--workspace",
         "--manifest-path",
@@ -488,7 +488,7 @@ fn invalid_root_manifest_workspace() {
     let (_tmpdir, manifest) = clone_out_test("tests/fixtures/upgrade/Cargo.toml.invalid");
 
     assert_cli::Assert::command(&[
-        get_command_path("upgrade").as_str(),
+        get_command_path("upgrade"),
         "upgrade",
         "--workspace",
         "--manifest-path",
@@ -504,25 +504,20 @@ fn invalid_root_manifest_workspace() {
 
 #[test]
 fn unknown_flags() {
-    assert_cli::Assert::command(&[
-        get_command_path("upgrade").as_str(),
-        "upgrade",
-        "foo",
-        "--flag",
-    ])
-    .with_env(&[("CARGO_IS_TEST", "1")])
-    .fails_with(1)
-    .and()
-    .stderr()
-    .is(
-        "error: Found argument '--flag' which wasn't expected, or isn't valid in this context
+    assert_cli::Assert::command(&[get_command_path("upgrade"), "upgrade", "foo", "--flag"])
+        .with_env(&[("CARGO_IS_TEST", "1")])
+        .fails_with(1)
+        .and()
+        .stderr()
+        .is(
+            "error: Found argument '--flag' which wasn't expected, or isn't valid in this context
 
 USAGE:
     cargo upgrade [FLAGS] [OPTIONS] [--] [dependency]...
 
 For more information try --help ",
-    )
-    .unwrap();
+        )
+        .unwrap();
 }
 
 // Verify that an upgraded Cargo.toml matches what we expect.
@@ -585,7 +580,7 @@ fn upgrade_prints_messages() {
     let (_tmpdir, manifest) = clone_out_test("tests/fixtures/upgrade/Cargo.toml.source");
 
     assert_cli::Assert::command(&[
-        get_command_path("upgrade").as_str(),
+        get_command_path("upgrade"),
         "upgrade",
         "docopt",
         &format!("--manifest-path={}", manifest),

--- a/tests/test_manifest.rs
+++ b/tests/test_manifest.rs
@@ -4,7 +4,7 @@ use crate::utils::get_command_path;
 #[test]
 fn invalid_manifest() {
     assert_cli::Assert::command(&[
-        get_command_path("add").as_str(),
+        get_command_path("add"),
         "add",
         "foo",
         "--manifest-path=tests/fixtures/manifest-invalid/Cargo.toml.sample",

--- a/tests/utils.rs
+++ b/tests/utils.rs
@@ -189,21 +189,11 @@ pub fn get_toml(manifest_path: &str) -> toml_edit::Document {
     s.parse().expect("toml parse error")
 }
 
-pub fn get_command_path(s: impl AsRef<OsStr>) -> String {
-    let target_dir: PathBuf = match env::var_os("CARGO_TARGET_DIR") {
-        Some(dir) => dir.into(),
-        None => env::current_dir()
-            .expect("Failed to get current dir")
-            .join("target"),
-    };
-
-    let mut binary_name = OsString::from("cargo-");
-    binary_name.push(s.as_ref());
-
-    target_dir
-        .join("debug")
-        .join(binary_name)
-        .to_str()
-        .unwrap()
-        .to_string()
+pub fn get_command_path(s: impl AsRef<OsStr>) -> &'static str {
+    match s.as_ref().to_str() {
+        Some("add") => env!("CARGO_BIN_EXE_cargo-add"),
+        Some("rm") => env!("CARGO_BIN_EXE_cargo-rm"),
+        Some("upgrade") => env!("CARGO_BIN_EXE_cargo-upgrade"),
+        _ => panic!("Unsupported subcommand"),
+    }
 }


### PR DESCRIPTION
This automatically picks `target/release/` or `target/debug/`, depending on how `cargo test` was executed.

This is helpful for packaging because currently all dependencies need to be built a second time when executing tests.

`CARGO_BIN_EXE_` was introduced in rustc 1.43.0.