### PR TITLE
Imply `--workspace` when running in workspace root

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,6 +236,7 @@ supported. Git/path dependencies will be ignored.
 
 All packages in the workspace will be upgraded if the `--workspace` flag is supplied.
 The `--workspace` flag may be supplied in the presence of a virtual manifest.
+Running in workspace root automatically implies `--workspace`
 
 If the '--to-lockfile' flag is supplied, all dependencies will be upgraded to the currently locked
 version as recorded in the Cargo.lock file. This flag requires that the Cargo.lock file is

--- a/src/bin/set-version/main.rs
+++ b/src/bin/set-version/main.rs
@@ -75,7 +75,8 @@ fn process(args: Args) -> Result<()> {
     if all {
         deprecated_message("The flag `--all` has been deprecated in favor of `--workspace`")?;
     }
-    let all = workspace || all;
+    let all = workspace || all || LocalManifest::find(&None)?.is_virtual();
+
     let manifests = if all {
         Manifests::get_all(&manifest_path)
     } else if let Some(ref pkgid) = pkgid {

--- a/src/bin/upgrade/main.rs
+++ b/src/bin/upgrade/main.rs
@@ -94,6 +94,7 @@ struct Args {
     all: bool,
 
     /// Upgrade all packages in the workspace.
+    /// Implied by default when running in a directory with virtual manifest.
     #[structopt(long = "workspace", conflicts_with = "all", conflicts_with = "pkgid")]
     workspace: bool,
 
@@ -468,7 +469,8 @@ fn process(args: Args) -> Result<()> {
         deprecated_message("The flag `--all` has been deprecated in favor of `--workspace`")?;
     }
 
-    let all = workspace || all;
+    // Running in workspace root automatically implies `--workspace`
+    let all = workspace || all || LocalManifest::find(&None)?.is_virtual();
 
     if !args.offline && !to_lockfile && std::env::var("CARGO_IS_TEST").is_err() {
         let url = registry_url(&find(&manifest_path)?, None)?;

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -293,10 +293,15 @@ impl LocalManifest {
         Ok(LocalManifest { manifest, path })
     }
 
+    /// Check if local manifest is virtual, i. e. corresponds to workspace root
+    pub fn is_virtual(&self) -> bool {
+        !self.data["workspace"].is_none()
+    }
+
     /// Write changes back to the file
     pub fn write(&self) -> Result<()> {
         if self.manifest.data["package"].is_none() && self.manifest.data["project"].is_none() {
-            if !self.manifest.data["workspace"].is_none() {
+            if self.is_virtual() {
                 return Err(ErrorKind::UnexpectedRootManifest.into());
             } else {
                 return Err(ErrorKind::InvalidManifest.into());


### PR DESCRIPTION
Aims for saner defaults & to match `cargo update` behavior
