### PR TITLE
BUGFIX: Rm activated features accidently created empty features table

### DIFF
--- a/src/bin/rm/main.rs
+++ b/src/bin/rm/main.rs
@@ -172,10 +172,8 @@ fn remove_feature_activation(feature_activations: &mut toml_edit::Array, dep: &s
         .enumerate()
         .filter_map(|(idx, feature_activation)| {
             if let toml_edit::Value::String(feature_activation) = feature_activation {
-                feature_activation
-                    .value()
-                    .starts_with(dep_feature)
-                    .then(|| idx)
+                let activation = feature_activation.value();
+                (activation == dep || activation.starts_with(dep_feature)).then(|| idx)
             } else {
                 None
             }

--- a/src/bin/rm/main.rs
+++ b/src/bin/rm/main.rs
@@ -124,9 +124,8 @@ fn handle_rm(args: &Args) -> Result<()> {
             // Now that we have removed the crate, if that was the last reference to that crate,
             // then we need to drop any explicitly activated features on that crate.
             if !dep_used(&manifest, dep) {
-                if let Ok(toml_edit::Item::Table(feature_table)) =
-                    manifest.get_table(&["features".to_string()])
-                {
+                if let toml_edit::Item::Table(feature_table) =
+                    &mut manifest.data.root["features".to_string()] {
                     for (_feature, mut activated_crates) in feature_table.iter_mut() {
                         if let toml_edit::Item::Value(toml_edit::Value::Array(
                             feature_activations,

--- a/src/bin/rm/main.rs
+++ b/src/bin/rm/main.rs
@@ -125,7 +125,8 @@ fn handle_rm(args: &Args) -> Result<()> {
             // then we need to drop any explicitly activated features on that crate.
             if !dep_used(&manifest, dep) {
                 if let toml_edit::Item::Table(feature_table) =
-                    &mut manifest.data.root["features".to_string()] {
+                    &mut manifest.data.root["features".to_string()]
+                {
                     for (_feature, mut activated_crates) in feature_table.iter_mut() {
                         if let toml_edit::Item::Value(toml_edit::Value::Array(
                             feature_activations,

--- a/tests/cargo-rm.rs
+++ b/tests/cargo-rm.rs
@@ -20,6 +20,21 @@ fn remove_existing_dependency() {
 }
 
 #[test]
+fn remove_existing_optional_dependency() {
+    let (_tmpdir, manifest) = clone_out_test("tests/fixtures/rm/Cargo.toml.sample");
+
+    let toml = get_toml(&manifest);
+    assert!(!toml["dependencies"]["clippy"].is_none());
+    assert_eq!(toml["features"]["annoy"].as_array().unwrap().len(), 1);
+
+    execute_command(&["rm", "clippy"], &manifest);
+    let toml = get_toml(&manifest);
+    assert!(toml["dependencies"]["clippy"].is_none());
+    // Also check that exact match feature activations are removed:
+    assert_eq!(toml["features"]["annoy"].as_array().unwrap().len(), 0);
+}
+
+#[test]
 fn remove_multiple_existing_dependencies() {
     let (_tmpdir, manifest) = clone_out_test("tests/fixtures/rm/Cargo.toml.sample");
 

--- a/tests/cargo-rm.rs
+++ b/tests/cargo-rm.rs
@@ -20,6 +20,19 @@ fn remove_existing_dependency() {
 }
 
 #[test]
+fn remove_existing_dependency_does_not_create_empty_tables() {
+    let (_tmpdir, manifest) = clone_out_test("tests/fixtures/rm/Cargo.toml.no_features.sample");
+
+    let toml = get_toml(&manifest);
+    assert!(toml["features"].is_none());
+    assert!(toml["build-dependencies"].is_none());
+    execute_command(&["rm", "docopt"], &manifest);
+    let toml = get_toml(&manifest);
+    assert!(toml["features"].is_none());
+    assert!(toml["build-dependencies"].is_none());
+}
+
+#[test]
 fn remove_existing_optional_dependency() {
     let (_tmpdir, manifest) = clone_out_test("tests/fixtures/rm/Cargo.toml.sample");
 

--- a/tests/cargo-rm.rs
+++ b/tests/cargo-rm.rs
@@ -26,7 +26,7 @@ fn remove_existing_dependency_does_not_create_empty_tables() {
     let toml = get_toml(&manifest);
     assert!(toml["features"].is_none());
     assert!(toml["build-dependencies"].is_none());
-    execute_command(&["rm", "docopt"], &manifest);
+    execute_command(&["rm", "clippy"], &manifest);
     let toml = get_toml(&manifest);
     assert!(toml["features"].is_none());
     assert!(toml["build-dependencies"].is_none());

--- a/tests/cargo-rm.rs
+++ b/tests/cargo-rm.rs
@@ -14,6 +14,9 @@ fn remove_existing_dependency() {
     execute_command(&["rm", "docopt"], &manifest);
     let toml = get_toml(&manifest);
     assert!(toml["dependencies"]["docopt"].is_none());
+
+    // Activated features should not be changed:
+    assert_eq!(toml["features"]["std"].as_array().unwrap().len(), 2);
 }
 
 #[test]
@@ -27,6 +30,15 @@ fn remove_multiple_existing_dependencies() {
     let toml = get_toml(&manifest);
     assert!(toml["dependencies"]["docopt"].is_none());
     assert!(toml["dependencies"]["semver"].is_none());
+
+    // "semver/std" activated feature should NOT have been dropped as
+    // there's still a build-dep on the crate:
+    assert_eq!(toml["features"]["std"].as_array().unwrap().len(), 2);
+
+    // Let's remove the last semver dependency and expect the associated feature to be dropped.
+    execute_command(&["rm", "--build", "semver"], &manifest);
+    let toml = get_toml(&manifest);
+    assert_eq!(toml["features"]["std"].as_array().unwrap().len(), 1);
 }
 
 #[test]

--- a/tests/fixtures/rm/Cargo.toml.no_features.sample
+++ b/tests/fixtures/rm/Cargo.toml.no_features.sample
@@ -1,0 +1,22 @@
+[package]
+name = "cargo-rm-test-fixture"
+version = "0.1.0"
+
+[[bin]]
+name = "main"
+path = "src/main.rs"
+
+[dependencies]
+docopt = "0.6"
+pad = "0.1"
+rustc-serialize = "0.3"
+semver = "0.1"
+toml = "0.1"
+clippy = {git = "https://github.com/Manishearth/rust-clippy.git", optional = true}
+
+[dev-dependencies]
+regex = "0.1.41"
+serde = "1.0.90"
+
+# no [features] or [build-dependencies] here.
+# We wish to test that we don't accidentally create empty tables.

--- a/tests/fixtures/rm/Cargo.toml.sample
+++ b/tests/fixtures/rm/Cargo.toml.sample
@@ -20,3 +20,6 @@ clippy = {git = "https://github.com/Manishearth/rust-clippy.git", optional = tru
 [dev-dependencies]
 regex = "0.1.41"
 serde = "1.0.90"
+
+[features]
+std = ["serde/std", "semver/std"]

--- a/tests/fixtures/rm/Cargo.toml.sample
+++ b/tests/fixtures/rm/Cargo.toml.sample
@@ -23,3 +23,4 @@ serde = "1.0.90"
 
 [features]
 std = ["serde/std", "semver/std"]
+annoy = ["clippy"]


### PR DESCRIPTION
If a dependency was removed but there was no features in that Cargo.toml then an empty features table was added.

UPDATE: Failing test and fix done. (Sorry I didn't spot it earlier!)