### PR TITLE
fix: Respect --manifest-path

### DIFF
--- a/src/bin/add/main.rs
+++ b/src/bin/add/main.rs
@@ -121,7 +121,7 @@ fn is_sorted(mut it: impl Iterator<Item = impl PartialOrd>) -> bool {
 
 fn handle_add(args: &Args) -> Result<()> {
     let manifest_path = if let Some(ref pkgid) = args.pkgid {
-        let pkg = manifest_from_pkgid(pkgid)?;
+        let pkg = manifest_from_pkgid(args.manifest_path.as_deref(), pkgid)?;
         Cow::Owned(Some(pkg.manifest_path.into_std_path_buf()))
     } else {
         Cow::Borrowed(&args.manifest_path)

--- a/src/bin/rm/main.rs
+++ b/src/bin/rm/main.rs
@@ -104,7 +104,7 @@ fn print_msg(name: &str, section: &str) -> Result<()> {
 
 fn handle_rm(args: &Args) -> Result<()> {
     let manifest_path = if let Some(ref pkgid) = args.pkgid {
-        let pkg = manifest_from_pkgid(pkgid)?;
+        let pkg = manifest_from_pkgid(args.manifest_path.as_deref(), pkgid)?;
         Cow::Owned(Some(pkg.manifest_path.into_std_path_buf()))
     } else {
         Cow::Borrowed(&args.manifest_path)

--- a/src/bin/set-version/main.rs
+++ b/src/bin/set-version/main.rs
@@ -77,7 +77,7 @@ fn process(args: Args) -> Result<()> {
     let manifests = if all {
         Manifests::get_all(&manifest_path)
     } else if let Some(ref pkgid) = pkgid {
-        Manifests::get_pkgid(pkgid)
+        Manifests::get_pkgid(manifest_path.as_deref(), pkgid)
     } else {
         Manifests::get_local_one(&manifest_path)
     }?;
@@ -132,8 +132,8 @@ impl Manifests {
             .map(Manifests)
     }
 
-    fn get_pkgid(pkgid: &str) -> Result<Self> {
-        let package = manifest_from_pkgid(pkgid)?;
+    fn get_pkgid(manifest_path: Option<&Path>, pkgid: &str) -> Result<Self> {
+        let package = manifest_from_pkgid(manifest_path, pkgid)?;
         let manifest = LocalManifest::try_new(Path::new(&package.manifest_path))?;
         Ok(Manifests(vec![(manifest, package)]))
     }

--- a/src/bin/upgrade/main.rs
+++ b/src/bin/upgrade/main.rs
@@ -191,8 +191,8 @@ impl Manifests {
             .map(Manifests)
     }
 
-    fn get_pkgid(pkgid: &str) -> Result<Self> {
-        let package = manifest_from_pkgid(pkgid)?;
+    fn get_pkgid(manifest_path: Option<&Path>, pkgid: &str) -> Result<Self> {
+        let package = manifest_from_pkgid(manifest_path, pkgid)?;
         let manifest = LocalManifest::try_new(Path::new(&package.manifest_path))?;
         Ok(Manifests(vec![(manifest, package)]))
     }
@@ -478,7 +478,7 @@ fn process(args: Args) -> Result<()> {
     let manifests = if all {
         Manifests::get_all(&manifest_path)
     } else if let Some(ref pkgid) = pkgid {
-        Manifests::get_pkgid(pkgid)
+        Manifests::get_pkgid(manifest_path.as_deref(), pkgid)
     } else {
         Manifests::get_local_one(&manifest_path)
     }?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,6 +35,6 @@ pub use crate::fetch::{
     get_latest_dependency, update_registry_index,
 };
 pub use crate::manifest::{find, LocalManifest, Manifest};
-pub use crate::metadata::manifest_from_pkgid;
+pub use crate::metadata::{manifest_from_pkgid, workspace_members};
 pub use crate::registry::registry_url;
 pub use crate::version::VersionExt;

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -1,10 +1,15 @@
 use crate::errors::*;
 use cargo_metadata::Package;
+use std::convert::TryInto;
+use std::path::Path;
 
 /// Takes a pkgid and attempts to find the path to it's `Cargo.toml`, using `cargo`'s metadata
-pub fn manifest_from_pkgid(pkgid: &str) -> Result<Package> {
+pub fn manifest_from_pkgid(manifest_path: Option<&Path>, pkgid: &str) -> Result<Package> {
     let mut cmd = cargo_metadata::MetadataCommand::new();
     cmd.no_deps();
+    if let Some(manifest_path) = manifest_path {
+        cmd.manifest_path(manifest_path);
+    }
     let result = cmd.exec().chain_err(|| "Invalid manifest")?;
     let packages = result.packages;
     let package = packages
@@ -15,4 +20,41 @@ pub fn manifest_from_pkgid(pkgid: &str) -> Result<Package> {
              actual package in this workspace. Try adding `--workspace`."
         })?;
     Ok(package)
+}
+
+/// Lookup all members of the current workspace
+pub fn workspace_members(manifest_path: Option<&Path>) -> Result<Vec<Package>> {
+    let mut cmd = cargo_metadata::MetadataCommand::new();
+    cmd.no_deps();
+    if let Some(manifest_path) = manifest_path {
+        cmd.manifest_path(manifest_path);
+    }
+    let result = cmd.exec().chain_err(|| "Invalid manifest")?;
+    let workspace_members: std::collections::HashSet<_> =
+        result.workspace_members.into_iter().collect();
+    let workspace_members: Vec<_> = result
+        .packages
+        .into_iter()
+        .filter(|p| workspace_members.contains(&p.id))
+        .map(|mut p| {
+            p.manifest_path = canonicalize_path(p.manifest_path);
+            for dep in p.dependencies.iter_mut() {
+                dep.path = dep.path.take().map(canonicalize_path);
+            }
+            p
+        })
+        .collect();
+    Ok(workspace_members)
+}
+
+fn canonicalize_path(
+    path: cargo_metadata::camino::Utf8PathBuf,
+) -> cargo_metadata::camino::Utf8PathBuf {
+    if let Ok(path) = path.canonicalize() {
+        if let Ok(path) = path.try_into() {
+            return path;
+        }
+    }
+
+    path
 }

--- a/tests/utils.rs
+++ b/tests/utils.rs
@@ -1,5 +1,6 @@
 #![allow(unused)]
 use assert_cmd::Command;
+use assert_fs::prelude::*;
 use std::ffi::{OsStr, OsString};
 use std::io::prelude::*;
 use std::{env, fs, path::Path, path::PathBuf, process};
@@ -55,15 +56,10 @@ pub fn copy_workspace_test() -> (assert_fs::TempDir, String, Vec<String>) {
 /// Create temporary working directory with Cargo.toml manifest
 pub fn clone_out_test(source: &str) -> (assert_fs::TempDir, String) {
     let tmpdir = assert_fs::TempDir::new().expect("failed to construct temporary directory");
-    fs::copy(source, tmpdir.path().join("Cargo.toml"))
-        .unwrap_or_else(|err| panic!("could not copy test manifest: {}", err));
-    let path = tmpdir
-        .path()
-        .join("Cargo.toml")
-        .to_str()
-        .unwrap()
-        .to_string()
-        .clone();
+    let manifest_path = tmpdir.child("Cargo.toml");
+    manifest_path.write_file(Path::new(source)).unwrap();
+    tmpdir.child("src/lib.rs").touch().unwrap();
+    let path = manifest_path.to_str().unwrap().to_string().clone();
 
     (tmpdir, path)
 }


### PR DESCRIPTION
We called into `cargo_metadata` without setting the manifest path, so it used the CWD.

I verified that at least `--workspace` is relative to `--manifest-path` in `cargo build`.