### PR TITLE
refactor: Exclusively switch to LocalManifest

### DIFF
--- a/src/bin/add/main.rs
+++ b/src/bin/add/main.rs
@@ -16,7 +16,7 @@ extern crate error_chain;
 
 use crate::args::{Args, Command};
 use cargo_edit::{
-    find, manifest_from_pkgid, registry_url, update_registry_index, Dependency, Manifest,
+    find, manifest_from_pkgid, registry_url, update_registry_index, Dependency, LocalManifest,
 };
 use std::borrow::Cow;
 use std::io::Write;
@@ -120,7 +120,7 @@ fn handle_add(args: &Args) -> Result<()> {
     } else {
         Cow::Borrowed(&args.manifest_path)
     };
-    let mut manifest = Manifest::open(&manifest_path)?;
+    let mut manifest = LocalManifest::find(&manifest_path)?;
 
     if !args.offline && std::env::var("CARGO_IS_TEST").is_err() {
         let url = registry_url(
@@ -164,8 +164,7 @@ fn handle_add(args: &Args) -> Result<()> {
             err
         })?;
 
-    let mut file = Manifest::find_file(&manifest_path)?;
-    manifest.write_to_file(&mut file)?;
+    manifest.write()?;
 
     Ok(())
 }

--- a/src/bin/rm/main.rs
+++ b/src/bin/rm/main.rs
@@ -14,7 +14,7 @@
 #[macro_use]
 extern crate error_chain;
 
-use cargo_edit::{manifest_from_pkgid, Manifest};
+use cargo_edit::{manifest_from_pkgid, LocalManifest};
 use std::borrow::Cow;
 use std::io::Write;
 use std::path::PathBuf;
@@ -109,7 +109,7 @@ fn handle_rm(args: &Args) -> Result<()> {
     } else {
         Cow::Borrowed(&args.manifest_path)
     };
-    let mut manifest = Manifest::open(&manifest_path)?;
+    let mut manifest = LocalManifest::find(&manifest_path)?;
     let deps = &args.crates;
 
     deps.iter()
@@ -127,8 +127,7 @@ fn handle_rm(args: &Args) -> Result<()> {
             err
         })?;
 
-    let mut file = Manifest::find_file(&manifest_path)?;
-    manifest.write_to_file(&mut file)?;
+    manifest.write()?;
 
     Ok(())
 }

--- a/src/fetch.rs
+++ b/src/fetch.rs
@@ -1,7 +1,7 @@
 use crate::errors::*;
 use crate::registry::registry_url;
 use crate::VersionExt;
-use crate::{Dependency, Manifest};
+use crate::{Dependency, LocalManifest, Manifest};
 use regex::Regex;
 use std::env;
 use std::io::Write;
@@ -327,7 +327,7 @@ pub fn get_crate_name_from_gitlab(repo: &str) -> Result<String> {
 /// Cargo.toml is not present in the root of the path.
 pub fn get_crate_name_from_path(path: &str) -> Result<String> {
     let cargo_file = Path::new(path).join("Cargo.toml");
-    Manifest::open(&Some(cargo_file))
+    LocalManifest::try_new(&cargo_file)
         .chain_err(|| "Unable to open local Cargo.toml")
         .and_then(|ref manifest| get_name_from_manifest(manifest))
 }


### PR DESCRIPTION
For local content.  This is prep for fixing some bugs with workspaces
where `Dependency` has a path relative from the wrong location.  My plan
to fix it so for `Depednency` to have an absolute path.  Creating and
serializing `Dependency` will then require knowing what the path is for
the relevant manifest so we can handle converting the path.