### PR TITLE
fix(fetch): fix a regression introduced in `b5d052e4e51c7cbf8506a284615551fabc2f0cd9`

### DIFF
--- a/src/fetch.rs
+++ b/src/fetch.rs
@@ -385,7 +385,7 @@ fn get_cargo_toml_from_git_url(url: &str) -> CargoResult<String> {
     {
         use std::sync::Arc;
 
-        let tls_connector = Arc::new(native_tls::TlsConnector::new().map_err(|e| e.to_string())?);
+        let tls_connector = Arc::new(native_tls::TlsConnector::new()?);
         agent = agent.tls_connector(tls_connector.clone());
     }
     if let Some(proxy) = env_proxy::for_url_str(url)


### PR DESCRIPTION
This pull request simply fixes a regression introduced in b5d052e4e51c7cbf8506a284615551fabc2f0cd9 where the return type of the function changed but the error type returned wasn't.