### PR TITLE
refactor(test): Use valid test versions

### DIFF
--- a/src/fetch.rs
+++ b/src/fetch.rs
@@ -37,12 +37,12 @@ pub fn get_latest_dependency(
         // We are in a simulated reality. Nothing is real here.
         // FIXME: Use actual test handling code.
         let new_version = if flag_allow_prerelease {
-            format!("{}--PRERELEASE_VERSION_TEST", crate_name)
+            format!("99999.0.0-alpha.1+{}", crate_name)
         } else {
             match crate_name {
                 "test_breaking" => "0.2.0".to_string(),
                 "test_nonbreaking" => "0.1.1".to_string(),
-                other => format!("{}--CURRENT_VERSION_TEST", other),
+                other => format!("99999.0.0+{}", other),
             }
         };
 

--- a/tests/cargo-add.rs
+++ b/tests/cargo-add.rs
@@ -36,7 +36,7 @@ fn adds_dependency() {
     // dependency present afterwards
     let toml = get_toml(&manifest);
     let val = &toml["dependencies"]["my-package"];
-    assert_eq!(val.as_str().unwrap(), "my-package--CURRENT_VERSION_TEST");
+    assert_eq!(val.as_str().unwrap(), "99999.0.0");
 }
 
 #[test]
@@ -52,7 +52,7 @@ fn adds_prerelease_dependency() {
     // dependency present afterwards
     let toml = get_toml(&manifest);
     let val = &toml["dependencies"]["my-package"];
-    assert_eq!(val.as_str().unwrap(), "my-package--PRERELEASE_VERSION_TEST");
+    assert_eq!(val.as_str().unwrap(), "99999.0.0-alpha.1");
 }
 
 fn upgrade_test_helper(upgrade_method: &str, expected_prefix: &str) {
@@ -70,7 +70,7 @@ fn upgrade_test_helper(upgrade_method: &str, expected_prefix: &str) {
     let toml = get_toml(&manifest);
     let val = &toml["dependencies"]["my-package"];
 
-    let expected_result = format!("{0}my-package--CURRENT_VERSION_TEST", expected_prefix);
+    let expected_result = format!("{}99999.0.0", expected_prefix);
     assert_eq!(val.as_str().unwrap(), expected_result);
 }
 
@@ -116,9 +116,9 @@ fn adds_multiple_dependencies() {
     // dependencies present afterwards
     let toml = get_toml(&manifest);
     let val = &toml["dependencies"]["my-package1"];
-    assert_eq!(val.as_str().unwrap(), "my-package1--CURRENT_VERSION_TEST");
+    assert_eq!(val.as_str().unwrap(), "99999.0.0");
     let val = &toml["dependencies"]["my-package2"];
-    assert_eq!(val.as_str().unwrap(), "my-package2--CURRENT_VERSION_TEST");
+    assert_eq!(val.as_str().unwrap(), "99999.0.0");
 }
 
 #[test]
@@ -134,10 +134,7 @@ fn adds_renamed_dependency() {
     // dependency present afterwards
     let toml = get_toml(&manifest);
     let renamed = &toml["dependencies"]["renamed"];
-    assert_eq!(
-        renamed["version"].as_str().unwrap(),
-        "my-package1--CURRENT_VERSION_TEST"
-    );
+    assert_eq!(renamed["version"].as_str().unwrap(), "99999.0.0");
     assert_eq!(renamed["package"].as_str().unwrap(), "my-package1");
 }
 
@@ -198,15 +195,9 @@ fn adds_dev_build_dependency() {
     // dependency present afterwards
     let toml = get_toml(&manifest);
     let val = &toml["dev-dependencies"]["my-dev-package"];
-    assert_eq!(
-        val.as_str().unwrap(),
-        "my-dev-package--CURRENT_VERSION_TEST"
-    );
+    assert_eq!(val.as_str().unwrap(), "99999.0.0");
     let val = &toml["build-dependencies"]["my-build-package"];
-    assert_eq!(
-        val.as_str().unwrap(),
-        "my-build-package--CURRENT_VERSION_TEST"
-    );
+    assert_eq!(val.as_str().unwrap(), "99999.0.0");
 
     // cannot run with both --dev and --build at the same time
     let call = Command::cargo_bin("cargo-add")
@@ -244,25 +235,13 @@ fn adds_multiple_dev_build_dependencies() {
     // dependencies present afterwards
     let toml = get_toml(&manifest);
     let val = &toml["dev-dependencies"]["my-dev-package1"];
-    assert_eq!(
-        val.as_str().unwrap(),
-        "my-dev-package1--CURRENT_VERSION_TEST"
-    );
+    assert_eq!(val.as_str().unwrap(), "99999.0.0");
     let val = &toml["dev-dependencies"]["my-dev-package2"];
-    assert_eq!(
-        val.as_str().unwrap(),
-        "my-dev-package2--CURRENT_VERSION_TEST"
-    );
+    assert_eq!(val.as_str().unwrap(), "99999.0.0");
     let val = &toml["build-dependencies"]["my-build-package1"];
-    assert_eq!(
-        val.as_str().unwrap(),
-        "my-build-package1--CURRENT_VERSION_TEST"
-    );
+    assert_eq!(val.as_str().unwrap(), "99999.0.0");
     let val = &toml["build-dependencies"]["my-build-package2"];
-    assert_eq!(
-        val.as_str().unwrap(),
-        "my-build-package2--CURRENT_VERSION_TEST"
-    );
+    assert_eq!(val.as_str().unwrap(), "99999.0.0");
 }
 
 #[test]
@@ -348,10 +327,7 @@ fn adds_multiple_dependencies_with_some_versions() {
     // dependencies present afterwards
     let toml = get_toml(&manifest);
     let val = &toml["dependencies"]["my-package1"];
-    assert_eq!(
-        val.as_str().expect("not string"),
-        "my-package1--CURRENT_VERSION_TEST"
-    );
+    assert_eq!(val.as_str().expect("not string"), "99999.0.0");
     let val = &toml["dependencies"]["my-package2"];
     assert_eq!(val.as_str().expect("not string"), "0.2.3");
 }
@@ -1188,7 +1164,7 @@ fn adds_dependency_with_target_triple() {
     let toml = get_toml(&manifest);
 
     let val = &toml["target"]["i686-unknown-linux-gnu"]["dependencies"]["my-package1"];
-    assert_eq!(val.as_str().unwrap(), "my-package1--CURRENT_VERSION_TEST");
+    assert_eq!(val.as_str().unwrap(), "99999.0.0");
 }
 
 #[test]
@@ -1205,7 +1181,7 @@ fn adds_dependency_with_target_cfg() {
     let toml = get_toml(&manifest);
     let val = &toml["target"]["cfg(unix)"]["dependencies"]["my-package1"];
 
-    assert_eq!(val.as_str().unwrap(), "my-package1--CURRENT_VERSION_TEST");
+    assert_eq!(val.as_str().unwrap(), "99999.0.0");
 }
 
 #[test]
@@ -1239,7 +1215,7 @@ fn overrides_existing_features() {
         &["add", "your-face", "--features", "mouth"],
         r#"
 [dependencies]
-your-face = { version = "your-face--CURRENT_VERSION_TEST", features = ["mouth"] }
+your-face = { version = "99999.0.0", features = ["mouth"] }
 "#,
     )
 }
@@ -1251,7 +1227,7 @@ fn keeps_existing_features_by_default() {
         &["add", "your-face"],
         r#"
 [dependencies]
-your-face = { version = "your-face--CURRENT_VERSION_TEST", features = ["nose"] }
+your-face = { version = "99999.0.0", features = ["nose"] }
 "#,
     )
 }
@@ -1270,7 +1246,7 @@ fn handles_specifying_features_option_multiple_times() {
         ],
         r#"
 [dependencies]
-your-face = { version = "your-face--CURRENT_VERSION_TEST", features = ["nose", "mouth"] }
+your-face = { version = "99999.0.0", features = ["nose", "mouth"] }
 "#,
     )
 }
@@ -1282,7 +1258,7 @@ fn can_be_forced_to_provide_an_empty_features_list() {
         &["add", "your-face", "--features", ""],
         r#"
 [dependencies]
-your-face = { version = "your-face--CURRENT_VERSION_TEST", features = [] }
+your-face = { version = "99999.0.0", features = [] }
 "#,
     )
 }
@@ -1294,7 +1270,7 @@ fn parses_space_separated_argument_to_features() {
         &["add", "your-face", "--features", "mouth ears"],
         r#"
 [dependencies]
-your-face = { version = "your-face--CURRENT_VERSION_TEST", features = ["mouth", "ears"] }
+your-face = { version = "99999.0.0", features = ["mouth", "ears"] }
 "#,
     )
 }
@@ -1325,7 +1301,7 @@ fn adds_dependency_with_custom_target() {
     let toml = get_toml(&manifest);
     // Get package by hand because toml-rs does not currently handle escaping dots in get()
     let val = &toml["target"]["windows.json"]["dependencies"]["my-package1"];
-    assert_eq!(val.as_str(), Some("my-package1--CURRENT_VERSION_TEST"));
+    assert_eq!(val.as_str(), Some("99999.0.0"));
 }
 
 #[test]
@@ -1494,7 +1470,7 @@ fn overwrite_version_with_version() {
         &["add", "versioned-package"],
         r#"
 [dependencies]
-versioned-package = { version = "versioned-package--CURRENT_VERSION_TEST", optional = true }
+versioned-package = { version = "99999.0.0", optional = true }
 "#,
     )
 }
@@ -1530,7 +1506,7 @@ fn overwrite_renamed() {
         &["add", "versioned-package", "--rename", "renamed"],
         r#"
 [dependencies]
-renamed = { version = "versioned-package--CURRENT_VERSION_TEST", package = "versioned-package" }
+renamed = { version = "99999.0.0", package = "versioned-package" }
 "#,
     )
 }
@@ -1542,7 +1518,7 @@ fn overwrite_renamed_optional() {
         &["add", "versioned-package", "--rename", "renamed"],
         r#"
 [dependencies]
-renamed = { version = "versioned-package--CURRENT_VERSION_TEST", optional = true, package = "versioned-package" }
+renamed = { version = "99999.0.0", optional = true, package = "versioned-package" }
 "#,
     )
 }
@@ -1596,7 +1572,7 @@ fn overwrite_path_with_version() {
         &["add", "versioned-package"],
         r#"
 [dependencies]
-versioned-package = "versioned-package--CURRENT_VERSION_TEST"
+versioned-package = "99999.0.0"
 "#,
     )
 }
@@ -1765,7 +1741,7 @@ version = "0.0.0"
 
 [dependencies]
 atty = "0.2.13"
-toml = "toml--CURRENT_VERSION_TEST"
+toml = "99999.0.0"
 toml_edit = "0.1.5"
 "#
     );
@@ -1789,7 +1765,7 @@ version = "0.0.0"
 [dependencies]
 toml_edit = "0.1.5"
 atty = "0.2.13"
-toml = "toml--CURRENT_VERSION_TEST"
+toml = "99999.0.0"
 "#
     );
 }
@@ -1811,7 +1787,7 @@ version = "0.0.0"
 
 [dependencies]
 atty = "0.2.13"
-toml = "toml--CURRENT_VERSION_TEST"
+toml = "99999.0.0"
 toml_edit = "0.1.5"
 "#
     );
@@ -1832,7 +1808,7 @@ fn add_dependency_to_workspace_member() {
         one["dependencies"]["toml"]
             .as_str()
             .expect("toml dependency did not exist"),
-        "toml--CURRENT_VERSION_TEST",
+        "99999.0.0",
     );
 }
 #[test]

--- a/tests/cargo-upgrade.rs
+++ b/tests/cargo-upgrade.rs
@@ -35,7 +35,7 @@ fn upgrade_all() {
     // Verify that `docopt` has been updated successfully.
     assert_eq!(
         get_toml(&manifest)["dependencies"]["docopt"].as_str(),
-        Some("docopt--CURRENT_VERSION_TEST")
+        Some("99999.0.0")
     );
 }
 
@@ -52,7 +52,7 @@ fn upgrade_all_allow_prerelease() {
     // Verify that `docopt` has been updated successfully.
     assert_eq!(
         get_toml(&manifest)["dependencies"]["docopt"].as_str(),
-        Some("docopt--PRERELEASE_VERSION_TEST")
+        Some("99999.0.0-alpha.1")
     );
 }
 
@@ -69,7 +69,7 @@ fn upgrade_prereleased_without_the_flag() {
     // Verify that `b` has been updated successfully to a prerelease version.
     assert_eq!(
         get_toml(&manifest)["dependencies"]["b"].as_str(),
-        Some("b--PRERELEASE_VERSION_TEST")
+        Some("99999.0.0-alpha.1")
     );
 }
 
@@ -87,12 +87,12 @@ fn upgrade_prerelease_already_prereleased() {
     // Verify that `a` has been updated successfully to a stable version.
     assert_eq!(
         get_toml(&manifest)["dependencies"]["a"].as_str(),
-        Some("a--CURRENT_VERSION_TEST")
+        Some("99999.0.0")
     );
     // Verify that `b` has been updated successfully to a prerelease version.
     assert_eq!(
         get_toml(&manifest)["dependencies"]["b"].as_str(),
-        Some("b--PRERELEASE_VERSION_TEST")
+        Some("99999.0.0-alpha.1")
     );
 }
 
@@ -143,10 +143,7 @@ fn upgrade_specified_only() {
 
     // Verify that `docopt` was upgraded, but not `env_proxy`
     let dependencies = &get_toml(&manifest)["dependencies"];
-    assert_eq!(
-        dependencies["docopt"].as_str(),
-        Some("docopt--CURRENT_VERSION_TEST")
-    );
+    assert_eq!(dependencies["docopt"].as_str(), Some("99999.0.0"));
     assert_eq!(dependencies["env_proxy"].as_str(), Some("0.1.1"));
 }
 
@@ -192,10 +189,7 @@ fn upgrade_optional_dependency() {
     // Dependency present afterwards - correct version, and still optional.
     let toml = get_toml(&manifest);
     let val = &toml["dependencies"]["docopt"];
-    assert_eq!(
-        val["version"].as_str(),
-        Some("docopt--CURRENT_VERSION_TEST")
-    );
+    assert_eq!(val["version"].as_str(), Some("99999.0.0"));
     assert_eq!(val["optional"].as_bool(), Some(true));
 }
 
@@ -239,16 +233,10 @@ fn upgrade_renamed_dependency_all() {
     let toml = get_toml(&manifest);
 
     let dep1 = &toml["dependencies"]["te"];
-    assert_eq!(
-        dep1["version"].as_str(),
-        Some("toml_edit--CURRENT_VERSION_TEST")
-    );
+    assert_eq!(dep1["version"].as_str(), Some("99999.0.0"));
 
     let dep2 = &toml["dependencies"]["rx"];
-    assert_eq!(
-        dep2["version"].as_str(),
-        Some("regex--CURRENT_VERSION_TEST")
-    );
+    assert_eq!(dep2["version"].as_str(), Some("99999.0.0"));
 }
 
 #[test]
@@ -259,10 +247,7 @@ fn upgrade_renamed_dependency_inline_specified_only() {
 
     let toml = get_toml(&manifest);
     let dep = &toml["dependencies"]["te"];
-    assert_eq!(
-        dep["version"].as_str(),
-        Some("toml_edit--CURRENT_VERSION_TEST")
-    );
+    assert_eq!(dep["version"].as_str(), Some("99999.0.0"));
 }
 
 #[test]
@@ -273,7 +258,7 @@ fn upgrade_renamed_dependency_table_specified_only() {
 
     let toml = get_toml(&manifest);
     let dep = &toml["dependencies"]["rx"];
-    assert_eq!(dep["version"].as_str(), Some("regex--CURRENT_VERSION_TEST"));
+    assert_eq!(dep["version"].as_str(), Some("99999.0.0"));
 }
 
 #[test]
@@ -290,17 +275,11 @@ fn upgrade_alt_registry_dependency_all() {
     let toml = get_toml(&manifest);
 
     let dep1 = &toml["dependencies"]["toml_edit"];
-    assert_eq!(
-        dep1["version"].as_str(),
-        Some("toml_edit--CURRENT_VERSION_TEST")
-    );
+    assert_eq!(dep1["version"].as_str(), Some("99999.0.0"));
     assert_eq!(dep1["registry"].as_str(), Some("alternative"));
 
     let dep2 = &toml["dependencies"]["regex"];
-    assert_eq!(
-        dep2["version"].as_str(),
-        Some("regex--CURRENT_VERSION_TEST")
-    );
+    assert_eq!(dep2["version"].as_str(), Some("99999.0.0"));
     assert_eq!(dep2["registry"].as_str(), Some("alternative"));
 }
 
@@ -313,10 +292,7 @@ fn upgrade_alt_registry_dependency_inline_specified_only() {
 
     let toml = get_toml(&manifest);
     let dep = &toml["dependencies"]["toml_edit"];
-    assert_eq!(
-        dep["version"].as_str(),
-        Some("toml_edit--CURRENT_VERSION_TEST")
-    );
+    assert_eq!(dep["version"].as_str(), Some("99999.0.0"));
     assert_eq!(dep["registry"].as_str(), Some("alternative"));
 }
 
@@ -329,7 +305,7 @@ fn upgrade_alt_registry_dependency_table_specified_only() {
 
     let toml = get_toml(&manifest);
     let dep = &toml["dependencies"]["regex"];
-    assert_eq!(dep["version"].as_str(), Some("regex--CURRENT_VERSION_TEST"));
+    assert_eq!(dep["version"].as_str(), Some("99999.0.0"));
     assert_eq!(dep["registry"].as_str(), Some("alternative"));
 }
 
@@ -375,7 +351,7 @@ fn upgrade_workspace_all() {
     for workspace_member in workspace_manifests {
         assert_eq!(
             get_toml(&workspace_member)["dependencies"]["libc"].as_str(),
-            Some("libc--CURRENT_VERSION_TEST")
+            Some("99999.0.0")
         );
     }
 }
@@ -390,7 +366,7 @@ fn upgrade_workspace_workspace() {
     for workspace_member in workspace_manifests {
         assert_eq!(
             get_toml(&workspace_member)["dependencies"]["libc"].as_str(),
-            Some("libc--CURRENT_VERSION_TEST")
+            Some("99999.0.0")
         );
     }
 }
@@ -410,7 +386,7 @@ fn upgrade_dependency_in_workspace_member() {
         one["dependencies"]["libc"]
             .as_str()
             .expect("libc dependency did not exist"),
-        "libc--CURRENT_VERSION_TEST",
+        "99999.0.0",
     );
 }
 

--- a/tests/fixtures/upgrade/Cargo.toml.target
+++ b/tests/fixtures/upgrade/Cargo.toml.target
@@ -6,41 +6,41 @@ version = "0.1.0"
 path = "dummy.rs"
 
 [dependencies]
-docopt = "docopt--CURRENT_VERSION_TEST"
-pad = "pad--CURRENT_VERSION_TEST"
-serde_json = "serde_json--CURRENT_VERSION_TEST"
-syn = { version = "syn--CURRENT_VERSION_TEST", default-features = false, features = ["parsing"] }
-tar = { version = "tar--CURRENT_VERSION_TEST", default-features = false }
-ftp = "ftp--CURRENT_VERSION_TEST"
-te = { package = "toml_edit", version = "toml_edit--CURRENT_VERSION_TEST" }
+docopt = "99999.0.0"
+pad = "99999.0.0"
+serde_json = "99999.0.0"
+syn = { version = "99999.0.0", default-features = false, features = ["parsing"] }
+tar = { version = "99999.0.0", default-features = false }
+ftp = "99999.0.0"
+te = { package = "toml_edit", version = "99999.0.0" }
 
 [dependencies.semver]
 features = ["serde"]
-version = "semver--CURRENT_VERSION_TEST"
+version = "99999.0.0"
 
 [dependencies.rn]
 package = "renamed"
-version = "renamed--CURRENT_VERSION_TEST"
+version = "99999.0.0"
 
 [dev-dependencies]
-assert_cli = "assert_cli--CURRENT_VERSION_TEST"
-tempdir = "tempdir--CURRENT_VERSION_TEST"
+assert_cli = "99999.0.0"
+tempdir = "99999.0.0"
 
 [build-dependencies]
 serde = { version = "1.0", git= "https://github.com/serde-rs/serde.git" }
 
 [target.'cfg(unix)'.dependencies]
-openssl = "openssl--CURRENT_VERSION_TEST"
+openssl = "99999.0.0"
 
 [target."windows.json"]
 # let's make it an inline table
-dependencies = { rget = "rget--CURRENT_VERSION_TEST" }
+dependencies = { rget = "99999.0.0" }
 
 [target.'cfg(target_arch = "x86_64")'.dev-dependencies]
-geo = { version = "geo--CURRENT_VERSION_TEST", default-features = false, features = ["postgis-integration"] }
+geo = { version = "99999.0.0", default-features = false, features = ["postgis-integration"] }
 
 [target.foo.build-dependencies]
-ftp = "ftp--CURRENT_VERSION_TEST"
+ftp = "99999.0.0"
 
 [features]
 default = []


### PR DESCRIPTION
With #480, we'll be parsing the `Cargo.toml`s which will fail with our
test "versions".  To make these still stand out, I used the metadata field and
chose a ridiculously large version.