### PR TITLE
fix(add): Form correct path dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -159,6 +159,7 @@ dependencies = [
  "failure",
  "git2",
  "hex",
+ "pathdiff",
  "predicates",
  "pretty_assertions",
  "regex",
@@ -716,6 +717,12 @@ checksum = "53cdc5b785b7a58c5aad8216b3dfa114df64b0b06ae6e1501cef91df2fbdf8f9"
 dependencies = [
  "winapi 0.3.9",
 ]
+
+[[package]]
+name = "pathdiff"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877630b3de15c0b64cc52f659345724fbf6bdad9bd9566699fc53688f3c34a34"
 
 [[package]]
 name = "percent-encoding"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,6 +68,7 @@ termcolor = "1.1.0"
 toml_edit = { version = "0.3.1", features = ["easy"] }
 url = "2.1.1"
 ureq = { version = "1.5.1", default-features = false, features = ["tls", "json", "socks"] }
+pathdiff = "0.2"
 
 [dependencies.semver]
 features = ["serde"]

--- a/src/bin/add/args.rs
+++ b/src/bin/add/args.rs
@@ -180,7 +180,7 @@ impl Args {
             }
 
             if let Some(ref path) = self.path {
-                dependency = dependency.set_path(path.to_str().unwrap());
+                dependency = dependency.set_path(path.canonicalize()?);
             }
 
             Ok(dependency)
@@ -198,7 +198,7 @@ impl Args {
                 dependency = dependency.set_git(repo, self.branch.clone());
             }
             if let Some(path) = &self.path {
-                dependency = dependency.set_path(path.to_str().unwrap());
+                dependency = dependency.set_path(path.canonicalize()?);
             }
             if let Some(version) = &self.vers {
                 dependency = dependency.set_version(parse_version_req(version)?);
@@ -352,14 +352,15 @@ mod tests {
 
     #[test]
     fn test_path_as_arg_parsing() {
-        let self_path = ".";
+        let self_path = std::env::current_dir().unwrap().canonicalize().unwrap();
         let args_path = Args {
-            crates: vec![self_path.to_owned()],
+            // Hacky to `display` but should generally work
+            crates: vec![self_path.display().to_string()],
             ..Args::default()
         };
         assert_eq!(
             args_path.parse_dependencies().unwrap(),
-            vec![Dependency::new("cargo-edit").set_path(self_path)]
+            vec![Dependency::new("cargo-edit").set_path(std::path::PathBuf::from(self_path))]
         );
     }
 }

--- a/src/crate_name.rs
+++ b/src/crate_name.rs
@@ -68,7 +68,8 @@ impl<'a> CrateName<'a> {
             }
         } else if self.is_path() {
             if let Ok(ref crate_name) = get_crate_name_from_path(self.0) {
-                return Ok(Dependency::new(crate_name).set_path(self.0));
+                let path = std::path::Path::new(self.0).canonicalize()?;
+                return Ok(Dependency::new(crate_name).set_path(path));
             }
         }
 

--- a/src/dependency.rs
+++ b/src/dependency.rs
@@ -1,8 +1,10 @@
+use std::path::{Path, PathBuf};
+
 #[derive(Debug, Hash, PartialEq, Eq, Clone)]
 enum DependencySource {
     Version {
         version: Option<String>,
-        path: Option<String>,
+        path: Option<PathBuf>,
         registry: Option<String>,
     },
     Git {
@@ -80,14 +82,23 @@ impl Dependency {
     }
 
     /// Set dependency to a given path
-    pub fn set_path(mut self, path: &str) -> Dependency {
+    ///
+    /// # Panic
+    ///
+    /// Panics if the path is relative
+    pub fn set_path(mut self, path: PathBuf) -> Dependency {
+        assert!(
+            path.is_absolute(),
+            "Absolute path needed, got: {}",
+            path.display()
+        );
         let old_version = match self.source {
             DependencySource::Version { version, .. } => version,
             _ => None,
         };
         self.source = DependencySource::Version {
             version: old_version,
-            path: Some(path.replace('\\', "/")),
+            path: Some(path),
             registry: None,
         };
         self
@@ -167,7 +178,16 @@ impl Dependency {
     /// or the path/git repository as an `InlineTable`.
     /// (If the dependency is set as `optional` or `default-features` is set to `false`,
     /// an `InlineTable` is returned in any case.)
-    pub fn to_toml(&self) -> (String, toml_edit::Item) {
+    ///
+    /// # Panic
+    ///
+    /// Panics if the path is relative
+    pub fn to_toml(&self, crate_root: &Path) -> (String, toml_edit::Item) {
+        assert!(
+            crate_root.is_absolute(),
+            "Absolute path needed, got: {}",
+            crate_root.display()
+        );
         let data: toml_edit::Item = match (
             self.optional,
             self.features.as_ref(),
@@ -201,7 +221,10 @@ impl Dependency {
                             data.get_or_insert("version", v);
                         }
                         if let Some(p) = path {
-                            data.get_or_insert("path", p);
+                            let relpath = pathdiff::diff_paths(p, crate_root)
+                                .expect("both paths are absolute");
+                            let relpath = relpath.to_str().unwrap().replace('\\', "/");
+                            data.get_or_insert("path", relpath);
                         }
                         if let Some(r) = registry {
                             data.get_or_insert("registry", r);
@@ -238,17 +261,22 @@ impl Dependency {
 #[cfg(test)]
 mod tests {
     use crate::dependency::Dependency;
+    use std::path::{Path, PathBuf};
 
     #[test]
     fn to_toml_simple_dep() {
-        let toml = Dependency::new("dep").to_toml();
+        let crate_root = Path::new("/").canonicalize().expect("root exists");
+        let toml = Dependency::new("dep").to_toml(&crate_root);
 
         assert_eq!(toml.0, "dep".to_owned());
     }
 
     #[test]
     fn to_toml_simple_dep_with_version() {
-        let toml = Dependency::new("dep").set_version("1.0").to_toml();
+        let crate_root = Path::new("/").canonicalize().expect("root exists");
+        let toml = Dependency::new("dep")
+            .set_version("1.0")
+            .to_toml(&crate_root);
 
         assert_eq!(toml.0, "dep".to_owned());
         assert_eq!(toml.1.as_str(), Some("1.0"));
@@ -256,7 +284,10 @@ mod tests {
 
     #[test]
     fn to_toml_optional_dep() {
-        let toml = Dependency::new("dep").set_optional(true).to_toml();
+        let crate_root = Path::new("/").canonicalize().expect("root exists");
+        let toml = Dependency::new("dep")
+            .set_optional(true)
+            .to_toml(&crate_root);
 
         assert_eq!(toml.0, "dep".to_owned());
         assert!(toml.1.is_inline_table());
@@ -267,7 +298,10 @@ mod tests {
 
     #[test]
     fn to_toml_dep_without_default_features() {
-        let toml = Dependency::new("dep").set_default_features(false).to_toml();
+        let crate_root = Path::new("/").canonicalize().expect("root exists");
+        let toml = Dependency::new("dep")
+            .set_default_features(false)
+            .to_toml(&crate_root);
 
         assert_eq!(toml.0, "dep".to_owned());
         assert!(toml.1.is_inline_table());
@@ -278,20 +312,25 @@ mod tests {
 
     #[test]
     fn to_toml_dep_with_path_source() {
-        let toml = Dependency::new("dep").set_path("~/foo/bar").to_toml();
+        let root = Path::new("/").canonicalize().expect("root exists");
+        let crate_root = root.join("foo");
+        let toml = Dependency::new("dep")
+            .set_path(root.join("bar"))
+            .to_toml(&crate_root);
 
         assert_eq!(toml.0, "dep".to_owned());
         assert!(toml.1.is_inline_table());
 
         let dep = toml.1.as_inline_table().unwrap();
-        assert_eq!(dep.get("path").unwrap().as_str(), Some("~/foo/bar"));
+        assert_eq!(dep.get("path").unwrap().as_str(), Some("../bar"));
     }
 
     #[test]
     fn to_toml_dep_with_git_source() {
+        let crate_root = Path::new("/").canonicalize().expect("root exists");
         let toml = Dependency::new("dep")
             .set_git("https://foor/bar.git", None)
-            .to_toml();
+            .to_toml(&crate_root);
 
         assert_eq!(toml.0, "dep".to_owned());
         assert!(toml.1.is_inline_table());
@@ -305,7 +344,8 @@ mod tests {
 
     #[test]
     fn to_toml_renamed_dep() {
-        let toml = Dependency::new("dep").set_rename("d").to_toml();
+        let crate_root = Path::new("/").canonicalize().expect("root exists");
+        let toml = Dependency::new("dep").set_rename("d").to_toml(&crate_root);
 
         assert_eq!(toml.0, "d".to_owned());
         assert!(toml.1.is_inline_table());
@@ -316,7 +356,10 @@ mod tests {
 
     #[test]
     fn to_toml_dep_from_alt_registry() {
-        let toml = Dependency::new("dep").set_registry("alternative").to_toml();
+        let crate_root = Path::new("/").canonicalize().expect("root exists");
+        let toml = Dependency::new("dep")
+            .set_registry("alternative")
+            .to_toml(&crate_root);
 
         assert_eq!(toml.0, "dep".to_owned());
         assert!(toml.1.is_inline_table());
@@ -327,11 +370,12 @@ mod tests {
 
     #[test]
     fn to_toml_complex_dep() {
+        let crate_root = Path::new("/").canonicalize().expect("root exists");
         let toml = Dependency::new("dep")
             .set_version("1.0")
             .set_default_features(false)
             .set_rename("d")
-            .to_toml();
+            .to_toml(&crate_root);
 
         assert_eq!(toml.0, "d".to_owned());
         assert!(toml.1.is_inline_table());
@@ -344,23 +388,27 @@ mod tests {
 
     #[test]
     fn paths_with_forward_slashes_are_left_as_is() {
-        let path = "../sibling/crate";
+        let crate_root = Path::new("/").canonicalize().expect("root exists");
+        let path = crate_root.join("sibling/crate");
+        let relpath = "sibling/crate";
         let dep = Dependency::new("dep").set_path(path);
 
-        let (_, toml) = dep.to_toml();
+        let (_, toml) = dep.to_toml(&crate_root);
 
         let table = toml.as_inline_table().unwrap();
         let got = table.get("path").unwrap().as_str().unwrap();
-        assert_eq!(got, path);
+        assert_eq!(got, relpath);
     }
 
     #[test]
+    #[cfg(windows)]
     fn normalise_windows_style_paths() {
-        let original = r"..\sibling\crate";
-        let should_be = "../sibling/crate";
+        let crate_root = Path::new("/").canonicalize().expect("root exists");
+        let original = crate_root.join(r"sibling\crate");
+        let should_be = "sibling/crate";
         let dep = Dependency::new("dep").set_path(original);
 
-        let (_, toml) = dep.to_toml();
+        let (_, toml) = dep.to_toml(&crate_root);
 
         let table = toml.as_inline_table().unwrap();
         let got = table.get("path").unwrap().as_str().unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,5 @@
 //! Show and Edit Cargo's Manifest Files
-#![recursion_limit = "128"]
+#![recursion_limit = "256"]
 #![cfg_attr(test, allow(dead_code))]
 #![warn(
     missing_docs,

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -66,10 +66,8 @@ fn str_or_1_len_table(item: &toml_edit::Item) -> bool {
 }
 /// Merge a new dependency into an old entry. See `Dependency::to_toml` for what the format of the
 /// new dependency will be.
-fn merge_dependencies(old_dep: &mut toml_edit::Item, new: &Dependency) {
+fn merge_dependencies(old_dep: &mut toml_edit::Item, new_toml: toml_edit::Item) {
     assert!(!old_dep.is_none());
-
-    let new_toml = new.to_toml().1;
 
     if str_or_1_len_table(old_dep) {
         // The old dependency is just a version/git/path. We are safe to overwrite.
@@ -272,7 +270,7 @@ impl LocalManifest {
     /// Construct a `LocalManifest`. If no path is provided, make an educated guess as to which one
     /// the user means.
     pub fn find(path: &Option<PathBuf>) -> Result<Self> {
-        let path = find(path)?;
+        let path = find(path)?.canonicalize()?;
         Self::try_new(&path)
     }
 
@@ -335,10 +333,12 @@ impl LocalManifest {
 
     /// Add entry to a Cargo.toml.
     pub fn insert_into_table(&mut self, table_path: &[String], dep: &Dependency) -> Result<()> {
-        let table = self.get_table(table_path)?;
+        let (dep_key, new_dependency) =
+            dep.to_toml(self.path.parent().expect("manifest path is absolute"));
 
+        let table = self.get_table(table_path)?;
         let existing_dep = Self::find_dep(table, &dep.name);
-        if let Some((mut dep_name, dep_item)) = existing_dep {
+        if let Some((old_dep_key, dep_item)) = existing_dep {
             // update an existing entry
 
             // if the `dep` is renamed in the `add` command,
@@ -350,9 +350,8 @@ impl LocalManifest {
             // alias = { version = "0.2", package = "a" }
             if let Some(renamed) = dep.rename() {
                 table[renamed] = dep_item.clone();
-                table[&dep_name] = toml_edit::Item::None;
-                dep_name = renamed.to_owned();
-            } else if dep.name != dep_name {
+                table[&old_dep_key] = toml_edit::Item::None;
+            } else if dep_key != old_dep_key {
                 // if `dep` had been renamed in the manifest,
                 // and is not rename in the `add` command,
                 // we need to remove the old entry and insert a new one
@@ -360,20 +359,18 @@ impl LocalManifest {
                 // alias = { version = "0.1", package = "a" }
                 // to
                 // a = "0.2"
-                table[&dep_name] = toml_edit::Item::None;
-                let (ref name, ref mut new_dependency) = dep.to_toml();
-                table[name] = new_dependency.clone();
-                dep_name = dep.name.to_owned();
+                table[&old_dep_key] = toml_edit::Item::None;
+                table[&dep_key] = new_dependency.clone();
             }
-            merge_dependencies(&mut table[dep_name], dep);
+            merge_dependencies(&mut table[&dep_key], new_dependency);
             if let Some(t) = table.as_inline_table_mut() {
                 t.fmt()
             }
         } else {
             // insert a new entry
-            let (ref name, ref mut new_dependency) = dep.to_toml();
-            table[name] = new_dependency.clone();
+            table[dep_key] = new_dependency;
         }
+
         Ok(())
     }
 
@@ -391,20 +388,23 @@ impl LocalManifest {
     pub fn update_table_named_entry(
         &mut self,
         table_path: &[String],
-        item_name: &str,
+        dep_key: &str,
         dep: &Dependency,
         dry_run: bool,
     ) -> Result<()> {
+        let (_dep_key, new_dependency) =
+            dep.to_toml(self.path.parent().expect("manifest path is absolute"));
+
         let table = self.get_table(table_path)?;
-        let new_dep = dep.to_toml().1;
 
         // If (and only if) there is an old entry, merge the new one in.
-        if !table[item_name].is_none() {
-            if let Err(e) = print_upgrade_if_necessary(&dep.name, &table[item_name], &new_dep) {
+        if !table[dep_key].is_none() {
+            if let Err(e) = print_upgrade_if_necessary(&dep.name, &table[dep_key], &new_dependency)
+            {
                 eprintln!("Error while displaying upgrade message, {}", e);
             }
             if !dry_run {
-                merge_dependencies(&mut table[item_name], dep);
+                merge_dependencies(&mut table[dep_key], new_dependency);
                 if let Some(t) = table.as_inline_table_mut() {
                     t.fmt()
                 }
@@ -422,7 +422,8 @@ impl LocalManifest {
     ///   use cargo_edit::{Dependency, LocalManifest, Manifest};
     ///   use toml_edit;
     ///
-    ///   let path = std::path::PathBuf::from("/Cargo.toml");
+    ///   let root = std::path::PathBuf::from("/").canonicalize().unwrap();
+    ///   let path = root.join("Cargo.toml");
     ///   let mut manifest = LocalManifest { path, manifest: Manifest { data: toml_edit::Document::new() } };
     ///   let dep = Dependency::new("cargo-edit").set_version("0.1.0");
     ///   let _ = manifest.insert_into_table(&vec!["dependencies".to_owned()], &dep);
@@ -500,8 +501,9 @@ mod tests {
 
     #[test]
     fn add_remove_dependency() {
+        let root = Path::new("/").canonicalize().expect("root exists");
         let mut manifest = LocalManifest {
-            path: PathBuf::from("/Cargo.toml"),
+            path: root.join("Cargo.toml"),
             manifest: Manifest {
                 data: toml_edit::Document::new(),
             },
@@ -517,8 +519,9 @@ mod tests {
 
     #[test]
     fn update_dependency() {
+        let root = Path::new("/").canonicalize().expect("root exists");
         let mut manifest = LocalManifest {
-            path: PathBuf::from("/Cargo.toml"),
+            path: root.join("Cargo.toml"),
             manifest: Manifest {
                 data: toml_edit::Document::new(),
             },
@@ -536,8 +539,9 @@ mod tests {
 
     #[test]
     fn update_wrong_dependency() {
+        let root = Path::new("/").canonicalize().expect("root exists");
         let mut manifest = LocalManifest {
-            path: PathBuf::from("/Cargo.toml"),
+            path: root.join("Cargo.toml"),
             manifest: Manifest {
                 data: toml_edit::Document::new(),
             },
@@ -558,8 +562,9 @@ mod tests {
 
     #[test]
     fn remove_dependency_no_section() {
+        let root = Path::new("/").canonicalize().expect("root exists");
         let mut manifest = LocalManifest {
-            path: PathBuf::from("/Cargo.toml"),
+            path: root.join("Cargo.toml"),
             manifest: Manifest {
                 data: toml_edit::Document::new(),
             },
@@ -572,8 +577,9 @@ mod tests {
 
     #[test]
     fn remove_dependency_non_existent() {
+        let root = Path::new("/").canonicalize().expect("root exists");
         let mut manifest = LocalManifest {
-            path: PathBuf::from("/Cargo.toml"),
+            path: root.join("Cargo.toml"),
             manifest: Manifest {
                 data: toml_edit::Document::new(),
             },
@@ -604,8 +610,9 @@ edition = "2015"
 
 [dependencies]
 "#;
+        let root = Path::new("/").canonicalize().expect("root exists");
         let mut manifest = LocalManifest {
-            path: PathBuf::from("/Cargo.toml"),
+            path: root.join("Cargo.toml"),
             manifest: original.parse::<Manifest>().unwrap(),
         };
         manifest.set_package_version(&semver::Version::parse("2.0.0").unwrap());

--- a/tests/utils.rs
+++ b/tests/utils.rs
@@ -103,7 +103,7 @@ where
     let subcommand_name = format!("cargo-{}", command[0].as_ref().to_str().unwrap());
     let cwd = cwd.as_ref();
 
-    let call = Command::cargo_bin(&subcommand_name)
+    let assert = Command::cargo_bin(&subcommand_name)
         .expect("can find bin")
         .args(command)
         .arg("--package")
@@ -112,22 +112,26 @@ where
         .env("CARGO_IS_TEST", "1")
         .assert()
         .success();
+    println!("Succeeded: {}", assert);
 }
 
 /// Execute local cargo command, includes `--manifest-path`
-pub fn execute_command<S>(command: &[S], manifest: &str)
+pub fn execute_command<S, P>(command: &[S], manifest: P)
 where
     S: AsRef<OsStr>,
+    P: AsRef<Path>,
 {
     let subcommand_name = format!("cargo-{}", command[0].as_ref().to_str().unwrap());
 
-    let call = Command::cargo_bin(&subcommand_name)
+    let assert = Command::cargo_bin(&subcommand_name)
         .expect("can find bin")
         .args(command)
-        .arg(format!("--manifest-path={}", manifest))
+        .arg("--manifest-path")
+        .arg(manifest.as_ref())
         .env("CARGO_IS_TEST", "1")
         .assert()
         .success();
+    println!("Succeeded: {}", assert);
 }
 
 /// Execute local cargo command in a given directory


### PR DESCRIPTION
We originally treated `--path` as relative to each crate being added
instead of relative to the current working directory.  This caused users
confusion and doesn't work with tab completion.

Now, we'll treat the relative path as if its relative to the current
working directory, adapting it for each crate root.

I went back and forth on how to handle the tests.  Existing tests rely
on reusable fixtures, backed by files with functions to set them up.  I
considered updating the functions to produce fixtures needed for the new
local file requirements (paths exist) or to create new functions.  In
the end, I went with customizing it per function.  This made it so
assumptions in the test are contained within the test (e.g. dependency
name) rather than being split in separate areas.  It also made it easy
to customize the behavior, like adding version metadata for one test but
not others.

Mac and Windows also added difficulty in updating tests and required all
test inputs to be canonicalized.

Fixes #477
Fixes #453

BREAKING CHANGE: We now treat `<path>` in `cargo add --path <path>`  as relative to CWD instead of relative to the root of the crate being edited.