### PR TITLE
fix(add): Feature-gate `--git`

### DIFF
--- a/src/bin/add/args.rs
+++ b/src/bin/add/args.rs
@@ -103,6 +103,10 @@ pub struct Args {
     /// Registry to use
     #[clap(long, conflicts_with = "git")]
     pub registry: Option<String>,
+
+    /// Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for details
+    #[clap(short = 'Z', value_name = "FLAG", global = true, arg_enum)]
+    pub unstable_features: Vec<UnstableOptions>,
 }
 
 impl Args {
@@ -305,8 +309,14 @@ impl Default for Args {
             quiet: false,
             offline: true,
             registry: None,
+            unstable_features: vec![],
         }
     }
+}
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq, clap::ArgEnum)]
+pub enum UnstableOptions {
+    Git,
 }
 
 #[cfg(test)]

--- a/src/bin/add/main.rs
+++ b/src/bin/add/main.rs
@@ -14,7 +14,7 @@
 #[macro_use]
 extern crate error_chain;
 
-use crate::args::{Args, Command};
+use crate::args::{Args, Command, UnstableOptions};
 use cargo_edit::{
     colorize_stderr, find, manifest_from_pkgid, registry_url, update_registry_index, Dependency,
     LocalManifest,
@@ -140,6 +140,10 @@ fn unrecognized_features_message(message: &str) -> Result<()> {
 }
 
 fn handle_add(mut args: Args) -> Result<()> {
+    if args.git.is_some() && !args.unstable_features.contains(&UnstableOptions::Git) {
+        return Err("`--git` is unstable and requires `-Z git`".into());
+    }
+
     if let Some(ref pkgid) = args.pkgid {
         let pkg = manifest_from_pkgid(args.manifest_path.as_deref(), pkgid)?;
         args.manifest_path = Some(pkg.manifest_path.into_std_path_buf());

--- a/tests/cmd/add/git.toml
+++ b/tests/cmd/add/git.toml
@@ -1,5 +1,5 @@
 bin.name = "cargo-add"
-args = ["add", "git-package", "--git", "http://localhost/git-package.git"]
+args = ["add", "git-package", "--git", "http://localhost/git-package.git", "-Zgit"]
 status = "success"
 stdout = ""
 stderr = """

--- a/tests/cmd/add/git_branch.toml
+++ b/tests/cmd/add/git_branch.toml
@@ -1,5 +1,5 @@
 bin.name = "cargo-add"
-args = ["add", "git-package", "--git", "http://localhost/git-package.git", "--branch", "main"]
+args = ["add", "git-package", "--git", "http://localhost/git-package.git", "--branch", "main", "-Zgit"]
 status = "success"
 stdout = ""
 stderr = """

--- a/tests/cmd/add/git_conflicts_namever.toml
+++ b/tests/cmd/add/git_conflicts_namever.toml
@@ -1,5 +1,5 @@
 bin.name = "cargo-add"
-args = ["add", "my-package:0.4.3", "--git", "https://github.com/dcjanus/invalid"]
+args = ["add", "my-package:0.4.3", "--git", "https://github.com/dcjanus/invalid", "-Zgit"]
 status.code = 1
 stdout = ""
 stderr = """

--- a/tests/cmd/add/git_conflicts_registry.toml
+++ b/tests/cmd/add/git_conflicts_registry.toml
@@ -1,12 +1,12 @@
 bin.name = "cargo-add"
-args = ["add", "my-package", "--git", "https://github.com/dcjanus/invalid", "--registry", "alternative"]
+args = ["add", "my-package", "--git", "https://github.com/dcjanus/invalid", "--registry", "alternative", "-Zgit"]
 status.code = 2
 stdout = ""
 stderr = """
 error: The argument '--git <URI>' cannot be used with '--registry <REGISTRY>'
 
 USAGE:
-    cargo add --git <URI> <CRATE>...
+    cargo add --git <URI> -Z <FLAG> <CRATE>...
 
 For more information try --help
 """

--- a/tests/cmd/add/git_dev.toml
+++ b/tests/cmd/add/git_dev.toml
@@ -1,6 +1,6 @@
 # Ensure it works with other flags
 bin.name = "cargo-add"
-args = ["add", "git-package", "--git", "http://localhost/git-package.git", "--dev"]
+args = ["add", "git-package", "--git", "http://localhost/git-package.git", "--dev", "-Zgit"]
 status = "success"
 stdout = ""
 stderr = """

--- a/tests/cmd/add/git_rev.toml
+++ b/tests/cmd/add/git_rev.toml
@@ -1,5 +1,5 @@
 bin.name = "cargo-add"
-args = ["add", "git-package", "--git", "http://localhost/git-package.git", "--rev", "423a3"]
+args = ["add", "git-package", "--git", "http://localhost/git-package.git", "--rev", "423a3", "-Zgit"]
 status = "success"
 stdout = ""
 stderr = """

--- a/tests/cmd/add/git_tag.toml
+++ b/tests/cmd/add/git_tag.toml
@@ -1,5 +1,5 @@
 bin.name = "cargo-add"
-args = ["add", "git-package", "--git", "http://localhost/git-package.git", "--tag", "v1.0.0"]
+args = ["add", "git-package", "--git", "http://localhost/git-package.git", "--tag", "v1.0.0", "-Zgit"]
 status = "success"
 stdout = ""
 stderr = """

--- a/tests/cmd/add/invalid_git_no_unstable.in
+++ b/tests/cmd/add/invalid_git_no_unstable.in
@@ -1,0 +1,1 @@
+add-basic.in/

--- a/tests/cmd/add/invalid_git_no_unstable.out/Cargo.toml
+++ b/tests/cmd/add/invalid_git_no_unstable.out/Cargo.toml
@@ -1,0 +1,3 @@
+[package]
+name = "cargo-list-test-fixture"
+version = "0.0.0"

--- a/tests/cmd/add/invalid_git_no_unstable.toml
+++ b/tests/cmd/add/invalid_git_no_unstable.toml
@@ -1,0 +1,11 @@
+bin.name = "cargo-add"
+args = ["add", "git-package", "--git", "http://localhost/git-package.git"]
+status.code = 1
+stdout = ""
+stderr = """
+Command failed due to unhandled error: `--git` is unstable and requires `-Z git`
+"""
+fs.sandbox = true
+
+[env.add]
+CARGO_IS_TEST="1"

--- a/tests/cmd/add/multiple_conflicts_with_git.toml
+++ b/tests/cmd/add/multiple_conflicts_with_git.toml
@@ -1,5 +1,5 @@
 bin.name = "cargo-add"
-args = ["add", "my-package1", "my-package2", "--git", "https://github.com/dcjanus/invalid"]
+args = ["add", "my-package1", "my-package2", "--git", "https://github.com/dcjanus/invalid", "-Zgit"]
 status.code = 1
 stdout = ""
 stderr = """

--- a/tests/cmd/add/overwrite_version_with_git.toml
+++ b/tests/cmd/add/overwrite_version_with_git.toml
@@ -1,5 +1,5 @@
 bin.name = "cargo-add"
-args = ["add", "versioned-package", "--git", "git://git.git"]
+args = ["add", "versioned-package", "--git", "git://git.git", "-Zgit"]
 status = "success"
 stdout = ""
 stderr = """


### PR DESCRIPTION
There are aspects we still need to figure out
- Separate `--branch`... flags,
  or `#branch=<branch>`... fragments
  or `#<branch|tag|rev>` fragment
- Can we integrate it into the crate-spec to fit in with the multi-add
  workflow?  (see #578 for issues)
- Should we allove overwriting these by crate name without re-specifying
  git url?