### PR TITLE
refactor: Canonicalize via `dunce`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -154,6 +154,7 @@ dependencies = [
  "cargo_metadata",
  "crates-index",
  "dirs-next",
+ "dunce",
  "env_proxy",
  "error-chain",
  "git2",
@@ -319,6 +320,12 @@ name = "doc-comment"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
+
+[[package]]
+name = "dunce"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "453440c271cf5577fd2a40e4942540cb7d0d2f85e27c8d07dd0023c925a67541"
 
 [[package]]
 name = "either"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,6 +52,7 @@ required-features = ["set-version"]
 atty = { version = "0.2.14", optional = true }
 cargo_metadata = "0.14.0"
 crates-index = "0.17.0"
+dunce = "1.0"
 dirs-next = "2.0.0"
 env_proxy = "0.4.1"
 error-chain = "0.12.4"

--- a/src/bin/add/args.rs
+++ b/src/bin/add/args.rs
@@ -185,7 +185,7 @@ impl Args {
             }
 
             if let Some(ref path) = self.path {
-                dependency = dependency.set_path(path.canonicalize()?);
+                dependency = dependency.set_path(dunce::canonicalize(path)?);
             }
 
             Ok(dependency)
@@ -224,7 +224,7 @@ impl Args {
                 dependency = dependency.set_git(repo, self.branch.clone());
             }
             if let Some(path) = &self.path {
-                dependency = dependency.set_path(path.canonicalize()?);
+                dependency = dependency.set_path(dunce::canonicalize(path)?);
             }
             if let Some(version) = &self.vers {
                 dependency = dependency.set_version(parse_version_req(version)?);
@@ -406,7 +406,7 @@ mod tests {
 
     #[test]
     fn test_path_as_arg_parsing() {
-        let self_path = std::env::current_dir().unwrap().canonicalize().unwrap();
+        let self_path = dunce::canonicalize(std::env::current_dir().unwrap()).unwrap();
         let args_path = Args {
             // Hacky to `display` but should generally work
             crates: vec![self_path.display().to_string()],

--- a/src/crate_name.rs
+++ b/src/crate_name.rs
@@ -68,7 +68,7 @@ impl<'a> CrateName<'a> {
             }
         } else if self.is_path() {
             if let Ok(ref crate_name) = get_crate_name_from_path(self.0) {
-                let path = std::path::Path::new(self.0).canonicalize()?;
+                let path = dunce::canonicalize(std::path::Path::new(self.0))?;
                 return Ok(Dependency::new(crate_name).set_path(path));
             }
         }

--- a/src/dependency.rs
+++ b/src/dependency.rs
@@ -278,7 +278,7 @@ mod tests {
 
     #[test]
     fn to_toml_simple_dep() {
-        let crate_root = Path::new("/").canonicalize().expect("root exists");
+        let crate_root = dunce::canonicalize(Path::new("/")).expect("root exists");
         let toml = Dependency::new("dep").to_toml(&crate_root);
 
         assert_eq!(toml.0, "dep".to_owned());
@@ -286,7 +286,7 @@ mod tests {
 
     #[test]
     fn to_toml_simple_dep_with_version() {
-        let crate_root = Path::new("/").canonicalize().expect("root exists");
+        let crate_root = dunce::canonicalize(Path::new("/")).expect("root exists");
         let toml = Dependency::new("dep")
             .set_version("1.0")
             .to_toml(&crate_root);
@@ -297,7 +297,7 @@ mod tests {
 
     #[test]
     fn to_toml_optional_dep() {
-        let crate_root = Path::new("/").canonicalize().expect("root exists");
+        let crate_root = dunce::canonicalize(Path::new("/")).expect("root exists");
         let toml = Dependency::new("dep")
             .set_optional(true)
             .to_toml(&crate_root);
@@ -311,7 +311,7 @@ mod tests {
 
     #[test]
     fn to_toml_dep_without_default_features() {
-        let crate_root = Path::new("/").canonicalize().expect("root exists");
+        let crate_root = dunce::canonicalize(Path::new("/")).expect("root exists");
         let toml = Dependency::new("dep")
             .set_default_features(false)
             .to_toml(&crate_root);
@@ -325,7 +325,7 @@ mod tests {
 
     #[test]
     fn to_toml_dep_with_path_source() {
-        let root = Path::new("/").canonicalize().expect("root exists");
+        let root = dunce::canonicalize(Path::new("/")).expect("root exists");
         let crate_root = root.join("foo");
         let toml = Dependency::new("dep")
             .set_path(root.join("bar"))
@@ -340,7 +340,7 @@ mod tests {
 
     #[test]
     fn to_toml_dep_with_git_source() {
-        let crate_root = Path::new("/").canonicalize().expect("root exists");
+        let crate_root = dunce::canonicalize(Path::new("/")).expect("root exists");
         let toml = Dependency::new("dep")
             .set_git("https://foor/bar.git", None)
             .to_toml(&crate_root);
@@ -357,7 +357,7 @@ mod tests {
 
     #[test]
     fn to_toml_renamed_dep() {
-        let crate_root = Path::new("/").canonicalize().expect("root exists");
+        let crate_root = dunce::canonicalize(Path::new("/")).expect("root exists");
         let toml = Dependency::new("dep").set_rename("d").to_toml(&crate_root);
 
         assert_eq!(toml.0, "d".to_owned());
@@ -369,7 +369,7 @@ mod tests {
 
     #[test]
     fn to_toml_dep_from_alt_registry() {
-        let crate_root = Path::new("/").canonicalize().expect("root exists");
+        let crate_root = dunce::canonicalize(Path::new("/")).expect("root exists");
         let toml = Dependency::new("dep")
             .set_registry("alternative")
             .to_toml(&crate_root);
@@ -383,7 +383,7 @@ mod tests {
 
     #[test]
     fn to_toml_complex_dep() {
-        let crate_root = Path::new("/").canonicalize().expect("root exists");
+        let crate_root = dunce::canonicalize(Path::new("/")).expect("root exists");
         let toml = Dependency::new("dep")
             .set_version("1.0")
             .set_default_features(false)
@@ -401,7 +401,7 @@ mod tests {
 
     #[test]
     fn paths_with_forward_slashes_are_left_as_is() {
-        let crate_root = Path::new("/").canonicalize().expect("root exists");
+        let crate_root = dunce::canonicalize(Path::new("/")).expect("root exists");
         let path = crate_root.join("sibling/crate");
         let relpath = "sibling/crate";
         let dep = Dependency::new("dep").set_path(path);
@@ -416,7 +416,7 @@ mod tests {
     #[test]
     #[cfg(windows)]
     fn normalise_windows_style_paths() {
-        let crate_root = Path::new("/").canonicalize().expect("root exists");
+        let crate_root = dunce::canonicalize(Path::new("/")).expect("root exists");
         let original = crate_root.join(r"sibling\crate");
         let should_be = "sibling/crate";
         let dep = Dependency::new("dep").set_path(original);

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -279,7 +279,7 @@ impl LocalManifest {
     /// Construct a `LocalManifest`. If no path is provided, make an educated guess as to which one
     /// the user means.
     pub fn find(path: &Option<PathBuf>) -> Result<Self> {
-        let path = find(path)?.canonicalize()?;
+        let path = dunce::canonicalize(find(path)?)?;
         Self::try_new(&path)
     }
 
@@ -510,7 +510,7 @@ mod tests {
 
     #[test]
     fn add_remove_dependency() {
-        let root = Path::new("/").canonicalize().expect("root exists");
+        let root = dunce::canonicalize(Path::new("/")).expect("root exists");
         let mut manifest = LocalManifest {
             path: root.join("Cargo.toml"),
             manifest: Manifest {
@@ -528,7 +528,7 @@ mod tests {
 
     #[test]
     fn update_dependency() {
-        let root = Path::new("/").canonicalize().expect("root exists");
+        let root = dunce::canonicalize(Path::new("/")).expect("root exists");
         let mut manifest = LocalManifest {
             path: root.join("Cargo.toml"),
             manifest: Manifest {
@@ -548,7 +548,7 @@ mod tests {
 
     #[test]
     fn update_wrong_dependency() {
-        let root = Path::new("/").canonicalize().expect("root exists");
+        let root = dunce::canonicalize(Path::new("/")).expect("root exists");
         let mut manifest = LocalManifest {
             path: root.join("Cargo.toml"),
             manifest: Manifest {
@@ -571,7 +571,7 @@ mod tests {
 
     #[test]
     fn remove_dependency_no_section() {
-        let root = Path::new("/").canonicalize().expect("root exists");
+        let root = dunce::canonicalize(Path::new("/")).expect("root exists");
         let mut manifest = LocalManifest {
             path: root.join("Cargo.toml"),
             manifest: Manifest {
@@ -586,7 +586,7 @@ mod tests {
 
     #[test]
     fn remove_dependency_non_existent() {
-        let root = Path::new("/").canonicalize().expect("root exists");
+        let root = dunce::canonicalize(Path::new("/")).expect("root exists");
         let mut manifest = LocalManifest {
             path: root.join("Cargo.toml"),
             manifest: Manifest {
@@ -619,7 +619,7 @@ edition = "2015"
 
 [dependencies]
 "#;
-        let root = Path::new("/").canonicalize().expect("root exists");
+        let root = dunce::canonicalize(Path::new("/")).expect("root exists");
         let mut manifest = LocalManifest {
             path: root.join("Cargo.toml"),
             manifest: original.parse::<Manifest>().unwrap(),

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -50,7 +50,7 @@ pub fn workspace_members(manifest_path: Option<&Path>) -> Result<Vec<Package>> {
 fn canonicalize_path(
     path: cargo_metadata::camino::Utf8PathBuf,
 ) -> cargo_metadata::camino::Utf8PathBuf {
-    if let Ok(path) = path.canonicalize() {
+    if let Ok(path) = dunce::canonicalize(&path) {
         if let Ok(path) = path.try_into() {
             return path;
         }


### PR DESCRIPTION
In a PR I'm working on, I'm trying to take a canonicalized path and add
a relative path to it but that doesn't seem to be supported with UNC
paths, so I need dunce's "simplified" paths to then perform resolve
relative paths.