### PR TITLE
refactor(upgrade): Track raw manfiest data

### DIFF
--- a/src/dependency.rs
+++ b/src/dependency.rs
@@ -170,6 +170,19 @@ impl Dependency {
         }
     }
 
+    /// Get registry of the dependency
+    pub fn registry(&self) -> Option<&str> {
+        if let DependencySource::Version {
+            registry: Some(ref registry),
+            ..
+        } = self.source
+        {
+            Some(registry)
+        } else {
+            None
+        }
+    }
+
     /// Get the git repo of the dependency
     pub fn git(&self) -> Option<&str> {
         if let DependencySource::Git { repo, .. } = &self.source {


### PR DESCRIPTION
For #613, we need an unprocessed version requirement.  This requires us from using data from `LocalManifest` instead of  `cargo_metadata` .