### PR TITLE
feat(fetch): add support for more CPU architectures

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -166,6 +166,7 @@ dependencies = [
  "git2",
  "hex",
  "indexmap",
+ "native-tls",
  "pathdiff",
  "predicates",
  "pretty_assertions",
@@ -299,6 +300,22 @@ name = "concolor-query"
 version = "0.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6417fe6fc03a8b533fd2177742eeb39a90c7233eedec7bac96d4d6b69a09449"
+
+[[package]]
+name = "core-foundation"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "194a7a9e6de53fa55116934067c844d9d749312f75c6f6d0980e8c252f8c2146"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
 
 [[package]]
 name = "crates-index"
@@ -465,6 +482,21 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
@@ -776,6 +808,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "native-tls"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48ba9f7719b5a0f42f338907614285fb5fd70e53858141f69898a1fb7203b24d"
+dependencies = [
+ "lazy_static",
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework",
+ "security-framework-sys",
+ "tempfile",
+]
+
+[[package]]
 name = "normalize-line-endings"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -814,6 +864,20 @@ name = "once_cell"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da32515d9f6e6e489d7bc9d84c71b060db7247dc035bbe44eac88cf87486d8d5"
+
+[[package]]
+name = "openssl"
+version = "0.10.38"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c7ae222234c30df141154f159066c5093ff73b63204dcda7121eb082fc56a95"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "foreign-types",
+ "libc",
+ "once_cell",
+ "openssl-sys",
+]
 
 [[package]]
 name = "openssl-probe"
@@ -1101,6 +1165,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "schannel"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f05ba609c234e60bee0d547fe94a4c7e9da733d1c962cf6e59efa4cd9c8bc75"
+dependencies = [
+ "lazy_static",
+ "winapi 0.3.9",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1114,6 +1188,29 @@ checksum = "d53dcdb7c9f8158937a7981b48accfd39a43af418591a5d008c7b22b5e1b7ca4"
 dependencies = [
  "ring",
  "untrusted",
+]
+
+[[package]]
+name = "security-framework"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dc14f172faf8a0194a3aded622712b0de276821addc574fa54fc0a1167e10dc"
+dependencies = [
+ "bitflags",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0160a13a177a45bfb43ce71c01580998474f556ad854dcbca936dd2841a5c556"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -1381,6 +1478,7 @@ dependencies = [
  "base64",
  "chunked_transfer",
  "log",
+ "native-tls",
  "once_cell",
  "rustls",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,12 +68,19 @@ termcolor = "1.1.0"
 toml_edit = { version = "0.13.3", features = ["easy"] }
 indexmap = "1"
 url = "2.1.1"
-ureq = { version = "2.4.0", default-features = false, features = ["tls", "json", "socks", "socks-proxy"] }
 pathdiff = "0.2"
 
 [dependencies.semver]
 features = ["serde"]
 version = "1.0.0"
+
+[target.'cfg(any(target_arch = "x86_64", target_arch = "arm", target_arch = "x86", target_arch = "aarch64"))'.dependencies]
+ureq = { version = "2.4.0", default-features = false, features = ["tls", "json", "socks", "socks-proxy"] }
+
+# if the CPU architecture is not supported by ring/rustls
+[target.'cfg(not(any(target_arch = "x86_64", target_arch = "arm", target_arch = "x86", target_arch = "aarch64")))'.dependencies]
+native-tls = "^0.2"
+ureq = { version = "2.4.0", default-features = false, features = ["native-tls", "json", "socks", "socks-proxy"] }
 
 [dev-dependencies]
 predicates = { version = "2.0.3", features = ["color-auto"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ readme = "README.md"
 repository = "https://github.com/killercup/cargo-edit"
 version = "0.8.0"
 edition = "2018"
+resolver = "2"
 
 [[bin]]
 name = "cargo-add"

--- a/src/fetch.rs
+++ b/src/fetch.rs
@@ -357,6 +357,18 @@ where
 
 fn get_cargo_toml_from_git_url(url: &str) -> Result<String> {
     let mut agent = ureq::AgentBuilder::new().timeout(get_default_timeout());
+    #[cfg(not(any(
+        target_arch = "x86_64",
+        target_arch = "arm",
+        target_arch = "x86",
+        target_arch = "aarch64"
+    )))]
+    {
+        use std::sync::Arc;
+
+        let tls_connector = Arc::new(native_tls::TlsConnector::new().map_err(|e| e.to_string())?);
+        agent = agent.tls_connector(tls_connector.clone());
+    }
     if let Some(proxy) = env_proxy::for_url_str(url)
         .to_url()
         .and_then(|url| ureq::Proxy::new(url).ok())


### PR DESCRIPTION
This pull request adds support for more CPU architectures (including several Rust Tier-2h targets).

The main issue is that `ureq` by default uses `ring` which only supports a total of 2 architecture families: `x86` and `arm` (and `ring` upstream did not plan to support other architectures any time soon).

This pull request resolves this issue by using `native-tls` instead of `ring` + `rustls` on "other architectures".

Due to limitations with the current `cargo` manifest format, the manifest change is a bit hacky. See https://github.com/rust-lang/cargo/issues/1197 for details on this limitation.

------

Blocked by #622 (needs to update `ureq` to 2.x in order to gain the ability to change TLS backend)