### PR TITLE
rm should drop associated features

### DIFF
--- a/src/bin/rm/main.rs
+++ b/src/bin/rm/main.rs
@@ -172,10 +172,8 @@ fn remove_feature_activation(feature_activations: &mut toml_edit::Array, dep: &s
         .enumerate()
         .filter_map(|(idx, feature_activation)| {
             if let toml_edit::Value::String(feature_activation) = feature_activation {
-                feature_activation
-                    .value()
-                    .starts_with(dep_feature)
-                    .then(|| idx)
+                let activation = feature_activation.value();
+                (activation == dep || activation.starts_with(dep_feature)).then(|| idx)
             } else {
                 None
             }

--- a/tests/cargo-rm.rs
+++ b/tests/cargo-rm.rs
@@ -20,6 +20,21 @@ fn remove_existing_dependency() {
 }
 
 #[test]
+fn remove_existing_optional_dependency() {
+    let (_tmpdir, manifest) = clone_out_test("tests/fixtures/rm/Cargo.toml.sample");
+
+    let toml = get_toml(&manifest);
+    assert!(!toml["dependencies"]["clippy"].is_none());
+    assert_eq!(toml["features"]["annoy"].as_array().unwrap().len(), 1);
+
+    execute_command(&["rm", "clippy"], &manifest);
+    let toml = get_toml(&manifest);
+    assert!(toml["dependencies"]["clippy"].is_none());
+    // Also check that exact match feature activations are removed:
+    assert_eq!(toml["features"]["annoy"].as_array().unwrap().len(), 0);
+}
+
+#[test]
 fn remove_multiple_existing_dependencies() {
     let (_tmpdir, manifest) = clone_out_test("tests/fixtures/rm/Cargo.toml.sample");
 

--- a/tests/cargo-rm.rs
+++ b/tests/cargo-rm.rs
@@ -14,6 +14,9 @@ fn remove_existing_dependency() {
     execute_command(&["rm", "docopt"], &manifest);
     let toml = get_toml(&manifest);
     assert!(toml["dependencies"]["docopt"].is_none());
+
+    // Activated features should not be changed:
+    assert_eq!(toml["features"]["std"].as_array().unwrap().len(), 2);
 }
 
 #[test]
@@ -27,6 +30,15 @@ fn remove_multiple_existing_dependencies() {
     let toml = get_toml(&manifest);
     assert!(toml["dependencies"]["docopt"].is_none());
     assert!(toml["dependencies"]["semver"].is_none());
+
+    // "semver/std" activated feature should NOT have been dropped as
+    // there's still a build-dep on the crate:
+    assert_eq!(toml["features"]["std"].as_array().unwrap().len(), 2);
+
+    // Let's remove the last semver dependency and expect the associated feature to be dropped.
+    execute_command(&["rm", "--build", "semver"], &manifest);
+    let toml = get_toml(&manifest);
+    assert_eq!(toml["features"]["std"].as_array().unwrap().len(), 1);
 }
 
 #[test]

--- a/tests/fixtures/rm/Cargo.toml.sample
+++ b/tests/fixtures/rm/Cargo.toml.sample
@@ -20,3 +20,6 @@ clippy = {git = "https://github.com/Manishearth/rust-clippy.git", optional = tru
 [dev-dependencies]
 regex = "0.1.41"
 serde = "1.0.90"
+
+[features]
+std = ["serde/std", "semver/std"]

--- a/tests/fixtures/rm/Cargo.toml.sample
+++ b/tests/fixtures/rm/Cargo.toml.sample
@@ -23,3 +23,4 @@ serde = "1.0.90"
 
 [features]
 std = ["serde/std", "semver/std"]
+annoy = ["clippy"]


### PR DESCRIPTION
(if no more crate references)

Fixes: #490

E.g. running the below on cargo-edit would then mean that cargo would complain that the git2 features ( `"git2/vendored-openssl"` ) couldn't be found:
```
cargo run --bin cargo-rm -- rm git2
```
After this PR, cargo would consider the Cargo.toml to be valid and rustc would legitimately complain that it could not find crate git2 (which makes perfect sense).

(An aside: The why: this change helps tools like udeps and undepend find and remove unused dependencies more successfully).