### PR TITLE
fix(add): Don't show two separate feature lists

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ name = "cargo-edit"
 readme = "README.md"
 repository = "https://github.com/killercup/cargo-edit"
 version = "0.8.0"
-edition = "2018"
+edition = "2021"
 resolver = "2"
 
 [[bin]]

--- a/src/bin/add/add.rs
+++ b/src/bin/add/add.rs
@@ -649,19 +649,31 @@ fn print_msg(dep: &Dependency, section: &[String], optional: bool) -> CargoResul
         format!("{} for target `{}`", &section[2], &section[1])
     };
     write!(output, " {}", section)?;
-    if let Some(f) = &dep.features {
-        if !f.is_empty() {
-            write!(output, " with features: {}", f.join(", "))?;
-        }
-    }
     writeln!(output, ".")?;
 
-    if !&dep.available_features.is_empty() {
-        writeln!(output, "{:>13}Available features:", " ")?;
-        for feat in dep.available_features.iter() {
+    let mut activated = dep.features.clone().unwrap_or_default();
+    activated.sort();
+    let mut deactivated;
+    if dep.available_features.is_empty() {
+        deactivated = vec![];
+    } else {
+        deactivated = dep
+            .available_features
+            .iter()
+            .filter(|f| !activated.contains(f))
+            .collect::<Vec<_>>();
+    }
+    deactivated.sort();
+    if !activated.is_empty() || !deactivated.is_empty() {
+        writeln!(output, "{:>13}Features:", " ")?;
+        for feat in activated {
+            writeln!(output, "{:>13}+ {}", " ", feat)?;
+        }
+        for feat in deactivated {
             writeln!(output, "{:>13}- {}", " ", feat)?;
         }
     }
+
     Ok(())
 }
 

--- a/src/bin/add/add.rs
+++ b/src/bin/add/add.rs
@@ -653,6 +653,14 @@ fn print_msg(dep: &Dependency, section: &[String], optional: bool) -> CargoResul
     writeln!(output, ".")?;
 
     let mut activated = dep.features.clone().unwrap_or_default();
+    if dep.default_features().unwrap_or(true) {
+        activated.extend(
+            dep.available_features
+                .get("default")
+                .into_iter()
+                .flat_map(|v| v.clone()),
+        );
+    }
     activated.sort();
     let mut deactivated;
     if dep.available_features.is_empty() {

--- a/src/bin/add/add.rs
+++ b/src/bin/add/add.rs
@@ -1,5 +1,6 @@
 #![allow(clippy::bool_assert_comparison)]
 
+use std::collections::BTreeMap;
 use std::collections::BTreeSet;
 use std::io::Write;
 use std::path::Path;
@@ -455,12 +456,12 @@ impl AddArgs {
             get_manifest_from_url(repo)?
                 .map(|m| m.features())
                 .transpose()?
-                .unwrap_or_else(Vec::new)
+                .unwrap_or_else(BTreeMap::default)
         } else if let Some(version) = dependency.version() {
             let registry_url = registry_url(manifest_path, self.registry.as_deref())?;
             get_features_from_registry(&dependency.name, version, &registry_url)?
         } else {
-            vec![]
+            BTreeMap::new()
         };
 
         let dependency = dependency.set_available_features(available_features);
@@ -562,7 +563,7 @@ fn exec(mut args: AddArgs) -> CargoResult<()> {
 
             let available_features = dep
                 .available_features
-                .iter()
+                .keys()
                 .map(|s| s.as_ref())
                 .collect::<BTreeSet<&str>>();
 
@@ -659,7 +660,7 @@ fn print_msg(dep: &Dependency, section: &[String], optional: bool) -> CargoResul
     } else {
         deactivated = dep
             .available_features
-            .iter()
+            .keys()
             .filter(|f| !activated.contains(f))
             .collect::<Vec<_>>();
     }

--- a/src/bin/add/add.rs
+++ b/src/bin/add/add.rs
@@ -669,7 +669,7 @@ fn print_msg(dep: &Dependency, section: &[String], optional: bool) -> CargoResul
         deactivated = dep
             .available_features
             .keys()
-            .filter(|f| !activated.contains(f))
+            .filter(|f| !activated.contains(f) && *f != "default")
             .collect::<Vec<_>>();
     }
     deactivated.sort();

--- a/src/bin/add/add.rs
+++ b/src/bin/add/add.rs
@@ -456,7 +456,7 @@ impl AddArgs {
             get_manifest_from_url(repo)?
                 .map(|m| m.features())
                 .transpose()?
-                .unwrap_or_else(BTreeMap::default)
+                .unwrap_or_default()
         } else if let Some(version) = dependency.version() {
             let registry_url = registry_url(manifest_path, self.registry.as_deref())?;
             get_features_from_registry(&dependency.name, version, &registry_url)?

--- a/src/bin/add/add.rs
+++ b/src/bin/add/add.rs
@@ -667,10 +667,16 @@ fn print_msg(dep: &Dependency, section: &[String], optional: bool) -> CargoResul
     if !activated.is_empty() || !deactivated.is_empty() {
         writeln!(output, "{:>13}Features:", " ")?;
         for feat in activated {
-            writeln!(output, "{:>13}+ {}", " ", feat)?;
+            output.set_color(ColorSpec::new().set_fg(Some(Color::Green)).set_bold(true))?;
+            write!(output, "{:>13}+ ", " ")?;
+            output.reset()?;
+            writeln!(output, "{}", feat)?;
         }
         for feat in deactivated {
-            writeln!(output, "{:>13}- {}", " ", feat)?;
+            output.set_color(ColorSpec::new().set_fg(Some(Color::Yellow)).set_bold(true))?;
+            write!(output, "{:>13}- ", " ")?;
+            output.reset()?;
+            writeln!(output, "{}", feat)?;
         }
     }
 

--- a/src/dependency.rs
+++ b/src/dependency.rs
@@ -200,6 +200,11 @@ impl Dependency {
     pub fn rename(&self) -> Option<&str> {
         self.rename.as_deref()
     }
+
+    /// Whether default features are activated
+    pub fn default_features(&self) -> Option<bool> {
+        self.default_features
+    }
 }
 
 impl Dependency {

--- a/src/dependency.rs
+++ b/src/dependency.rs
@@ -1,3 +1,4 @@
+use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 
 use super::manifest::str_or_1_len_table;
@@ -17,7 +18,7 @@ pub struct Dependency {
     rename: Option<String>,
 
     /// Features that are exposed by the dependency
-    pub available_features: Vec<String>,
+    pub available_features: BTreeMap<String, Vec<String>>,
 }
 
 impl Dependency {
@@ -60,7 +61,10 @@ impl Dependency {
     }
 
     /// Set the available features of the dependency to a given vec
-    pub fn set_available_features(mut self, available_features: Vec<String>) -> Dependency {
+    pub fn set_available_features(
+        mut self,
+        available_features: BTreeMap<String, Vec<String>>,
+    ) -> Dependency {
         self.available_features = available_features;
         self
     }
@@ -278,7 +282,7 @@ impl Dependency {
                 None
             };
 
-            let available_features = vec![];
+            let available_features = BTreeMap::default();
 
             let optional = if let Some(value) = table.get("optional") {
                 value.as_bool()?
@@ -544,7 +548,7 @@ impl Default for Dependency {
                 path: None,
                 registry: None,
             },
-            available_features: vec![],
+            available_features: BTreeMap::default(),
         }
     }
 }

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -150,7 +150,7 @@ impl Manifest {
                         v.map(|v| (k, v))
                     })
                     .collect::<Option<_>>()
-                    .ok_or_else(|| invalid_cargo_config())?,
+                    .ok_or_else(invalid_cargo_config)?,
                 _ => return Err(invalid_cargo_config()),
             },
         };

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -1,3 +1,4 @@
+use std::collections::BTreeMap;
 use std::fs::{self};
 use std::io::Write;
 use std::ops::{Deref, DerefMut};
@@ -129,17 +130,27 @@ impl Manifest {
     }
 
     /// returns features exposed by this manifest
-    pub fn features(&self) -> CargoResult<Vec<String>> {
-        let mut features: Vec<String> = match self.data.as_table().get("features") {
-            None => vec![],
+    pub fn features(&self) -> CargoResult<BTreeMap<String, Vec<String>>> {
+        let mut features: BTreeMap<String, Vec<String>> = match self.data.as_table().get("features")
+        {
+            None => BTreeMap::default(),
             Some(item) => match item {
-                toml_edit::Item::None => vec![],
+                toml_edit::Item::None => BTreeMap::default(),
                 toml_edit::Item::Table(t) => t
-                    .get_values()
                     .iter()
-                    .map(|(keys, _val)| keys.iter().map(|&k| k.get().trim().to_owned()))
-                    .flatten()
-                    .collect(),
+                    .map(|(k, v)| {
+                        let k = k.to_owned();
+                        let v = v
+                            .as_array()
+                            .cloned()
+                            .unwrap_or_default()
+                            .iter()
+                            .map(|v| v.as_str().map(|s| s.to_owned()))
+                            .collect::<Option<Vec<_>>>();
+                        v.map(|v| (k, v))
+                    })
+                    .collect::<Option<_>>()
+                    .ok_or_else(|| invalid_cargo_config())?,
                 _ => return Err(invalid_cargo_config()),
             },
         };
@@ -157,7 +168,7 @@ impl Manifest {
                             .and_then(|o| o.as_value())
                             .and_then(|o| o.as_bool())
                             .unwrap_or(false)
-                            .then(|| key.to_owned())
+                            .then(|| (key.to_owned(), vec![]))
                     }),
             );
         }

--- a/tests/cmd/add/add_normalized_name_external.toml
+++ b/tests/cmd/add/add_normalized_name_external.toml
@@ -16,8 +16,8 @@ WARN: Added `linked-hash-map` instead of `linked_hash_map`
              - serde_test
       Adding Inflector v0.11.4 to dependencies.
              Features:
+             + heavyweight
              - default
-             - heavyweight
              - lazy_static
              - regex
              - unstable

--- a/tests/cmd/add/add_normalized_name_external.toml
+++ b/tests/cmd/add/add_normalized_name_external.toml
@@ -17,7 +17,6 @@ WARN: Added `linked-hash-map` instead of `linked_hash_map`
       Adding Inflector v0.11.4 to dependencies.
              Features:
              + heavyweight
-             - default
              - lazy_static
              - regex
              - unstable

--- a/tests/cmd/add/add_normalized_name_external.toml
+++ b/tests/cmd/add/add_normalized_name_external.toml
@@ -6,7 +6,7 @@ stderr = """
     Updating 'https://github.com/rust-lang/crates.io-index' index
 WARN: Added `linked-hash-map` instead of `linked_hash_map`
       Adding linked-hash-map v0.5.4 to dependencies.
-             Available features:
+             Features:
              - clippy
              - heapsize
              - heapsize_impl
@@ -15,7 +15,7 @@ WARN: Added `linked-hash-map` instead of `linked_hash_map`
              - serde_impl
              - serde_test
       Adding Inflector v0.11.4 to dependencies.
-             Available features:
+             Features:
              - default
              - heavyweight
              - lazy_static

--- a/tests/cmd/add/features.toml
+++ b/tests/cmd/add/features.toml
@@ -3,12 +3,12 @@ args = ["add", "your-face", "--features", "eyes"]
 status = "success"
 stdout = ""
 stderr = """
-      Adding your-face v99999.0.0 to dependencies with features: eyes.
-             Available features:
-             - nose
-             - mouth
-             - eyes
+      Adding your-face v99999.0.0 to dependencies.
+             Features:
+             + eyes
              - ears
+             - mouth
+             - nose
 """
 fs.sandbox = true
 

--- a/tests/cmd/add/features_empty.toml
+++ b/tests/cmd/add/features_empty.toml
@@ -4,11 +4,11 @@ status = "success"
 stdout = ""
 stderr = """
       Adding your-face v99999.0.0 to dependencies.
-             Available features:
-             - nose
-             - mouth
-             - eyes
+             Features:
              - ears
+             - eyes
+             - mouth
+             - nose
 """
 fs.sandbox = true
 

--- a/tests/cmd/add/features_multiple_occurrences.toml
+++ b/tests/cmd/add/features_multiple_occurrences.toml
@@ -3,12 +3,12 @@ args = ["add", "your-face", "--features", "eyes", "--features", "nose"]
 status = "success"
 stdout = ""
 stderr = """
-      Adding your-face v99999.0.0 to dependencies with features: eyes, nose.
-             Available features:
-             - nose
-             - mouth
-             - eyes
+      Adding your-face v99999.0.0 to dependencies.
+             Features:
+             + eyes
+             + nose
              - ears
+             - mouth
 """
 fs.sandbox = true
 

--- a/tests/cmd/add/features_preserve.toml
+++ b/tests/cmd/add/features_preserve.toml
@@ -4,11 +4,11 @@ status = "success"
 stdout = ""
 stderr = """
       Adding your-face v99999.0.0 to dependencies.
-             Available features:
-             - nose
-             - mouth
-             - eyes
+             Features:
              - ears
+             - eyes
+             - mouth
+             - nose
 """
 fs.sandbox = true
 

--- a/tests/cmd/add/features_spaced_values.toml
+++ b/tests/cmd/add/features_spaced_values.toml
@@ -3,12 +3,12 @@ args = ["add", "your-face", "--features", "eyes nose"]
 status = "success"
 stdout = ""
 stderr = """
-      Adding your-face v99999.0.0 to dependencies with features: eyes, nose.
-             Available features:
-             - nose
-             - mouth
-             - eyes
+      Adding your-face v99999.0.0 to dependencies.
+             Features:
+             + eyes
+             + nose
              - ears
+             - mouth
 """
 fs.sandbox = true
 

--- a/tests/cmd/add/features_unknown.toml
+++ b/tests/cmd/add/features_unknown.toml
@@ -4,12 +4,13 @@ status = "success"
 stdout = ""
 stderr = """
     Warning: Unrecognized features: [\"noze\"]
-      Adding your-face v99999.0.0 to dependencies with features: noze.
-             Available features:
-             - nose
-             - mouth
-             - eyes
+      Adding your-face v99999.0.0 to dependencies.
+             Features:
+             + noze
              - ears
+             - eyes
+             - mouth
+             - nose
 """
 fs.sandbox = true
 

--- a/tests/cmd/add/git_external.toml
+++ b/tests/cmd/add/git_external.toml
@@ -6,16 +6,16 @@ stderr = """
     Updating 'https://github.com/rust-lang/crates.io-index' index
       Adding cargo-edit to dependencies.
              Features:
-             - add
+             + add
+             + rm
+             + set-version
+             + upgrade
+             + vendored-libgit2
              - clap
              - cli
              - color
              - default
-             - rm
-             - set-version
              - test-external-apis
-             - upgrade
-             - vendored-libgit2
              - vendored-openssl
 """
 fs.sandbox = true

--- a/tests/cmd/add/git_external.toml
+++ b/tests/cmd/add/git_external.toml
@@ -14,7 +14,6 @@ stderr = """
              - clap
              - cli
              - color
-             - default
              - test-external-apis
              - vendored-openssl
 """

--- a/tests/cmd/add/git_external.toml
+++ b/tests/cmd/add/git_external.toml
@@ -5,17 +5,17 @@ stdout = ""
 stderr = """
     Updating 'https://github.com/rust-lang/crates.io-index' index
       Adding cargo-edit to dependencies.
-             Available features:
-             - default
+             Features:
              - add
-             - rm
-             - upgrade
-             - set-version
+             - clap
              - cli
              - color
+             - default
+             - rm
+             - set-version
              - test-external-apis
-             - vendored-openssl
+             - upgrade
              - vendored-libgit2
-             - clap
+             - vendored-openssl
 """
 fs.sandbox = true

--- a/tests/cmd/add/list_features.toml
+++ b/tests/cmd/add/list_features.toml
@@ -4,11 +4,11 @@ status = "success"
 stdout = ""
 stderr = """
       Adding your-face v99999.0.0 to dependencies.
-             Available features:
-             - nose
-             - mouth
-             - eyes
+             Features:
              - ears
+             - eyes
+             - mouth
+             - nose
 """
 fs.sandbox = true
 

--- a/tests/cmd/add/list_features_path.toml
+++ b/tests/cmd/add/list_features_path.toml
@@ -5,11 +5,11 @@ stdout = ""
 stderr = """
       Adding cargo-list-test-fixture-dependency v99999.0.0 to dependencies.
       Adding your-face (local) to dependencies.
-             Available features:
+             Features:
              - default
-             - nose
-             - mouth
              - eyes
+             - mouth
+             - nose
              - optional-dependency
 """
 fs.sandbox = true

--- a/tests/cmd/add/list_features_path.toml
+++ b/tests/cmd/add/list_features_path.toml
@@ -8,7 +8,6 @@ stderr = """
              Features:
              + mouth
              + nose
-             - default
              - eyes
              - optional-dependency
 """

--- a/tests/cmd/add/list_features_path.toml
+++ b/tests/cmd/add/list_features_path.toml
@@ -6,10 +6,10 @@ stderr = """
       Adding cargo-list-test-fixture-dependency v99999.0.0 to dependencies.
       Adding your-face (local) to dependencies.
              Features:
+             + mouth
+             + nose
              - default
              - eyes
-             - mouth
-             - nose
              - optional-dependency
 """
 fs.sandbox = true

--- a/tests/cmd/add/overwrite_features.toml
+++ b/tests/cmd/add/overwrite_features.toml
@@ -3,12 +3,12 @@ args = ["add", "your-face", "--features", "nose"]
 status = "success"
 stdout = ""
 stderr = """
-      Adding your-face v99999.0.0 to dependencies with features: nose.
-             Available features:
-             - nose
-             - mouth
-             - eyes
+      Adding your-face v99999.0.0 to dependencies.
+             Features:
+             + nose
              - ears
+             - eyes
+             - mouth
 """
 fs.sandbox = true
 

--- a/tests/cmd/add/overwrite_inline_features.toml
+++ b/tests/cmd/add/overwrite_inline_features.toml
@@ -4,12 +4,12 @@ status = "success"
 stdout = ""
 stderr = """
       Adding unrelateed-crate v99999.0.0 to dependencies.
-      Adding your-face v99999.0.0 to dependencies with features: nose, mouth, ears.
-             Available features:
-             - nose
-             - mouth
+      Adding your-face v99999.0.0 to dependencies.
+             Features:
+             + ears
+             + mouth
+             + nose
              - eyes
-             - ears
 """
 fs.sandbox = true
 


### PR DESCRIPTION
Before, we showed a list of activated features (comma-separated) and all features (bulleted).

Now, we'll show a bulleted list of all features with a `+` or `-` (colored) signifying whether they are activated.  This includes default-activated features.

Additionally, `default` no longer (sometimes) shows up in the list.