### PR TITLE
make clippy a bit happier

### DIFF
--- a/src/bin/add/args.rs
+++ b/src/bin/add/args.rs
@@ -156,9 +156,8 @@ impl Args {
         } else if self.build {
             vec!["build-dependencies".to_owned()]
         } else if let Some(ref target) = self.target {
-            if target.is_empty() {
-                panic!("Target specification may not be empty");
-            }
+            assert!(!target.is_empty(), "Target specification may not be empty");
+
             vec![
                 "target".to_owned(),
                 target.clone(),

--- a/src/bin/upgrade/main.rs
+++ b/src/bin/upgrade/main.rs
@@ -130,7 +130,7 @@ fn is_version_dep(dependency: &cargo_metadata::Dependency) -> bool {
     match dependency.source {
         // This is the criterion cargo uses (in `SourceId::from_url`) to decide whether a
         // dependency has the 'registry' kind.
-        Some(ref s) => s.splitn(2, '+').next() == Some("registry"),
+        Some(ref s) => s.split_once('+').map(|(x, _)| x) == Some("registry"),
         _ => false,
     }
 }

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -48,7 +48,7 @@ fn search(dir: &Path) -> Result<PathBuf> {
     } else {
         dir.parent()
             .ok_or_else(|| ErrorKind::MissingManifest.into())
-            .and_then(|dir| search(dir))
+            .and_then(search)
     }
 }
 
@@ -537,7 +537,6 @@ impl LocalManifest {
 mod tests {
     use super::*;
     use crate::dependency::Dependency;
-    use toml_edit;
 
     #[test]
     fn add_remove_dependency() {

--- a/src/version.rs
+++ b/src/version.rs
@@ -298,7 +298,7 @@ mod test {
         #[track_caller]
         fn assert_req_bump<'a, O: Into<Option<&'a str>>>(version: &str, req: &str, expected: O) {
             let version = semver::Version::parse(version).unwrap();
-            let actual = upgrade_requirement(&req, &version).unwrap();
+            let actual = upgrade_requirement(req, &version).unwrap();
             let expected = expected.into();
             assert_eq!(actual.as_deref(), expected);
         }

--- a/tests/cargo-add.rs
+++ b/tests/cargo-add.rs
@@ -99,7 +99,7 @@ fn adds_dependency_with_upgrade_bad() {
     let toml = get_toml(&manifest);
     assert!(toml["dependencies"].is_none());
 
-    let upgrade_arg = format!("--upgrade=an_invalid_string",);
+    let upgrade_arg = "--upgrade=an_invalid_string".to_string();
     execute_bad_command(&["add", "my-package", upgrade_arg.as_str()], &manifest);
 }
 
@@ -1129,7 +1129,7 @@ fn adds_optional_dependency() {
     // dependency present afterwards
     let toml = get_toml(&manifest);
     let val = &toml["dependencies"]["versioned-package"]["optional"];
-    assert_eq!(val.as_bool().expect("optional not a bool"), true);
+    assert!(val.as_bool().expect("optional not a bool"));
 }
 
 #[test]
@@ -1177,7 +1177,7 @@ fn adds_no_default_features_dependency() {
     // dependency present afterwards
     let toml = get_toml(&manifest);
     let val = &toml["dependencies"]["versioned-package"]["default-features"];
-    assert_eq!(val.as_bool().expect("default-features not a bool"), false);
+    assert!(!val.as_bool().expect("default-features not a bool"));
 }
 
 #[test]
@@ -1440,6 +1440,7 @@ fn adds_dependency_normalized_name() {
             "Inflector",
             &format!("--manifest-path={}", manifest),
         ])
+        .assert()
         .success()
         .stderr(predicates::str::contains(
             "WARN: Added `linked-hash-map` instead of `linked_hash_map`",
@@ -1844,11 +1845,10 @@ fn add_typo() {
         .env("CARGO_IS_TEST", "1")
         .assert()
         .code(1)
-    .stderr()
-    .contains(
+    .stderr(predicates::str::contains(
         "The crate `lets_hope_nobody_ever_publishes_this_crate` could not be found in registry index.",
-    )
-    .unwrap();
+    ))
+    ;
 }
 
 #[test]

--- a/tests/utils.rs
+++ b/tests/utils.rs
@@ -46,11 +46,7 @@ pub fn copy_workspace_test() -> (assert_fs::TempDir, String, Vec<String>) {
         (root_manifest_path, workspace_manifest_paths)
     };
 
-    (
-        tmpdir,
-        root_manifest_path,
-        workspace_manifest_paths.to_owned(),
-    )
+    (tmpdir, root_manifest_path, workspace_manifest_paths)
 }
 
 /// Create temporary working directory with Cargo.toml manifest
@@ -59,7 +55,7 @@ pub fn clone_out_test(source: &str) -> (assert_fs::TempDir, String) {
     let manifest_path = tmpdir.child("Cargo.toml");
     manifest_path.write_file(Path::new(source)).unwrap();
     tmpdir.child("src/lib.rs").touch().unwrap();
-    let path = manifest_path.to_str().unwrap().to_string().clone();
+    let path = manifest_path.to_str().unwrap().to_string();
 
     (tmpdir, path)
 }


### PR DESCRIPTION
As promised the clippy warning fixes in a separate PR. Mostly consists of removing redundant clones, and one splitn that was rewritten to split_once. Also fixed two compiler errors in cargo-add tests by adding a `.assert()` call.