### PR TITLE
feat: Report features with `name@ver` deps

### DIFF
--- a/src/bin/upgrade/main.rs
+++ b/src/bin/upgrade/main.rs
@@ -427,7 +427,7 @@ impl DesiredUpgrades {
                             &dep.name,
                             allow_prerelease,
                             manifest_path,
-                            &registry_url,
+                            registry_url.as_ref(),
                         )
                         .map(|new_dep| {
                             (

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,7 +31,8 @@ pub use crate::crate_name::CrateName;
 pub use crate::dependency::Dependency;
 pub use crate::errors::*;
 pub use crate::fetch::{
-    get_latest_dependency, get_manifest_from_path, get_manifest_from_url, update_registry_index,
+    get_features_from_registry, get_latest_dependency, get_manifest_from_path,
+    get_manifest_from_url, update_registry_index,
 };
 pub use crate::manifest::{find, LocalManifest, Manifest};
 pub use crate::metadata::{manifest_from_pkgid, workspace_members};


### PR DESCRIPTION
This should cover the last gap for closing out #529

```
 cargo-add serde@1
   Compiling cargo-edit v0.8.0 (/home/epage/src/personal/cargo-edit)
    Finished dev [unoptimized + debuginfo] target(s) in 4.60s
     Running `target/debug/cargo-add add 'serde@1'`
    Updating 'https://github.com/rust-lang/crates.io-index' index
      Adding serde v1 to dependencies.
             Available features:
             - derive
             - default
             - alloc
             - std
             - rc
             - unstable
```

Fixes #529