### PR TITLE
refactor: Prepare for new `modify` logic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -175,7 +175,7 @@ dependencies = [
  "serde_json",
  "subprocess",
  "termcolor",
- "toml_edit 0.13.2",
+ "toml_edit 0.13.3",
  "trycmd",
  "ureq",
  "url",
@@ -1319,9 +1319,9 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.13.2"
+version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "367437aa05be74122fa0d982b84a91938871df88c69edb759ed1c310724fe2d9"
+checksum = "7a0e86b53683f540d6920ba1a9ac4648b389d28e7eb12ddd202687f132364c5f"
 dependencies = [
  "combine",
  "indexmap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,7 +65,7 @@ serde_json = "1.0.58"
 clap = { version = "3.0", features = ["derive", "wrap_help"], optional = true }
 subprocess = "0.2.6"
 termcolor = "1.1.0"
-toml_edit = { version = "0.13.2", features = ["easy"] }
+toml_edit = { version = "0.13.3", features = ["easy"] }
 url = "2.1.1"
 ureq = { version = "1.5.1", default-features = false, features = ["tls", "json", "socks"] }
 pathdiff = "0.2"

--- a/src/dependency.rs
+++ b/src/dependency.rs
@@ -204,10 +204,10 @@ impl Dependency {
                 None,
             ) => toml_edit::value(v),
             // Other cases are represented as an inline table
-            (optional, features, default_features, source, rename) => {
+            (_, _, _, _, _) => {
                 let mut data = toml_edit::InlineTable::default();
 
-                match source {
+                match &self.source {
                     DependencySource::Version {
                         version,
                         path,
@@ -244,18 +244,18 @@ impl Dependency {
                         }
                     }
                 }
-                if rename.is_some() {
+                if self.rename.is_some() {
                     data.insert("package", self.name.as_str().into());
                 }
                 if !self.default_features {
-                    data.insert("default-features", default_features.into());
+                    data.insert("default-features", self.default_features.into());
                 }
-                if let Some(features) = features {
+                if let Some(features) = self.features.as_deref() {
                     let features: toml_edit::Value = features.iter().cloned().collect();
                     data.insert("features", features);
                 }
                 if self.optional {
-                    data.insert("optional", optional.into());
+                    data.insert("optional", self.optional.into());
                 }
 
                 toml_edit::value(toml_edit::Value::InlineTable(data))

--- a/src/dependency.rs
+++ b/src/dependency.rs
@@ -214,16 +214,16 @@ impl Dependency {
                         registry,
                     } => {
                         if let Some(v) = version {
-                            data.get_or_insert("version", v);
+                            data.insert("version", v.into());
                         }
                         if let Some(p) = path {
                             let relpath = pathdiff::diff_paths(p, crate_root)
                                 .expect("both paths are absolute");
                             let relpath = relpath.to_str().unwrap().replace('\\', "/");
-                            data.get_or_insert("path", relpath);
+                            data.insert("path", relpath.into());
                         }
                         if let Some(r) = registry {
-                            data.get_or_insert("registry", r);
+                            data.insert("registry", r.into());
                         }
                     }
                     DependencySource::Git {
@@ -232,30 +232,30 @@ impl Dependency {
                         tag,
                         rev,
                     } => {
-                        data.get_or_insert("git", repo);
+                        data.insert("git", repo.into());
                         if let Some(branch) = branch {
-                            data.get_or_insert("branch", branch);
+                            data.insert("branch", branch.into());
                         }
                         if let Some(tag) = tag {
-                            data.get_or_insert("tag", tag);
+                            data.insert("tag", tag.into());
                         }
                         if let Some(rev) = rev {
-                            data.get_or_insert("rev", rev);
+                            data.insert("rev", rev.into());
                         }
                     }
                 }
                 if rename.is_some() {
-                    data.get_or_insert("package", self.name.clone());
+                    data.insert("package", self.name.as_str().into());
                 }
                 if !self.default_features {
-                    data.get_or_insert("default-features", default_features);
+                    data.insert("default-features", default_features.into());
                 }
                 if let Some(features) = features {
                     let features: toml_edit::Value = features.iter().cloned().collect();
-                    data.get_or_insert("features", features);
+                    data.insert("features", features);
                 }
                 if self.optional {
-                    data.get_or_insert("optional", optional);
+                    data.insert("optional", optional.into());
                 }
 
                 toml_edit::value(toml_edit::Value::InlineTable(data))

--- a/src/dependency.rs
+++ b/src/dependency.rs
@@ -256,7 +256,6 @@ impl Dependency {
                     data.get_or_insert("package", self.name.clone());
                 }
 
-                data.fmt();
                 toml_edit::value(toml_edit::Value::InlineTable(data))
             }
         };

--- a/src/dependency.rs
+++ b/src/dependency.rs
@@ -217,9 +217,7 @@ impl Dependency {
                             data.insert("version", v.into());
                         }
                         if let Some(p) = path {
-                            let relpath = pathdiff::diff_paths(p, crate_root)
-                                .expect("both paths are absolute");
-                            let relpath = relpath.to_str().unwrap().replace('\\', "/");
+                            let relpath = path_field(crate_root, p);
                             data.insert("path", relpath.into());
                         }
                         if let Some(r) = registry {
@@ -298,6 +296,12 @@ impl Dependency {
             unreachable!("Invalid dependency type: {}", item.type_name());
         }
     }
+}
+
+fn path_field(crate_root: &Path, abs_path: &Path) -> String {
+    let relpath = pathdiff::diff_paths(abs_path, crate_root).expect("both paths are absolute");
+    let relpath = relpath.to_str().unwrap().replace('\\', "/");
+    relpath
 }
 
 fn is_package_eq(item: &mut toml_edit::Item, name: &str, rename: Option<&str>) -> bool {

--- a/src/dependency.rs
+++ b/src/dependency.rs
@@ -306,47 +306,45 @@ mod tests {
     #[test]
     fn to_toml_simple_dep() {
         let crate_root = dunce::canonicalize(Path::new("/")).expect("root exists");
-        let toml = Dependency::new("dep").to_toml(&crate_root);
+        let dep = Dependency::new("dep");
+        let (key, _item) = dep.to_toml(&crate_root);
 
-        assert_eq!(toml.0, "dep".to_owned());
+        assert_eq!(key, "dep".to_owned());
     }
 
     #[test]
     fn to_toml_simple_dep_with_version() {
         let crate_root = dunce::canonicalize(Path::new("/")).expect("root exists");
-        let toml = Dependency::new("dep")
-            .set_version("1.0")
-            .to_toml(&crate_root);
+        let dep = Dependency::new("dep").set_version("1.0");
+        let (key, item) = dep.to_toml(&crate_root);
 
-        assert_eq!(toml.0, "dep".to_owned());
-        assert_eq!(toml.1.as_str(), Some("1.0"));
+        assert_eq!(key, "dep".to_owned());
+        assert_eq!(item.as_str(), Some("1.0"));
     }
 
     #[test]
     fn to_toml_optional_dep() {
         let crate_root = dunce::canonicalize(Path::new("/")).expect("root exists");
-        let toml = Dependency::new("dep")
-            .set_optional(true)
-            .to_toml(&crate_root);
+        let dep = Dependency::new("dep").set_optional(true);
+        let (key, item) = dep.to_toml(&crate_root);
 
-        assert_eq!(toml.0, "dep".to_owned());
-        assert!(toml.1.is_inline_table());
+        assert_eq!(key, "dep".to_owned());
+        assert!(item.is_inline_table());
 
-        let dep = toml.1.as_inline_table().unwrap();
+        let dep = item.as_inline_table().unwrap();
         assert_eq!(dep.get("optional").unwrap().as_bool(), Some(true));
     }
 
     #[test]
     fn to_toml_dep_without_default_features() {
         let crate_root = dunce::canonicalize(Path::new("/")).expect("root exists");
-        let toml = Dependency::new("dep")
-            .set_default_features(false)
-            .to_toml(&crate_root);
+        let dep = Dependency::new("dep").set_default_features(false);
+        let (key, item) = dep.to_toml(&crate_root);
 
-        assert_eq!(toml.0, "dep".to_owned());
-        assert!(toml.1.is_inline_table());
+        assert_eq!(key, "dep".to_owned());
+        assert!(item.is_inline_table());
 
-        let dep = toml.1.as_inline_table().unwrap();
+        let dep = item.as_inline_table().unwrap();
         assert_eq!(dep.get("default-features").unwrap().as_bool(), Some(false));
     }
 
@@ -354,28 +352,26 @@ mod tests {
     fn to_toml_dep_with_path_source() {
         let root = dunce::canonicalize(Path::new("/")).expect("root exists");
         let crate_root = root.join("foo");
-        let toml = Dependency::new("dep")
-            .set_path(root.join("bar"))
-            .to_toml(&crate_root);
+        let dep = Dependency::new("dep").set_path(root.join("bar"));
+        let (key, item) = dep.to_toml(&crate_root);
 
-        assert_eq!(toml.0, "dep".to_owned());
-        assert!(toml.1.is_inline_table());
+        assert_eq!(key, "dep".to_owned());
+        assert!(item.is_inline_table());
 
-        let dep = toml.1.as_inline_table().unwrap();
+        let dep = item.as_inline_table().unwrap();
         assert_eq!(dep.get("path").unwrap().as_str(), Some("../bar"));
     }
 
     #[test]
     fn to_toml_dep_with_git_source() {
         let crate_root = dunce::canonicalize(Path::new("/")).expect("root exists");
-        let toml = Dependency::new("dep")
-            .set_git("https://foor/bar.git", None, None, None)
-            .to_toml(&crate_root);
+        let dep = Dependency::new("dep").set_git("https://foor/bar.git", None, None, None);
+        let (key, item) = dep.to_toml(&crate_root);
 
-        assert_eq!(toml.0, "dep".to_owned());
-        assert!(toml.1.is_inline_table());
+        assert_eq!(key, "dep".to_owned());
+        assert!(item.is_inline_table());
 
-        let dep = toml.1.as_inline_table().unwrap();
+        let dep = item.as_inline_table().unwrap();
         assert_eq!(
             dep.get("git").unwrap().as_str(),
             Some("https://foor/bar.git")
@@ -385,42 +381,42 @@ mod tests {
     #[test]
     fn to_toml_renamed_dep() {
         let crate_root = dunce::canonicalize(Path::new("/")).expect("root exists");
-        let toml = Dependency::new("dep").set_rename("d").to_toml(&crate_root);
+        let dep = Dependency::new("dep").set_rename("d");
+        let (key, item) = dep.to_toml(&crate_root);
 
-        assert_eq!(toml.0, "d".to_owned());
-        assert!(toml.1.is_inline_table());
+        assert_eq!(key, "d".to_owned());
+        assert!(item.is_inline_table());
 
-        let dep = toml.1.as_inline_table().unwrap();
+        let dep = item.as_inline_table().unwrap();
         assert_eq!(dep.get("package").unwrap().as_str(), Some("dep"));
     }
 
     #[test]
     fn to_toml_dep_from_alt_registry() {
         let crate_root = dunce::canonicalize(Path::new("/")).expect("root exists");
-        let toml = Dependency::new("dep")
-            .set_registry("alternative")
-            .to_toml(&crate_root);
+        let dep = Dependency::new("dep").set_registry("alternative");
+        let (key, item) = dep.to_toml(&crate_root);
 
-        assert_eq!(toml.0, "dep".to_owned());
-        assert!(toml.1.is_inline_table());
+        assert_eq!(key, "dep".to_owned());
+        assert!(item.is_inline_table());
 
-        let dep = toml.1.as_inline_table().unwrap();
+        let dep = item.as_inline_table().unwrap();
         assert_eq!(dep.get("registry").unwrap().as_str(), Some("alternative"));
     }
 
     #[test]
     fn to_toml_complex_dep() {
         let crate_root = dunce::canonicalize(Path::new("/")).expect("root exists");
-        let toml = Dependency::new("dep")
+        let dep = Dependency::new("dep")
             .set_version("1.0")
             .set_default_features(false)
-            .set_rename("d")
-            .to_toml(&crate_root);
+            .set_rename("d");
+        let (key, item) = dep.to_toml(&crate_root);
 
-        assert_eq!(toml.0, "d".to_owned());
-        assert!(toml.1.is_inline_table());
+        assert_eq!(key, "d".to_owned());
+        assert!(item.is_inline_table());
 
-        let dep = toml.1.as_inline_table().unwrap();
+        let dep = item.as_inline_table().unwrap();
         assert_eq!(dep.get("package").unwrap().as_str(), Some("dep"));
         assert_eq!(dep.get("version").unwrap().as_str(), Some("1.0"));
         assert_eq!(dep.get("default-features").unwrap().as_bool(), Some(false));
@@ -432,10 +428,9 @@ mod tests {
         let path = crate_root.join("sibling/crate");
         let relpath = "sibling/crate";
         let dep = Dependency::new("dep").set_path(path);
+        let (_key, item) = dep.to_toml(&crate_root);
 
-        let (_, toml) = dep.to_toml(&crate_root);
-
-        let table = toml.as_inline_table().unwrap();
+        let table = item.as_inline_table().unwrap();
         let got = table.get("path").unwrap().as_str().unwrap();
         assert_eq!(got, relpath);
     }
@@ -447,10 +442,9 @@ mod tests {
         let original = crate_root.join(r"sibling\crate");
         let should_be = "sibling/crate";
         let dep = Dependency::new("dep").set_path(original);
+        let (key, item) = dep.to_toml(&crate_root);
 
-        let (_, toml) = dep.to_toml(&crate_root);
-
-        let table = toml.as_inline_table().unwrap();
+        let table = item.as_inline_table().unwrap();
         let got = table.get("path").unwrap().as_str().unwrap();
         assert_eq!(got, should_be);
     }

--- a/src/dependency.rs
+++ b/src/dependency.rs
@@ -265,6 +265,7 @@ impl Dependency {
 
     /// Modify existing entry to match this dependency
     pub fn update_toml(&self, crate_root: &Path, item: &mut toml_edit::Item) {
+        #[allow(clippy::if_same_then_else)]
         if str_or_1_len_table(item) {
             // Nothing to preserve
             *item = self.to_toml(crate_root);

--- a/src/dependency.rs
+++ b/src/dependency.rs
@@ -244,18 +244,18 @@ impl Dependency {
                         }
                     }
                 }
-                if self.optional {
-                    data.get_or_insert("optional", optional);
+                if rename.is_some() {
+                    data.get_or_insert("package", self.name.clone());
+                }
+                if !self.default_features {
+                    data.get_or_insert("default-features", default_features);
                 }
                 if let Some(features) = features {
                     let features: toml_edit::Value = features.iter().cloned().collect();
                     data.get_or_insert("features", features);
                 }
-                if !self.default_features {
-                    data.get_or_insert("default-features", default_features);
-                }
-                if rename.is_some() {
-                    data.get_or_insert("package", self.name.clone());
+                if self.optional {
+                    data.get_or_insert("optional", optional);
                 }
 
                 toml_edit::value(toml_edit::Value::InlineTable(data))

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -228,8 +228,8 @@ impl LocalManifest {
 
     /// Add entry to a Cargo.toml.
     pub fn insert_into_table(&mut self, table_path: &[String], dep: &Dependency) -> Result<()> {
-        let (dep_key, new_dependency) =
-            dep.to_toml(self.path.parent().expect("manifest path is absolute"));
+        let dep_key = dep.toml_key();
+        let new_dependency = dep.to_toml(self.path.parent().expect("manifest path is absolute"));
 
         let table = self.get_table(table_path)?;
         if let Some(dep_item) = table.as_table_like_mut().unwrap().get_mut(&dep_key) {
@@ -253,7 +253,7 @@ impl LocalManifest {
         dep: &Dependency,
         dry_run: bool,
     ) -> Result<()> {
-        self.update_table_named_entry(table_path, dep.name_in_manifest(), dep, dry_run)
+        self.update_table_named_entry(table_path, dep.toml_key(), dep, dry_run)
     }
 
     /// Update an entry with a specified name in Cargo.toml.
@@ -264,8 +264,7 @@ impl LocalManifest {
         dep: &Dependency,
         dry_run: bool,
     ) -> Result<()> {
-        let (_dep_key, new_dependency) =
-            dep.to_toml(self.path.parent().expect("manifest path is absolute"));
+        let new_dependency = dep.to_toml(self.path.parent().expect("manifest path is absolute"));
 
         let table = self.get_table(table_path)?;
 

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -236,7 +236,7 @@ impl LocalManifest {
         let dep_key = dep.toml_key();
 
         let table = self.get_table(table_path)?;
-        if let Some(dep_item) = table.as_table_like_mut().unwrap().get_mut(&dep_key) {
+        if let Some(dep_item) = table.as_table_like_mut().unwrap().get_mut(dep_key) {
             dep.update_toml(&crate_root, dep_item);
         } else {
             let new_dependency = dep.to_toml(&crate_root);


### PR DESCRIPTION
We are wanting "modify" to
- Append features
- Handle optional well (#298) and default-features
- Not change version

To do this, we need to merge at a higher level.  This makes it so we now merge with the `Dependency` data structure rather than doing toml to toml merge.