### PR TITLE
cargo add now validates features against manifest before adding

### DIFF
--- a/src/bin/add/args.rs
+++ b/src/bin/add/args.rs
@@ -307,7 +307,10 @@ impl Args {
     }
 
     /// Build dependencies from arguments
-    pub fn parse_dependencies(&self) -> Result<Vec<Dependency>> {
+    pub fn parse_dependencies(
+        &self,
+        requested_features: Option<Vec<String>>,
+    ) -> Result<Vec<Dependency>> {
         let workspace_members = workspace_members(self.manifest_path.as_deref())?;
 
         if self.crates.len() > 1
@@ -331,7 +334,7 @@ impl Args {
                     .map(|x| {
                         let mut x = x
                             .set_optional(self.optional)
-                            .set_features(self.features.clone())
+                            .set_features(requested_features.to_owned())
                             .set_default_features(!self.no_default_features);
                         if let Some(ref rename) = self.rename {
                             x = x.set_rename(rename);
@@ -395,7 +398,7 @@ mod tests {
         };
 
         assert_eq!(
-            args.parse_dependencies().unwrap(),
+            args.parse_dependencies(None).unwrap(),
             vec![Dependency::new("demo").set_version("0.4.2")]
         );
     }
@@ -409,7 +412,7 @@ mod tests {
             ..Args::default()
         };
         assert_eq!(
-            args_github.parse_dependencies().unwrap(),
+            args_github.parse_dependencies(None).unwrap(),
             vec![Dependency::new("cargo-edit").set_git(github_url, None)]
         );
 
@@ -419,7 +422,7 @@ mod tests {
             ..Args::default()
         };
         assert_eq!(
-            args_gitlab.parse_dependencies().unwrap(),
+            args_gitlab.parse_dependencies(None).unwrap(),
             vec![Dependency::new("polly").set_git(gitlab_url, None)]
         );
     }
@@ -433,7 +436,9 @@ mod tests {
             ..Args::default()
         };
         assert_eq!(
-            args_path.parse_dependencies().unwrap()[0].path().unwrap(),
+            args_path.parse_dependencies(None).unwrap()[0]
+                .path()
+                .unwrap(),
             self_path
         );
     }

--- a/src/bin/add/main.rs
+++ b/src/bin/add/main.rs
@@ -145,10 +145,13 @@ fn handle_add(args: &Args) -> Result<()> {
         )?;
         update_registry_index(&url, args.quiet)?;
     }
-    let requested_features: Option<BTreeSet<&str>> = args
-        .features
-        .as_ref()
-        .map(|v| v.iter().map(|s| s.split(' ')).flatten().filter(|s| !s.is_empty()).collect());
+    let requested_features: Option<BTreeSet<&str>> = args.features.as_ref().map(|v| {
+        v.iter()
+            .map(|s| s.split(' '))
+            .flatten()
+            .filter(|s| !s.is_empty())
+            .collect()
+    });
 
     let deps = &args.parse_dependencies(
         requested_features

--- a/src/bin/upgrade/main.rs
+++ b/src/bin/upgrade/main.rs
@@ -141,13 +141,13 @@ fn deprecated_message(message: &str) -> Result<()> {
     buffer
         .set_color(ColorSpec::new().set_fg(Some(Color::Red)).set_bold(true))
         .chain_err(|| "Failed to set output colour")?;
-    writeln!(&mut buffer, "{}", message).chain_err(|| "Failed to write dry run message")?;
+    writeln!(&mut buffer, "{}", message).chain_err(|| "Failed to write deprecated message")?;
     buffer
         .set_color(&ColorSpec::new())
         .chain_err(|| "Failed to clear output colour")?;
     bufwtr
         .print(&buffer)
-        .chain_err(|| "Failed to print dry run message")
+        .chain_err(|| "Failed to print deprecated message")
 }
 
 fn dry_run_message() -> Result<()> {

--- a/src/dependency.rs
+++ b/src/dependency.rs
@@ -90,13 +90,7 @@ impl Dependency {
     }
     /// Set features as an array of string (does some basic parsing)
     pub fn set_features(mut self, features: Option<Vec<String>>) -> Dependency {
-        self.features = features.map(|f| {
-            f.iter()
-                .map(|x| x.split(' ').map(String::from))
-                .flatten()
-                .filter(|s| !s.is_empty())
-                .collect::<Vec<String>>()
-        });
+        self.features = features;
         self
     }
 

--- a/src/fetch.rs
+++ b/src/fetch.rs
@@ -40,7 +40,12 @@ pub fn get_latest_dependency(
         };
 
         let features = if crate_name == "your-face" {
-            vec!["nose".to_string(), "mouth".to_string(), "eyes".to_string()]
+            vec![
+                "nose".to_string(),
+                "mouth".to_string(),
+                "eyes".to_string(),
+                "ears".to_string(),
+            ]
         } else {
             vec![]
         };

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -104,9 +104,8 @@ impl Manifest {
                 toml_edit::Item::Table(t) => Ok(t
                     .get_values()
                     .iter()
-                    .map(|(keys, _val)| keys.iter().map(|&k| k.to_string()))
+                    .map(|(keys, _val)| keys.iter().map(|&k| k.get().trim().to_owned()))
                     .flatten()
-                    .map(|s| s.trim().to_string())
                     .collect()),
                 _ => Err(ErrorKind::InvalidCargoConfig.into()),
             },

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -104,8 +104,9 @@ impl Manifest {
                 toml_edit::Item::Table(t) => Ok(t
                     .get_values()
                     .iter()
-                    .map(|(keys, _val)| keys.iter().map(|k| k.to_string()))
+                    .map(|(keys, _val)| keys.iter().map(|&k| k.to_string()))
                     .flatten()
+                    .map(|s| s.trim().to_string())
                     .collect()),
                 _ => Err(ErrorKind::InvalidCargoConfig.into()),
             },

--- a/tests/cargo-add.rs
+++ b/tests/cargo-add.rs
@@ -1335,11 +1335,13 @@ fn warns_on_unknown_features_dependency() {
         .env("CARGO_IS_TEST", "1")
         .assert()
         .success()
-        .stdout(predicates::str::contains("WARN: The features [\"noze\"] were requested but are not exposed by the crate. Available features are: "))
-        .stdout(predicates::str::contains("eyes"))
-        .stdout(predicates::str::contains("nose"))
-        .stdout(predicates::str::contains("mouth"))
-        .stdout(predicates::str::contains("ears"));
+        .stderr(predicates::str::contains(
+            "Unrecognized features: [\"noze\"]",
+        ))
+        .stderr(predicates::str::contains("eyes"))
+        .stderr(predicates::str::contains("nose"))
+        .stderr(predicates::str::contains("mouth"))
+        .stderr(predicates::str::contains("ears"));
 
     // dependency is present afterwards
     let toml = get_toml(&manifest);


### PR DESCRIPTION
Addresses #474. Was surprisingly easy after #538 was merged. Some of tests had to be slightly modified since they couldn't use non-existent features for testing anymore, but in spirit they remain the same. Perhaps one day we could even recommend options with fuzzy search but I think that one is for another day. 

Fixes #474 