### PR TITLE
refactor: Raise visibility of pub items

### DIFF
--- a/src/dependency.rs
+++ b/src/dependency.rs
@@ -1,18 +1,5 @@
 use std::path::{Path, PathBuf};
 
-#[derive(Debug, Hash, PartialEq, Eq, Clone)]
-enum DependencySource {
-    Version {
-        version: Option<String>,
-        path: Option<PathBuf>,
-        registry: Option<String>,
-    },
-    Git {
-        repo: String,
-        branch: Option<String>,
-    },
-}
-
 /// A dependency handled by Cargo
 #[derive(Debug, Hash, PartialEq, Eq, Clone)]
 pub struct Dependency {
@@ -26,23 +13,6 @@ pub struct Dependency {
     /// If the dependency is renamed, this is the new name for the dependency
     /// as a string.  None if it is not renamed.
     rename: Option<String>,
-}
-
-impl Default for Dependency {
-    fn default() -> Dependency {
-        Dependency {
-            name: "".into(),
-            rename: None,
-            optional: false,
-            features: None,
-            default_features: true,
-            source: DependencySource::Version {
-                version: None,
-                path: None,
-                registry: None,
-            },
-        }
-    }
 }
 
 impl Dependency {
@@ -269,6 +239,36 @@ impl Dependency {
 
         (self.name_in_manifest().to_string(), data)
     }
+}
+
+impl Default for Dependency {
+    fn default() -> Dependency {
+        Dependency {
+            name: "".into(),
+            rename: None,
+            optional: false,
+            features: None,
+            default_features: true,
+            source: DependencySource::Version {
+                version: None,
+                path: None,
+                registry: None,
+            },
+        }
+    }
+}
+
+#[derive(Debug, Hash, PartialEq, Eq, Clone)]
+enum DependencySource {
+    Version {
+        version: Option<String>,
+        path: Option<PathBuf>,
+        registry: Option<String>,
+    },
+    Git {
+        repo: String,
+        branch: Option<String>,
+    },
 }
 
 #[cfg(test)]

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -6,36 +6,6 @@ use url::Url;
 const CRATES_IO_INDEX: &str = "https://github.com/rust-lang/crates.io-index";
 const CRATES_IO_REGISTRY: &str = "crates-io";
 
-#[derive(Debug, Deserialize)]
-struct Source {
-    #[serde(rename = "replace-with")]
-    replace_with: Option<String>,
-    registry: Option<String>,
-}
-
-#[derive(Debug, Deserialize)]
-struct Registry {
-    index: Option<String>,
-}
-
-#[derive(Debug, Deserialize)]
-struct CargoConfig {
-    #[serde(default)]
-    registries: HashMap<String, Registry>,
-    #[serde(default)]
-    source: HashMap<String, Source>,
-}
-
-fn cargo_home() -> Result<PathBuf> {
-    let default_cargo_home = dirs_next::home_dir()
-        .map(|x| x.join(".cargo"))
-        .chain_err(|| ErrorKind::ReadHomeDirFailure)?;
-    let cargo_home = std::env::var("CARGO_HOME")
-        .map(PathBuf::from)
-        .unwrap_or(default_cargo_home);
-    Ok(cargo_home)
-}
-
 /// Find the URL of a registry
 pub fn registry_url(manifest_path: &Path, registry: Option<&str>) -> Result<Url> {
     // TODO support local registry sources, directory sources, git sources: https://doc.rust-lang.org/cargo/reference/source-replacement.html?highlight=replace-with#source-replacement
@@ -116,6 +86,36 @@ pub fn registry_url(manifest_path: &Path, registry: Option<&str>) -> Result<Url>
         .chain_err(|| ErrorKind::InvalidCargoConfig)?;
 
     Ok(registry_url)
+}
+
+#[derive(Debug, Deserialize)]
+struct CargoConfig {
+    #[serde(default)]
+    registries: HashMap<String, Registry>,
+    #[serde(default)]
+    source: HashMap<String, Source>,
+}
+
+#[derive(Debug, Deserialize)]
+struct Source {
+    #[serde(rename = "replace-with")]
+    replace_with: Option<String>,
+    registry: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct Registry {
+    index: Option<String>,
+}
+
+fn cargo_home() -> Result<PathBuf> {
+    let default_cargo_home = dirs_next::home_dir()
+        .map(|x| x.join(".cargo"))
+        .chain_err(|| ErrorKind::ReadHomeDirFailure)?;
+    let cargo_home = std::env::var("CARGO_HOME")
+        .map(PathBuf::from)
+        .unwrap_or(default_cargo_home);
+    Ok(cargo_home)
 }
 
 mod code_from_cargo {


### PR DESCRIPTION
Before, functions were scattered in the files.  Now. each mod starts
with a `pub` and groups impl blocks next to their related item, making
it easier to discover related logic.