### PR TITLE
enable vendored-libgit2 by default

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -86,6 +86,7 @@ default = [
     "rm",
     "upgrade",
     "set-version",
+    "vendored-libgit2",
 ]
 add = ["cli"]
 rm = ["cli"]


### PR DESCRIPTION
This is an issue for out-of-date system libgit2 packages.

See #510, #487.