### PR TITLE
fix(add): Prevent adding `.`

### DIFF
--- a/src/dependency.rs
+++ b/src/dependency.rs
@@ -167,6 +167,19 @@ impl Dependency {
         }
     }
 
+    /// Get the path of the dependency
+    pub fn path(&self) -> Option<&Path> {
+        if let DependencySource::Version {
+            path: Some(ref path),
+            ..
+        } = self.source
+        {
+            Some(path.as_path())
+        } else {
+            None
+        }
+    }
+
     /// Get the alias for the dependency (if any)
     pub fn rename(&self) -> Option<&str> {
         self.rename.as_deref()
@@ -261,7 +274,7 @@ impl Dependency {
 #[cfg(test)]
 mod tests {
     use crate::dependency::Dependency;
-    use std::path::{Path, PathBuf};
+    use std::path::Path;
 
     #[test]
     fn to_toml_simple_dep() {

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -159,6 +159,15 @@ fn print_upgrade_if_necessary(
 }
 
 impl Manifest {
+    /// Get the manifest's package name
+    pub fn package_name(&self) -> Result<&str> {
+        self.data
+            .as_table()
+            .get("package")
+            .and_then(|m| m["name"].as_str())
+            .ok_or_else(|| ErrorKind::ParseCargoToml.into())
+    }
+
     /// Get the specified table from the manifest.
     pub fn get_table<'a>(&'a mut self, table_path: &[String]) -> Result<&'a mut toml_edit::Item> {
         /// Descend into a manifest until the required table is found.

--- a/tests/cargo-add.rs
+++ b/tests/cargo-add.rs
@@ -906,6 +906,24 @@ cargo-list-test-fixture-dependency = { version = "0.4.3", path = "../dependency"
 }
 
 #[test]
+fn local_path_is_self() {
+    let (tmpdir, manifest) = clone_out_test("tests/fixtures/add/Cargo.toml.sample");
+
+    let assert = Command::cargo_bin("cargo-add")
+        .expect("can find bin")
+        .args(&["add", BOGUS_CRATE_NAME])
+        .args(&["--path", "."])
+        .arg(format!("--manifest-path={}", &manifest))
+        .env("CARGO_IS_TEST", "1")
+        .current_dir(tmpdir.path())
+        .assert()
+        .failure();
+    println!("Succeeded: {}", assert);
+
+    assert!(no_manifest_failures(&get_toml(&manifest).root));
+}
+
+#[test]
 fn git_and_version_flags_are_mutually_exclusive() {
     let (_tmpdir, manifest) = clone_out_test("tests/fixtures/add/Cargo.toml.sample");
 


### PR DESCRIPTION
With #497, we can now detect when adding a crate to itself, with any
path, and error out.

Fixes #455