### PR TITLE
refactor(add): Prepare to not overwrite version

### DIFF
--- a/src/bin/add/args.rs
+++ b/src/bin/add/args.rs
@@ -311,7 +311,7 @@ impl Args {
                         dependency = dependency.set_version(&v);
                     }
                 } else {
-                    dependency =
+                    let latest =
                         get_latest_dependency(name, false, &manifest_path, Some(&registry_url))?;
                     let op = "";
                     let v = format!(
@@ -319,9 +319,11 @@ impl Args {
                         op = op,
                         // If version is unavailable `get_latest_dependency` must have
                         // returned `Err(FetchVersionError::GetVersion)`
-                        version = dependency.version().unwrap_or_else(|| unreachable!())
+                        version = latest.version().unwrap_or_else(|| unreachable!())
                     );
-                    dependency = dependency.set_version(&v);
+                    dependency = dependency
+                        .set_version(&v)
+                        .set_available_features(latest.available_features);
                 }
 
                 dependency

--- a/src/bin/add/args.rs
+++ b/src/bin/add/args.rs
@@ -213,17 +213,22 @@ impl Args {
             .map(|crate_spec| {
                 self.parse_single_dependency(crate_spec, &workspace_members)
                     .map(|x| {
-                        let mut x = x
-                            .set_optional(self.optional())
-                            .set_features(requested_features.to_owned())
-                            .set_default_features(self.default_features());
-                        if let Some(ref rename) = self.rename {
-                            x = x.set_rename(rename);
-                        }
+                        let x = self.populate_dependency(x);
+                        let x = x.set_features(requested_features.to_owned());
                         x
                     })
             })
             .collect()
+    }
+
+    fn populate_dependency(&self, mut dependency: Dependency) -> Dependency {
+        dependency = dependency
+            .set_optional(self.optional())
+            .set_default_features(self.default_features());
+        if let Some(ref rename) = self.rename {
+            dependency = dependency.set_rename(rename);
+        }
+        dependency
     }
 
     fn parse_single_dependency(


### PR DESCRIPTION
We need a fully populated `dependency` to check the old version in one specific case.