### PR TITLE
fix(add)!: Re-adding appends features

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -165,6 +165,7 @@ dependencies = [
  "error-chain",
  "git2",
  "hex",
+ "indexmap",
  "pathdiff",
  "predicates",
  "pretty_assertions",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,6 +66,7 @@ clap = { version = "3.0", features = ["derive", "wrap_help"], optional = true }
 subprocess = "0.2.6"
 termcolor = "1.1.0"
 toml_edit = { version = "0.13.3", features = ["easy"] }
+indexmap = "1"
 url = "2.1.1"
 ureq = { version = "1.5.1", default-features = false, features = ["tls", "json", "socks"] }
 pathdiff = "0.2"

--- a/tests/cmd/add/overwrite_features.out/Cargo.toml
+++ b/tests/cmd/add/overwrite_features.out/Cargo.toml
@@ -3,4 +3,4 @@ name = "cargo-list-test-fixture"
 version = "0.0.0"
 
 [dependencies]
-your-face = { version = "99999.0.0", features = ["nose"] }
+your-face = { version = "99999.0.0", features = ["eyes", "nose"] }


### PR DESCRIPTION
Take
```console
$ cargo add clap --features derive
$ cargo add clap --features unicode
```

Before, this would result in
```toml
clap = { version = "3.0.13", features = ["unicode"] }
```

Now, it results in
```toml
clap = { version = "3.0.13", features = ["derive", "unicode"] }
```

This is part of a larger effort to make `cargo add` "append-only".  We
should only modify fields users explicitly mention and, when we do, we
should append-or-replace (depending on the data type).