### PR TITLE
list available features when adding a dependency through cargo-add

### DIFF
--- a/src/bin/add/args.rs
+++ b/src/bin/add/args.rs
@@ -190,7 +190,7 @@ impl Args {
                 let manifest = get_manifest_from_path(path)?;
                 let dep_path = dunce::canonicalize(path)?;
 
-                dependency = dependency.set_available_features(manifest.features());
+                dependency = dependency.set_available_features(manifest.features()?);
                 dependency = dependency.set_path(dep_path);
             }
 
@@ -211,10 +211,10 @@ impl Args {
                         );
 
                         dependency = dependency.set_version(&v);
-                    }
 
-                    if let Some(registry) = &self.registry {
-                        dependency = dependency.set_registry(registry);
+                        if let Some(registry) = &self.registry {
+                            dependency = dependency.set_registry(registry);
+                        }
                     }
                 }
             }
@@ -227,7 +227,7 @@ impl Args {
                 assert!(self.path.is_none());
                 assert!(self.registry.is_none());
                 let features = get_manifest_from_url(repo)?
-                    .map(|m| m.features())
+                    .map(|m| m.features().unwrap())
                     .unwrap_or_else(Vec::new);
 
                 dependency = dependency
@@ -238,7 +238,7 @@ impl Args {
                     assert!(self.registry.is_none());
                     let manifest = get_manifest_from_path(path)?;
 
-                    dependency = dependency.set_available_features(manifest.features());
+                    dependency = dependency.set_available_features(manifest.features()?);
                     dependency = dependency.set_path(dunce::canonicalize(path)?);
                 }
                 if let Some(version) = &self.vers {

--- a/src/bin/add/args.rs
+++ b/src/bin/add/args.rs
@@ -4,8 +4,8 @@
 
 use cargo_edit::{find, registry_url, workspace_members, Dependency};
 use cargo_edit::{get_latest_dependency, CrateName};
-use cargo_metadata::Package;
-use std::path::PathBuf;
+use cargo_metadata::{MetadataCommand, Package};
+use std::path::{Path, PathBuf};
 use structopt::{clap::AppSettings, StructOpt};
 
 use crate::errors::*;
@@ -141,11 +141,40 @@ pub struct Args {
     /// Registry to use
     #[structopt(long = "registry", conflicts_with = "git", conflicts_with = "path")]
     pub registry: Option<String>,
+
+    /// print available features inline. Useful for testing
+    #[structopt(long = "inline")]
+    pub inline: bool,
 }
 
 fn parse_version_req(s: &str) -> Result<&str> {
     semver::VersionReq::parse(s).chain_err(|| "Invalid dependency version requirement")?;
     Ok(s)
+}
+
+pub fn get_featues_from_manifest_path(manifest: &Path) -> Vec<String> {
+    let cargo_path = if manifest.ends_with("Cargo.toml") {
+        manifest.into()
+    } else {
+        manifest.join("Cargo.toml")
+    };
+    //TODO: be better about error handling
+    let dep_package = MetadataCommand::new()
+        .no_deps()
+        .manifest_path(&cargo_path)
+        .exec()
+        .ok()
+        .and_then(|m| m.packages.get(0).cloned());
+
+    match dep_package {
+        Some(pkg) => {
+            let mut tmp = pkg.features.keys().cloned().collect::<Vec<String>>();
+            tmp.sort();
+            tmp.dedup();
+            tmp
+        }
+        None => vec![],
+    }
 }
 
 impl Args {
@@ -202,10 +231,15 @@ impl Args {
                             prefix = self.get_upgrade_prefix(),
                             version = package.version
                         );
+
                         dependency = dependency.set_version(&v);
-                        if let Some(registry) = &self.registry {
-                            dependency = dependency.set_registry(registry);
-                        }
+                    }
+                    let available_features = get_featues_from_manifest_path(&dep_path);
+
+                    dependency = dependency.set_available_features(available_features);
+
+                    if let Some(registry) = &self.registry {
+                        dependency = dependency.set_registry(registry);
                     }
                 }
             }
@@ -218,6 +252,7 @@ impl Args {
                 assert!(self.path.is_none());
                 assert!(self.registry.is_none());
                 dependency = dependency.set_git(repo, self.branch.clone());
+<<<<<<< HEAD
             } else {
                 if let Some(path) = &self.path {
                     assert!(self.registry.is_none());
@@ -263,6 +298,46 @@ impl Args {
                             &find(&self.manifest_path)?,
                             &registry_url,
                         )?;
+=======
+            }
+            if let Some(path) = &self.path {
+                dependency = dependency.set_path(dunce::canonicalize(path)?);
+                dependency =
+                    dependency.set_available_features(get_featues_from_manifest_path(path));
+            }
+            if let Some(version) = &self.vers {
+                dependency = dependency.set_version(parse_version_req(version)?);
+            }
+            let registry_url = if let Some(registry) = &self.registry {
+                Some(registry_url(&find(&self.manifest_path)?, Some(registry))?)
+            } else {
+                None
+            };
+
+            if self.git.is_none() && self.path.is_none() && self.vers.is_none() {
+                // Only special-case workspaces when the user doesn't provide any extra
+                // information, otherwise, trust the user.
+                if let Some(package) = workspace_members
+                    .iter()
+                    .find(|p| p.name == crate_name.name())
+                {
+                    dependency = dependency.set_path(
+                        package
+                            .manifest_path
+                            .parent()
+                            .expect("at least parent dir")
+                            .as_std_path()
+                            .to_owned(),
+                    );
+
+                    let available_features =
+                        get_featues_from_manifest_path(dependency.path().unwrap());
+
+                    dependency = dependency.set_available_features(available_features);
+
+                    // dev-dependencies do not need the version populated
+                    if !self.dev {
+>>>>>>> de411630 (list available features when adding a dependency through cargo-add)
                         let v = format!(
                             "{prefix}{version}",
                             prefix = self.get_upgrade_prefix(),
@@ -357,6 +432,7 @@ impl Default for Args {
             offline: true,
             sort: false,
             registry: None,
+            inline: false,
         }
     }
 }

--- a/src/bin/add/args.rs
+++ b/src/bin/add/args.rs
@@ -227,7 +227,8 @@ impl Args {
                 assert!(self.path.is_none());
                 assert!(self.registry.is_none());
                 let features = get_manifest_from_url(repo)?
-                    .map(|m| m.features().unwrap())
+                    .map(|m| m.features())
+                    .transpose()?
                     .unwrap_or_else(Vec::new);
 
                 dependency = dependency

--- a/src/bin/add/main.rs
+++ b/src/bin/add/main.rs
@@ -68,7 +68,7 @@ mod errors {
 
 use crate::errors::*;
 
-fn print_msg(dep: &Dependency, section: &[String], optional: bool, inline: bool) -> Result<()> {
+fn print_msg(dep: &Dependency, section: &[String], optional: bool) -> Result<()> {
     let colorchoice = if atty::is(atty::Stream::Stdout) {
         ColorChoice::Auto
     } else {
@@ -95,28 +95,14 @@ fn print_msg(dep: &Dependency, section: &[String], optional: bool, inline: bool)
     };
     write!(output, " {}", section)?;
     if let Some(f) = &dep.features {
-        if inline {
-            write!(output, " with features: {:?}", f)?;
-        } else {
-            writeln!(output, " with features: {:?}", f)?;
-        };
+        writeln!(output, " with features: {:?}", f)?;
     }
-    if !inline {
-        writeln!(output, ". ")?;
-    } else {
-        write!(output, ". ")?;
-    };
+    writeln!(output, ". ")?;
 
     if !&dep.available_features.is_empty() {
-        if inline {
-            write!(output, " Optional features: [")?;
-            write!(output, "{}", &dep.available_features.join(", "))?;
-            write!(output, "]")?
-        } else {
-            writeln!(output, "{:>13}Optional features: ", " ")?;
-            for feat in dep.available_features.iter() {
-                writeln!(output, "{:>13}- {}", " ", feat)?;
-            }
+        writeln!(output, "{:>13}Available features: ", " ")?;
+        for feat in dep.available_features.iter() {
+            writeln!(output, "{:>13}- {}", " ", feat)?;
         }
     }
     Ok(())
@@ -166,7 +152,7 @@ fn handle_add(args: &Args) -> Result<()> {
     deps.iter()
         .map(|dep| {
             if !args.quiet {
-                print_msg(dep, &args.get_section(), args.optional, args.inline)?;
+                print_msg(dep, &args.get_section(), args.optional)?;
             }
             if let Some(path) = dep.path() {
                 if path == manifest.path.parent().unwrap_or_else(|| Path::new("")) {

--- a/src/crate_name.rs
+++ b/src/crate_name.rs
@@ -42,13 +42,23 @@ impl<'a> CrateName<'a> {
     pub fn parse_crate_name_from_uri(&self) -> Result<Option<Dependency>> {
         if let Some(manifest) = get_manifest_from_url(self.0)? {
             let crate_name = manifest.package_name()?;
-            Ok(Some(Dependency::new(crate_name).set_git(self.0, None)))
+            let available_features = manifest.features();
+            Ok(Some(
+                Dependency::new(crate_name)
+                    .set_git(self.0, None)
+                    .set_available_features(available_features),
+            ))
         } else if self.is_path() {
             let path = std::path::Path::new(self.0);
             let manifest = get_manifest_from_path(path)?;
             let crate_name = manifest.package_name()?;
             let path = dunce::canonicalize(path)?;
-            Ok(Some(Dependency::new(crate_name).set_path(path)))
+            let available_features = manifest.features();
+            Ok(Some(
+                Dependency::new(crate_name)
+                    .set_path(path)
+                    .set_available_features(available_features),
+            ))
         } else {
             Ok(None)
         }

--- a/src/crate_name.rs
+++ b/src/crate_name.rs
@@ -42,7 +42,7 @@ impl<'a> CrateName<'a> {
     pub fn parse_crate_name_from_uri(&self) -> Result<Option<Dependency>> {
         if let Some(manifest) = get_manifest_from_url(self.0)? {
             let crate_name = manifest.package_name()?;
-            let available_features = manifest.features();
+            let available_features = manifest.features()?;
             Ok(Some(
                 Dependency::new(crate_name)
                     .set_git(self.0, None)
@@ -53,7 +53,7 @@ impl<'a> CrateName<'a> {
             let manifest = get_manifest_from_path(path)?;
             let crate_name = manifest.package_name()?;
             let path = dunce::canonicalize(path)?;
-            let available_features = manifest.features();
+            let available_features = manifest.features()?;
             Ok(Some(
                 Dependency::new(crate_name)
                     .set_path(path)

--- a/src/dependency.rs
+++ b/src/dependency.rs
@@ -13,6 +13,9 @@ pub struct Dependency {
     /// If the dependency is renamed, this is the new name for the dependency
     /// as a string.  None if it is not renamed.
     rename: Option<String>,
+
+    /// Features that are exposed by the dependency
+    pub available_features: Vec<String>,
 }
 
 impl Dependency {
@@ -39,6 +42,12 @@ impl Dependency {
             path: old_path,
             registry: old_registry,
         };
+        self
+    }
+
+    /// Set the available features of the dependency to a given vec
+    pub fn set_available_features(mut self, available_features: Vec<String>) -> Dependency {
+        self.available_features = available_features;
         self
     }
 
@@ -254,6 +263,7 @@ impl Default for Dependency {
                 path: None,
                 registry: None,
             },
+            available_features: vec![],
         }
     }
 }

--- a/src/fetch.rs
+++ b/src/fetch.rs
@@ -39,7 +39,15 @@ pub fn get_latest_dependency(
             }
         };
 
-        return Ok(Dependency::new(crate_name).set_version(&new_version));
+        let features = if crate_name == "your-face" {
+            vec!["nose".to_string(), "mouth".to_string(), "eyes".to_string()]
+        } else {
+            vec![]
+        };
+
+        return Ok(Dependency::new(crate_name)
+            .set_version(&new_version)
+            .set_available_features(features));
     }
 
     if crate_name.is_empty() {
@@ -161,7 +169,12 @@ fn read_latest_version(
 
     let name = &latest.name;
     let version = latest.version.to_string();
-    Ok(Dependency::new(name).set_version(&version))
+    let mut available_features = latest.features.clone();
+    available_features.sort();
+    available_features.dedup();
+    Ok(Dependency::new(name)
+        .set_version(&version)
+        .set_available_features(available_features))
 }
 
 /// update registry index for given project
@@ -219,7 +232,7 @@ fn registry_blocked_message(output: &mut StandardStream) -> Result<()> {
 /// Load Cargo.toml in a local path
 ///
 /// This will fail, when Cargo.toml is not present in the root of the path.
-pub fn get_manifest_from_path(path: &Path) -> Result<LocalManifest> {
+pub fn ifest_from_path(path: &Path) -> Result<LocalManifest> {
     let cargo_file = path.join("Cargo.toml");
     LocalManifest::try_new(&cargo_file).chain_err(|| "Unable to open local Cargo.toml")
 }
@@ -230,11 +243,11 @@ pub fn get_manifest_from_path(path: &Path) -> Result<LocalManifest> {
 /// - there is no Internet connection,
 /// - Cargo.toml is not present in the root of the master branch,
 /// - the response from the server is an error or in an incorrect format.
-pub fn get_manifest_from_url(url: &str) -> Result<Option<Manifest>> {
+pub fn ifest_from_url(url: &str) -> Result<Option<Manifest>> {
     let manifest = if is_github_url(url) {
-        Some(get_manifest_from_github(url)?)
+        Some(ifest_from_github(url)?)
     } else if is_gitlab_url(url) {
-        Some(get_manifest_from_gitlab(url)?)
+        Some(ifest_from_gitlab(url)?)
     } else {
         None
     };
@@ -249,10 +262,10 @@ fn is_gitlab_url(url: &str) -> bool {
     url.contains("https://gitlab.com")
 }
 
-fn get_manifest_from_github(repo: &str) -> Result<Manifest> {
+fn ifest_from_github(repo: &str) -> Result<Manifest> {
     let re =
         Regex::new(r"^https://github.com/([-_0-9a-zA-Z]+)/([-_0-9a-zA-Z]+)(/|.git)?$").unwrap();
-    get_manifest_from_repository(repo, &re, |user, repo| {
+    ifest_from_repository(repo, &re, |user, repo| {
         format!(
             "https://raw.githubusercontent.com/{user}/{repo}/master/Cargo.toml",
             user = user,
@@ -261,10 +274,10 @@ fn get_manifest_from_github(repo: &str) -> Result<Manifest> {
     })
 }
 
-fn get_manifest_from_gitlab(repo: &str) -> Result<Manifest> {
+fn ifest_from_gitlab(repo: &str) -> Result<Manifest> {
     let re =
         Regex::new(r"^https://gitlab.com/([-_0-9a-zA-Z]+)/([-_0-9a-zA-Z]+)(/|.git)?$").unwrap();
-    get_manifest_from_repository(repo, &re, |user, repo| {
+    ifest_from_repository(repo, &re, |user, repo| {
         format!(
             "https://gitlab.com/{user}/{repo}/raw/master/Cargo.toml",
             user = user,
@@ -273,7 +286,7 @@ fn get_manifest_from_gitlab(repo: &str) -> Result<Manifest> {
     })
 }
 
-fn get_manifest_from_repository<T>(repo: &str, matcher: &Regex, url_template: T) -> Result<Manifest>
+fn ifest_from_repository<T>(repo: &str, matcher: &Regex, url_template: T) -> Result<Manifest>
 where
     T: Fn(&str, &str) -> String,
 {

--- a/src/fetch.rs
+++ b/src/fetch.rs
@@ -242,7 +242,7 @@ pub fn get_manifest_from_url(url: &str) -> Result<Option<Manifest>> {
     let manifest = if is_github_url(url) {
         Some(get_manifest_from_github(url)?)
     } else if is_gitlab_url(url) {
-        Some(get_manget_manifest_from_gitlab(url)?)
+        Some(get_manifest_from_gitlab(url)?)
     } else {
         None
     };
@@ -269,7 +269,7 @@ fn get_manifest_from_github(repo: &str) -> Result<Manifest> {
     })
 }
 
-fn get_manget_manifest_from_gitlab(repo: &str) -> Result<Manifest> {
+fn get_manifest_from_gitlab(repo: &str) -> Result<Manifest> {
     let re =
         Regex::new(r"^https://gitlab.com/([-_0-9a-zA-Z]+)/([-_0-9a-zA-Z]+)(/|.git)?$").unwrap();
     get_manifest_from_repository(repo, &re, |user, repo| {

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -96,18 +96,18 @@ impl Manifest {
     }
 
     /// returns features exposed by this manifest
-    pub fn features(&self) -> Vec<String> {
+    pub fn features(&self) -> Result<Vec<String>> {
         match self.data.as_table().get("features") {
-            None => vec![],
+            None => Ok(vec![]),
             Some(item) => match item {
-                toml_edit::Item::None => vec![],
-                toml_edit::Item::Table(t) => t
+                toml_edit::Item::None => Ok(vec![]),
+                toml_edit::Item::Table(t) => Ok(t
                     .get_values()
                     .iter()
                     .map(|(keys, _val)| keys.iter().map(|k| k.to_string()))
                     .flatten()
-                    .collect(),
-                _ => unreachable!(),
+                    .collect()),
+                _ => Err(ErrorKind::InvalidCargoConfig.into()),
             },
         }
     }

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -94,6 +94,33 @@ impl Manifest {
 
         sections
     }
+
+    /// returns features exposed by this manifest
+    pub fn features(&self) -> Vec<String> {
+        match self.data.as_table().get("features") {
+            None => vec![],
+            Some(item) => match item {
+                toml_edit::Item::None => vec![],
+                toml_edit::Item::Value(v) => vec![v.to_string()],
+                toml_edit::Item::Table(t) => t
+                    .get_values()
+                    .iter()
+                    .map(|(keys, _val)| keys.iter().map(|k| k.to_string()))
+                    .flatten()
+                    .collect(),
+                toml_edit::Item::ArrayOfTables(a) => a
+                    .iter()
+                    .map(|t| {
+                        t.get_values()
+                            .iter()
+                            .map(|(keys, _val)| keys.iter().map(|k| k.to_string()))
+                            .flatten()
+                            .collect()
+                    })
+                    .collect(),
+            },
+        }
+    }
 }
 
 impl str::FromStr for Manifest {

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -101,23 +101,13 @@ impl Manifest {
             None => vec![],
             Some(item) => match item {
                 toml_edit::Item::None => vec![],
-                toml_edit::Item::Value(v) => vec![v.to_string()],
                 toml_edit::Item::Table(t) => t
                     .get_values()
                     .iter()
                     .map(|(keys, _val)| keys.iter().map(|k| k.to_string()))
                     .flatten()
                     .collect(),
-                toml_edit::Item::ArrayOfTables(a) => a
-                    .iter()
-                    .map(|t| {
-                        t.get_values()
-                            .iter()
-                            .map(|(keys, _val)| keys.iter().map(|k| k.to_string()))
-                            .flatten()
-                            .collect()
-                    })
-                    .collect(),
+                _ => unreachable!(),
             },
         }
     }

--- a/tests/cargo-add.rs
+++ b/tests/cargo-add.rs
@@ -1358,6 +1358,7 @@ fn lists_features_path_dependency() {
             &format!("{}", dep_tmpdir.path().display()),
             &format!("--manifest-path={}", crate_manifest),
         ])
+        .env("CARGO_IS_TEST", "1")
         .assert()
         .stderr(predicates::str::contains("Available features:"))
         .stderr(predicates::str::contains("nose"))
@@ -1396,6 +1397,7 @@ fn lists_features_versioned_dependency_with_path() {
             &format!("{}", dep_tmpdir.path().display()),
             &format!("--manifest-path={}", crate_manifest),
         ])
+        .env("CARGO_IS_TEST", "1")
         .assert()
         .stderr(predicates::str::contains("Available features:"))
         .stderr(predicates::str::contains("nose"))

--- a/tests/cargo-add.rs
+++ b/tests/cargo-add.rs
@@ -1339,11 +1339,9 @@ fn lists_features_dependency_with_path() {
             "--path",
             &format!("{}", dep_tmpdir.path().display()),
             &format!("--manifest-path={}", crate_manifest),
-            "--inline",
         ])
-        .env("CARGO_IS_TEST", "1")
         .assert()
-        .stderr(predicates::str::contains("Optional features:"))
+        .stderr(predicates::str::contains("Available features:"))
         .stderr(predicates::str::contains("nose"))
         .stderr(predicates::str::contains("mouth"))
         .stderr(predicates::str::contains("eyes"));
@@ -1359,11 +1357,9 @@ fn lists_features_path_dependency() {
             "add",
             &format!("{}", dep_tmpdir.path().display()),
             &format!("--manifest-path={}", crate_manifest),
-            "--inline",
         ])
-        .env("CARGO_IS_TEST", "1")
         .assert()
-        .stderr(predicates::str::contains("Optional features:"))
+        .stderr(predicates::str::contains("Available features:"))
         .stderr(predicates::str::contains("nose"))
         .stderr(predicates::str::contains("mouth"))
         .stderr(predicates::str::contains("eyes"));
@@ -1378,11 +1374,30 @@ fn lists_features_plain_dependency() {
             "add",
             "your-face",
             &format!("--manifest-path={}", crate_manifest),
-            "--inline",
         ])
         .env("CARGO_IS_TEST", "1")
         .assert()
-        .stderr(predicates::str::contains("Optional features:"))
+        .stderr(predicates::str::contains("Available features:"))
+        .stderr(predicates::str::contains("nose"))
+        .stderr(predicates::str::contains("mouth"))
+        .stderr(predicates::str::contains("eyes"));
+}
+
+#[test]
+fn lists_features_versioned_dependency_with_path() {
+    let (_crate_tmpdir, crate_manifest) = clone_out_test("tests/fixtures/add/Cargo.toml.sample");
+    let (dep_tmpdir, _dep_manifest) = clone_out_test("tests/fixtures/add/Cargo.toml.features");
+    Command::cargo_bin("cargo-add")
+        .expect("can find bin")
+        .args(&[
+            "add",
+            "your-face@0.1.3",
+            "--path",
+            &format!("{}", dep_tmpdir.path().display()),
+            &format!("--manifest-path={}", crate_manifest),
+        ])
+        .assert()
+        .stderr(predicates::str::contains("Available features:"))
         .stderr(predicates::str::contains("nose"))
         .stderr(predicates::str::contains("mouth"))
         .stderr(predicates::str::contains("eyes"));

--- a/tests/cargo-add.rs
+++ b/tests/cargo-add.rs
@@ -1304,7 +1304,7 @@ fn adds_dependency_with_target_cfg() {
 }
 
 #[test]
-fn lists_features_github_dependency() {
+fn adds_features_dependency() {
     let (_tmpdir, manifest) = clone_out_test("tests/fixtures/add/Cargo.toml.sample");
 
     // dependency not present beforehand
@@ -1333,13 +1333,10 @@ fn lists_features_dependency_with_path() {
     let (dep_tmpdir, _dep_manifest) = clone_out_test("tests/fixtures/add/Cargo.toml.features");
     Command::cargo_bin("cargo-add")
         .expect("can find bin")
-        .args(&[
-            "add",
-            "your-face",
-            "--path",
-            &format!("{}", dep_tmpdir.path().display()),
-            &format!("--manifest-path={}", crate_manifest),
-        ])
+        .args(&["add", "your-face", "--path"])
+        .arg(&dep_tmpdir.path())
+        .arg("--manifest-path")
+        .arg(crate_manifest)
         .assert()
         .stderr(predicates::str::contains("Available features:"))
         .stderr(predicates::str::contains("nose"))
@@ -1353,11 +1350,10 @@ fn lists_features_path_dependency() {
     let (dep_tmpdir, _dep_manifest) = clone_out_test("tests/fixtures/add/Cargo.toml.features");
     Command::cargo_bin("cargo-add")
         .expect("can find bin")
-        .args(&[
-            "add",
-            &format!("{}", dep_tmpdir.path().display()),
-            &format!("--manifest-path={}", crate_manifest),
-        ])
+        .args(&["add"])
+        .arg(&dep_tmpdir.path())
+        .arg("--manifest-path")
+        .arg(crate_manifest)
         .env("CARGO_IS_TEST", "1")
         .assert()
         .stderr(predicates::str::contains("Available features:"))
@@ -1371,11 +1367,9 @@ fn lists_features_plain_dependency() {
     let (_tmpdir, crate_manifest) = clone_out_test("tests/fixtures/add/Cargo.toml.sample");
     Command::cargo_bin("cargo-add")
         .expect("can find bin")
-        .args(&[
-            "add",
-            "your-face",
-            &format!("--manifest-path={}", crate_manifest),
-        ])
+        .args(&["add", "your-face"])
+        .arg("--manifest-path")
+        .arg(crate_manifest)
         .env("CARGO_IS_TEST", "1")
         .assert()
         .stderr(predicates::str::contains("Available features:"))
@@ -1390,13 +1384,10 @@ fn lists_features_versioned_dependency_with_path() {
     let (dep_tmpdir, _dep_manifest) = clone_out_test("tests/fixtures/add/Cargo.toml.features");
     Command::cargo_bin("cargo-add")
         .expect("can find bin")
-        .args(&[
-            "add",
-            "your-face@0.1.3",
-            "--path",
-            &format!("{}", dep_tmpdir.path().display()),
-            &format!("--manifest-path={}", crate_manifest),
-        ])
+        .args(&["add", "your-face@0.1.3", "--path"])
+        .arg(&dep_tmpdir.path())
+        .arg("--manifest-path")
+        .arg(crate_manifest)
         .env("CARGO_IS_TEST", "1")
         .assert()
         .stderr(predicates::str::contains("Available features:"))

--- a/tests/cargo-add.rs
+++ b/tests/cargo-add.rs
@@ -1304,7 +1304,7 @@ fn adds_dependency_with_target_cfg() {
 }
 
 #[test]
-fn adds_features_dependency() {
+fn lists_features_github_dependency() {
     let (_tmpdir, manifest) = clone_out_test("tests/fixtures/add/Cargo.toml.sample");
 
     // dependency not present beforehand
@@ -1325,6 +1325,67 @@ fn adds_features_dependency() {
     let toml = get_toml(&manifest);
     let val = toml["dependencies"]["cargo-edit"]["features"][0].as_str();
     assert_eq!(val, Some("jui"));
+}
+
+#[test]
+fn lists_features_dependency_with_path() {
+    let (_crate_tmpdir, crate_manifest) = clone_out_test("tests/fixtures/add/Cargo.toml.sample");
+    let (dep_tmpdir, _dep_manifest) = clone_out_test("tests/fixtures/add/Cargo.toml.features");
+    Command::cargo_bin("cargo-add")
+        .expect("can find bin")
+        .args(&[
+            "add",
+            "your-face",
+            "--path",
+            &format!("{}", dep_tmpdir.path().display()),
+            &format!("--manifest-path={}", crate_manifest),
+            "--inline",
+        ])
+        .env("CARGO_IS_TEST", "1")
+        .assert()
+        .stderr(predicates::str::contains("Optional features:"))
+        .stderr(predicates::str::contains("nose"))
+        .stderr(predicates::str::contains("mouth"))
+        .stderr(predicates::str::contains("eyes"));
+}
+
+#[test]
+fn lists_features_path_dependency() {
+    let (_crate_tmpdir, crate_manifest) = clone_out_test("tests/fixtures/add/Cargo.toml.sample");
+    let (dep_tmpdir, _dep_manifest) = clone_out_test("tests/fixtures/add/Cargo.toml.features");
+    Command::cargo_bin("cargo-add")
+        .expect("can find bin")
+        .args(&[
+            "add",
+            &format!("{}", dep_tmpdir.path().display()),
+            &format!("--manifest-path={}", crate_manifest),
+            "--inline",
+        ])
+        .env("CARGO_IS_TEST", "1")
+        .assert()
+        .stderr(predicates::str::contains("Optional features:"))
+        .stderr(predicates::str::contains("nose"))
+        .stderr(predicates::str::contains("mouth"))
+        .stderr(predicates::str::contains("eyes"));
+}
+
+#[test]
+fn lists_features_plain_dependency() {
+    let (_tmpdir, crate_manifest) = clone_out_test("tests/fixtures/add/Cargo.toml.sample");
+    Command::cargo_bin("cargo-add")
+        .expect("can find bin")
+        .args(&[
+            "add",
+            "your-face",
+            &format!("--manifest-path={}", crate_manifest),
+            "--inline",
+        ])
+        .env("CARGO_IS_TEST", "1")
+        .assert()
+        .stderr(predicates::str::contains("Optional features:"))
+        .stderr(predicates::str::contains("nose"))
+        .stderr(predicates::str::contains("mouth"))
+        .stderr(predicates::str::contains("eyes"));
 }
 
 #[test]

--- a/tests/fixtures/add/Cargo.toml.features
+++ b/tests/fixtures/add/Cargo.toml.features
@@ -1,0 +1,13 @@
+[package]
+name = "your-face"
+version = "0.1.3"
+
+[dependencies]
+toml_edit = "0.1.5"
+atty = "0.2.13"
+
+[features]
+default = ["nose","mouth"]
+nose = []
+mouth = []
+eyes = []


### PR DESCRIPTION
This one is to address #529 and does precisely that. One decision I made that the reviewer might want to consider is that I didn't add this functionality when using `cargo-add` to add specific versioned crates. That was mostly because that currently doesn't have to hit either the file system or the registry and I didn't want to add that there and basically duplicate all the effort, nor did I want to try and refactor the whole thing in this PR so for now I just left it. If this is something people would like to see I'm willing to work on that. Otherwise it's a relatively small PR, mostly just connecting the dots on work that was already done, so hopefully it will be an easy merge. 

I also still have a draft PR (#528) that is related to this, and will at the least be easier to implement if this gets pulled. This does already do a long way to addressing the issue I wanted to address with that PR so if this gets pulled and nobody tells me that they would really like to see that one too, I might just close that. We'll see.

Over all I think it's a really nice QoL improvement and I hope you all like it :) Feedback is welcome as always.

