### PR TITLE
refactor: Make manifest loading reusable

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,8 +31,7 @@ pub use crate::crate_name::CrateName;
 pub use crate::dependency::Dependency;
 pub use crate::errors::*;
 pub use crate::fetch::{
-    get_crate_name_from_github, get_crate_name_from_gitlab, get_crate_name_from_path,
-    get_latest_dependency, update_registry_index,
+    get_latest_dependency, get_manifest_from_path, get_manifest_from_url, update_registry_index,
 };
 pub use crate::manifest::{find, LocalManifest, Manifest};
 pub use crate::metadata::{manifest_from_pkgid, workspace_members};


### PR DESCRIPTION
Both the loading from inferred url/path and the explicit can now reuse
logic from each other.