### PR TITLE
Revert "fix(add)!: Use `:` from pkgid, rather than `@`"

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ UNSTABLE:
 
 Examples:
   $ cargo add regex
-  $ cargo add regex:0.1.41 --build
+  $ cargo add regex@0.1.41 --build
   $ cargo add trycmd --dev
   $ cargo add ./crate/parser/
 
@@ -219,7 +219,7 @@ This command differs from `cargo update`, which updates the dependency versions 
 local lock file (Cargo.lock).
 
 If `<dependency>`(s) are provided, only the specified dependencies will be upgraded. The version to
-upgrade to for each can be specified with e.g. `docopt:0.8.0` or `serde:>=0.9,<2.0`.
+upgrade to for each can be specified with e.g. `docopt@0.8.0` or `serde@>=0.9,<2.0`.
 
 Dev, build, and all target dependencies will also be upgraded. Only dependencies from crates.io are
 supported. Git/path dependencies will be ignored.

--- a/src/bin/add/args.rs
+++ b/src/bin/add/args.rs
@@ -21,7 +21,7 @@ pub enum Command {
     #[clap(after_help = "\
 Examples:
   $ cargo add regex
-  $ cargo add regex:0.1.41 --build
+  $ cargo add regex@0.1.41 --build
   $ cargo add trycmd --dev
   $ cargo add ./crate/parser/
 ")]
@@ -36,7 +36,7 @@ pub struct Args {
     ///
     /// You can reference a packages by:{n}
     /// - `<name>`, like `cargo add serde` (latest version will be used){n}
-    /// - `<name>:<version-req>`, like `cargo add serde:1` or `cargo add serde:=1.0.38`{n}
+    /// - `<name>@<version-req>`, like `cargo add serde@1` or `cargo add serde@=1.0.38`{n}
     /// - `<path>`, like `cargo add ./crates/parser/`
     #[clap(value_name = "DEP_ID", required = true)]
     pub crates: Vec<String>,
@@ -241,7 +241,7 @@ impl Args {
                 version_req: Some(_),
             } => {
                 let mut dependency = crate_spec.to_dependency()?;
-                // crate specifier includes a version (e.g. `docopt:0.8`)
+                // crate specifier includes a version (e.g. `docopt@0.8`)
                 if let Some(ref url) = self.git {
                     let url = url.clone();
                     let version = dependency.version().unwrap().to_string();

--- a/src/bin/upgrade/main.rs
+++ b/src/bin/upgrade/main.rs
@@ -48,7 +48,7 @@ This command differs from `cargo update`, which updates the dependency versions 
 local lock file (Cargo.lock).
 
 If `<dependency>`(s) are provided, only the specified dependencies will be upgraded. The version \
-to upgrade to for each can be specified with e.g. `docopt:0.8.0` or `serde:>=0.9,<2.0`.
+to upgrade to for each can be specified with e.g. `docopt@0.8.0` or `serde@>=0.9,<2.0`.
 
 Dev, build, and all target dependencies will also be upgraded. Only dependencies from crates.io \
 are supported. Git/path dependencies will be ignored.

--- a/src/crate_spec.rs
+++ b/src/crate_spec.rs
@@ -31,7 +31,7 @@ impl CrateSpec {
             Self::Path(path.to_owned())
         } else {
             let (name, version) = pkg_id
-                .split_once(':')
+                .split_once('@')
                 .map(|(n, v)| (n, Some(v)))
                 .unwrap_or((pkg_id, None));
 

--- a/tests/cmd/add/default_features.toml
+++ b/tests/cmd/add/default_features.toml
@@ -1,5 +1,5 @@
 bin.name = "cargo-add"
-args = ["add", "my-package1", "my-package2:0.4.1", "--default-features"]
+args = ["add", "my-package1", "my-package2@0.4.1", "--default-features"]
 status = "success"
 stdout = ""
 stderr = """

--- a/tests/cmd/add/git_conflicts_namever.toml
+++ b/tests/cmd/add/git_conflicts_namever.toml
@@ -1,5 +1,5 @@
 bin.name = "cargo-add"
-args = ["add", "my-package:0.4.3", "--git", "https://github.com/dcjanus/invalid", "-Zgit"]
+args = ["add", "my-package@0.4.3", "--git", "https://github.com/dcjanus/invalid", "-Zgit"]
 status.code = 1
 stdout = ""
 stderr = """

--- a/tests/cmd/add/invalid_vers.toml
+++ b/tests/cmd/add/invalid_vers.toml
@@ -1,5 +1,5 @@
 bin.name = "cargo-add"
-args = ["add", "my-package:invalid version string"]
+args = ["add", "my-package@invalid version string"]
 status.code = 1
 stdout = ""
 stderr = """

--- a/tests/cmd/add/namever.toml
+++ b/tests/cmd/add/namever.toml
@@ -1,5 +1,5 @@
 bin.name = "cargo-add"
-args = ["add", "my-package1:>=0.1.1", "my-package2:0.2.3", "my-package"]
+args = ["add", "my-package1@>=0.1.1", "my-package2@0.2.3", "my-package"]
 status = "success"
 stdout = ""
 stderr = """

--- a/tests/cmd/add/no_default_features.toml
+++ b/tests/cmd/add/no_default_features.toml
@@ -1,5 +1,5 @@
 bin.name = "cargo-add"
-args = ["add", "my-package1", "my-package2:0.4.1", "--no-default-features"]
+args = ["add", "my-package1", "my-package2@0.4.1", "--no-default-features"]
 status = "success"
 stdout = ""
 stderr = """

--- a/tests/cmd/add/no_optional.toml
+++ b/tests/cmd/add/no_optional.toml
@@ -1,5 +1,5 @@
 bin.name = "cargo-add"
-args = ["add", "my-package1", "my-package2:0.4.1", "--no-optional"]
+args = ["add", "my-package1", "my-package2@0.4.1", "--no-optional"]
 status = "success"
 stdout = ""
 stderr = """

--- a/tests/cmd/add/optional.toml
+++ b/tests/cmd/add/optional.toml
@@ -1,5 +1,5 @@
 bin.name = "cargo-add"
-args = ["add", "my-package1", "my-package2:0.4.1", "--optional"]
+args = ["add", "my-package1", "my-package2@0.4.1", "--optional"]
 status = "success"
 stdout = ""
 stderr = """

--- a/tests/cmd/add/overwrite_default_features.toml
+++ b/tests/cmd/add/overwrite_default_features.toml
@@ -1,5 +1,5 @@
 bin.name = "cargo-add"
-args = ["add", "my-package1", "my-package2:0.4.1", "--default-features"]
+args = ["add", "my-package1", "my-package2@0.4.1", "--default-features"]
 status = "success"
 stdout = ""
 stderr = """

--- a/tests/cmd/add/overwrite_default_features_with_no_default_features.toml
+++ b/tests/cmd/add/overwrite_default_features_with_no_default_features.toml
@@ -1,5 +1,5 @@
 bin.name = "cargo-add"
-args = ["add", "my-package1", "my-package2:0.4.1", "--no-default-features"]
+args = ["add", "my-package1", "my-package2@0.4.1", "--no-default-features"]
 status = "success"
 stdout = ""
 stderr = """

--- a/tests/cmd/add/overwrite_no_default_features.toml
+++ b/tests/cmd/add/overwrite_no_default_features.toml
@@ -1,5 +1,5 @@
 bin.name = "cargo-add"
-args = ["add", "my-package1", "my-package2:0.4.1", "--no-default-features"]
+args = ["add", "my-package1", "my-package2@0.4.1", "--no-default-features"]
 status = "success"
 stdout = ""
 stderr = """

--- a/tests/cmd/add/overwrite_no_default_features_with_default_features.toml
+++ b/tests/cmd/add/overwrite_no_default_features_with_default_features.toml
@@ -1,5 +1,5 @@
 bin.name = "cargo-add"
-args = ["add", "my-package1", "my-package2:0.4.1", "--default-features"]
+args = ["add", "my-package1", "my-package2@0.4.1", "--default-features"]
 status = "success"
 stdout = ""
 stderr = """

--- a/tests/cmd/add/overwrite_no_optional.toml
+++ b/tests/cmd/add/overwrite_no_optional.toml
@@ -1,5 +1,5 @@
 bin.name = "cargo-add"
-args = ["add", "my-package1", "my-package2:0.4.1", "--no-optional"]
+args = ["add", "my-package1", "my-package2@0.4.1", "--no-optional"]
 status = "success"
 stdout = ""
 stderr = """

--- a/tests/cmd/add/overwrite_no_optional_with_optional.toml
+++ b/tests/cmd/add/overwrite_no_optional_with_optional.toml
@@ -1,5 +1,5 @@
 bin.name = "cargo-add"
-args = ["add", "my-package1", "my-package2:0.4.1", "--optional"]
+args = ["add", "my-package1", "my-package2@0.4.1", "--optional"]
 status = "success"
 stdout = ""
 stderr = """

--- a/tests/cmd/add/overwrite_optional.toml
+++ b/tests/cmd/add/overwrite_optional.toml
@@ -1,5 +1,5 @@
 bin.name = "cargo-add"
-args = ["add", "my-package1", "my-package2:0.4.1", "--optional"]
+args = ["add", "my-package1", "my-package2@0.4.1", "--optional"]
 status = "success"
 stdout = ""
 stderr = """

--- a/tests/cmd/add/overwrite_optional_with_no_optional.toml
+++ b/tests/cmd/add/overwrite_optional_with_no_optional.toml
@@ -1,5 +1,5 @@
 bin.name = "cargo-add"
-args = ["add", "my-package1", "my-package2:0.4.1", "--no-optional"]
+args = ["add", "my-package1", "my-package2@0.4.1", "--no-optional"]
 status = "success"
 stdout = ""
 stderr = """

--- a/tests/cmd/add/vers.toml
+++ b/tests/cmd/add/vers.toml
@@ -1,5 +1,5 @@
 bin.name = "cargo-add"
-args = ["add", "my-package:>=0.1.1"]
+args = ["add", "my-package@>=0.1.1"]
 status = "success"
 stdout = ""
 stderr = """

--- a/tests/cmd/upgrade/to_version.toml
+++ b/tests/cmd/upgrade/to_version.toml
@@ -1,5 +1,5 @@
 bin.name = "cargo-upgrade"
-args = ["upgrade", "docopt:1000000.0.0"]
+args = ["upgrade", "docopt@1000000.0.0"]
 status = "success"
 stdout = """
 cargo-list-test-fixture:


### PR DESCRIPTION
This reverts commit 36c9a1b97242c2fd634d4e47e91d8201d5e816cd.

There is interest in changing cargo, instead of changing `cargo add`.