### PR TITLE
fix(add): Allow ',' to separate features

### DIFF
--- a/src/bin/add/main.rs
+++ b/src/bin/add/main.rs
@@ -159,8 +159,8 @@ fn handle_add(mut args: Args) -> Result<()> {
     }
     let requested_features: Option<BTreeSet<&str>> = args.features.as_ref().map(|v| {
         v.iter()
-            .map(|s| s.split(' '))
-            .flatten()
+            .flat_map(|s| s.split(' '))
+            .flat_map(|s| s.split(','))
             .filter(|s| !s.is_empty())
             .collect()
     });


### PR DESCRIPTION
I had assumed we were using clap for the splitting and was holding off
until we could use cargo's infrastructure for this.

Turns out we did it ourselves and its easy to add comma support.