### PR TITLE
feat(version): Update dependents in workspace

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -97,5 +97,9 @@ error_chain! {
         InvalidReleaseLevel(actual: &'static str, version: semver::Version) {
             display("Cannot increment the {} field for {}", actual, version)
         }
+        /// Modifying a version req with an unsupported comparator.
+        UnsupportedVersionReq(req: String) {
+            display("Support for modifying {} is currently unsupported", req)
+        }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,4 +37,4 @@ pub use crate::fetch::{
 pub use crate::manifest::{find, LocalManifest, Manifest};
 pub use crate::metadata::{manifest_from_pkgid, workspace_members};
 pub use crate::registry::registry_url;
-pub use crate::version::VersionExt;
+pub use crate::version::{upgrade_requirement, VersionExt};

--- a/tests/cargo-set-version.rs
+++ b/tests/cargo-set-version.rs
@@ -2,6 +2,9 @@
 extern crate pretty_assertions;
 
 mod utils;
+
+use assert_fs::prelude::*;
+
 use crate::utils::{clone_out_test, execute_bad_command, execute_command, get_toml};
 
 #[test]
@@ -52,4 +55,164 @@ fn downgrade_error() {
     assert_eq!(val.as_str().unwrap(), "0.1.0");
 
     execute_bad_command(&["set-version", "0.0.1"], &manifest);
+}
+
+#[test]
+fn test_version_dependency_ignored() {
+    let tmpdir = assert_fs::TempDir::new().expect("failed to construct temporary directory");
+    tmpdir
+        .child("Cargo.toml")
+        .write_str(
+            r#"[workspace]
+members = ["primary", "dependency"]
+"#,
+        )
+        .expect("Manifest is writeable");
+    let primary_manifest_path = tmpdir.child("primary/Cargo.toml");
+    let primary_manifest = r#"[package]
+name = "cargo-list-test-fixture"
+version = "0.0.0"
+
+[lib]
+path = "dummy.rs"
+
+[dependencies]
+cargo-list-test-fixture-dependency = "0.4.3"
+"#;
+    primary_manifest_path
+        .write_str(primary_manifest)
+        .expect("Manifest is writeable");
+    let dependency_manifest_path = tmpdir.child("dependency/Cargo.toml");
+    let dependency_manifest = r#"[package]
+name = "cargo-list-test-fixture-dependency"
+version = "0.4.3"
+
+[lib]
+path = "dummy.rs"
+"#;
+    dependency_manifest_path
+        .write_str(dependency_manifest)
+        .expect("Manifest is writeable");
+
+    execute_command(&["set-version", "2.0.0"], &dependency_manifest_path);
+    let dependency_manifest = r#"[package]
+name = "cargo-list-test-fixture-dependency"
+version = "2.0.0"
+
+[lib]
+path = "dummy.rs"
+"#;
+
+    primary_manifest_path.assert(primary_manifest);
+    dependency_manifest_path.assert(dependency_manifest);
+}
+
+#[test]
+fn test_compatible_dependency_ignored() {
+    let tmpdir = assert_fs::TempDir::new().expect("failed to construct temporary directory");
+    tmpdir
+        .child("Cargo.toml")
+        .write_str(
+            r#"[workspace]
+members = ["primary", "dependency"]
+"#,
+        )
+        .expect("Manifest is writeable");
+    let primary_manifest_path = tmpdir.child("primary/Cargo.toml");
+    let primary_manifest = r#"[package]
+name = "cargo-list-test-fixture"
+version = "0.0.0"
+
+[lib]
+path = "dummy.rs"
+
+[dependencies]
+cargo-list-test-fixture-dependency = { version = "0.4", path = "../dependency" }
+"#;
+    primary_manifest_path
+        .write_str(primary_manifest)
+        .expect("Manifest is writeable");
+    let dependency_manifest_path = tmpdir.child("dependency/Cargo.toml");
+    let dependency_manifest = r#"[package]
+name = "cargo-list-test-fixture-dependency"
+version = "0.4.3"
+
+[lib]
+path = "dummy.rs"
+"#;
+    dependency_manifest_path
+        .write_str(dependency_manifest)
+        .expect("Manifest is writeable");
+
+    execute_command(&["set-version", "0.4.5"], &dependency_manifest_path);
+    let dependency_manifest = r#"[package]
+name = "cargo-list-test-fixture-dependency"
+version = "0.4.5"
+
+[lib]
+path = "dummy.rs"
+"#;
+
+    primary_manifest_path.assert(primary_manifest);
+    dependency_manifest_path.assert(dependency_manifest);
+}
+
+#[test]
+fn test_dependency_upgraded() {
+    let tmpdir = assert_fs::TempDir::new().expect("failed to construct temporary directory");
+    tmpdir
+        .child("Cargo.toml")
+        .write_str(
+            r#"[workspace]
+members = ["primary", "dependency"]
+"#,
+        )
+        .expect("Manifest is writeable");
+    let primary_manifest_path = tmpdir.child("primary/Cargo.toml");
+    let primary_manifest = r#"[package]
+name = "cargo-list-test-fixture"
+version = "0.0.0"
+
+[lib]
+path = "dummy.rs"
+
+[dependencies]
+cargo-list-test-fixture-dependency = { version = "0.4", path = "../dependency" }
+"#;
+    primary_manifest_path
+        .write_str(primary_manifest)
+        .expect("Manifest is writeable");
+    let dependency_manifest_path = tmpdir.child("dependency/Cargo.toml");
+    let dependency_manifest = r#"[package]
+name = "cargo-list-test-fixture-dependency"
+version = "0.4.3"
+
+[lib]
+path = "dummy.rs"
+"#;
+    dependency_manifest_path
+        .write_str(dependency_manifest)
+        .expect("Manifest is writeable");
+
+    execute_command(&["set-version", "2.0.0"], &dependency_manifest_path);
+    let primary_manifest = r#"[package]
+name = "cargo-list-test-fixture"
+version = "0.0.0"
+
+[lib]
+path = "dummy.rs"
+
+[dependencies]
+cargo-list-test-fixture-dependency = { version = "2.0", path = "../dependency" }
+"#;
+    let dependency_manifest = r#"[package]
+name = "cargo-list-test-fixture-dependency"
+version = "2.0.0"
+
+[lib]
+path = "dummy.rs"
+"#;
+
+    primary_manifest_path.assert(primary_manifest);
+    dependency_manifest_path.assert(dependency_manifest);
 }


### PR DESCRIPTION
This will preserve both the comparator (like `^`) and number of version
field (`2.0` vs `2.0.0`) as we modify dependents in the workspace as we
modify versions.