### PR TITLE
Improve `update_table_named_entry`

### DIFF
--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -358,12 +358,12 @@ impl LocalManifest {
             .parent()
             .expect("manifest path is absolute")
             .to_owned();
-        let new_dependency = dep.to_toml(self.path.parent().expect("manifest path is absolute"));
-
         let table = self.get_table_mut(table_path)?;
 
         // If (and only if) there is an old entry, merge the new one in.
         if table.as_table_like().unwrap().contains_key(dep_key) {
+            let new_dependency = dep.to_toml(&crate_root);
+
             if let Err(e) = print_upgrade_if_necessary(&dep.name, &table[dep_key], &new_dependency)
             {
                 eprintln!("Error while displaying upgrade message, {}", e);


### PR DESCRIPTION
Currently, `update_table_named_entry` calls `self.path.parent()` twice to determine the `crate_root`.

Moreover, `update_table_named_entry` creates `new_dependency` outside of the `if` block, even though `new_dependency` is needed only inside of the `if` block.

This small change resolves these two inefficiencies.

(These observations are a consequence of #613. But this change is not needed to implement #613.)