### PR TITLE
feat(add): Add `-F` short flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ ARGS:
 OPTIONS:
         --no-default-features     Disable the default features
         --default-features        Re-enable the default features
-        --features <FEATURES>     Space-separated list of features to add
+    -F, --features <FEATURES>     Space-separated list of features to add
         --optional                Mark the dependency as optional
         --no-optional             Mark the dependency as required
     -r, --rename <RENAME>         Rename the dependency

--- a/src/bin/add/args.rs
+++ b/src/bin/add/args.rs
@@ -60,7 +60,7 @@ pub struct Args {
     ///
     /// Alternatively, you can specify features for a dependency by following it with a
     /// `+<FEATURE>`.
-    #[clap(long)]
+    #[clap(short = 'F', long)]
     pub features: Option<Vec<String>>,
 
     /// Mark the dependency as optional


### PR DESCRIPTION
This is serving as a "living" proposal for `-F` to be added to cargo
generally.  Before, we've rejected this because we wanted to mirror
cargo.

`-F` was chosen because `-f`'s de facto meaning is `--force`.  Even if
we don't have a `--force` flag, a cargo command could in the future and
we don't want conflicts.

Fixes #450