### PR TITLE
feature flag now validates requested features 

### DIFF
--- a/src/bin/add/args.rs
+++ b/src/bin/add/args.rs
@@ -173,6 +173,7 @@ impl Args {
         &self,
         crate_name: &str,
         workspace_members: &[Package],
+        features: Option<Vec<String>>,
     ) -> Result<Dependency> {
         let crate_name = CrateName::new(crate_name);
 
@@ -265,6 +266,7 @@ impl Args {
                         self.allow_prerelease,
                         &find(&self.manifest_path)?,
                         &registry_url,
+                        features,
                     )?;
                     let v = format!(
                         "{prefix}{version}",
@@ -307,7 +309,7 @@ impl Args {
         self.crates
             .iter()
             .map(|crate_name| {
-                self.parse_single_dependency(crate_name, &workspace_members)
+                self.parse_single_dependency(crate_name, &workspace_members, self.features.clone())
                     .map(|x| {
                         let mut x = x
                             .set_optional(self.optional)

--- a/src/bin/upgrade/main.rs
+++ b/src/bin/upgrade/main.rs
@@ -428,6 +428,7 @@ impl DesiredUpgrades {
                             allow_prerelease,
                             manifest_path,
                             &registry_url,
+                            None
                         )
                         .map(|new_dep| {
                             (

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -34,6 +34,12 @@ error_chain! {
                          --allow-prerelease flag might solve the issue."
             )
         }
+        /// No versions available with requested feature
+        NoVersionsWithFeaturesAvailable {
+            description("Versions of the crates do exist, but not with the requested features. \
+                         Check that the features you requested are indeed available."
+            )
+        }
         /// Unable to parse external Cargo.toml
         ParseCargoToml {
             description("Unable to parse external Cargo.toml")

--- a/tests/cargo-add.rs
+++ b/tests/cargo-add.rs
@@ -1328,6 +1328,24 @@ fn adds_features_dependency() {
 }
 
 #[test]
+fn fails_adding_dependency_with_non_existant_features() {
+    let (_tmpdir, manifest) = clone_out_test("tests/fixtures/add/Cargo.toml.sample");
+
+    // dependency not present beforehand
+    let toml = get_toml(&manifest);
+    assert!(toml["dependencies"].is_none());
+
+    execute_bad_command(
+        &["add", "cargo-edit", "--features", "non-existant-feature"],
+        &manifest,
+    );
+
+    // dependency present afterwards
+    let toml = get_toml(&manifest);
+    assert!(toml["dependencies"].is_none());
+}
+
+#[test]
 fn overrides_existing_features() {
     overwrite_dependency_test(
         &["add", "your-face", "--features", "nose"],


### PR DESCRIPTION
in response to #474. All in all not a huge change. All it really does is pass down any features supplied in the CLI until the latest versions are retrieved and filters the available versions that don't have the requested features. For now it's not very ergonomic since it just exists if a problem occurs. There are no QOL features like fuzzy search or listing features that are available, but I figured it's a good start. 