### PR TITLE
Partially match `stderr` for 'invalid_workspace_root_manifest'

### DIFF
--- a/tests/cmd/upgrade/invalid_workspace_root_manifest.toml
+++ b/tests/cmd/upgrade/invalid_workspace_root_manifest.toml
@@ -12,7 +12,7 @@ Caused by:
       could not parse input as TOML
     
     Caused by:
-      expected an equals, found an identifier at line 1 column 6
+...
 """
 fs.sandbox = true
 


### PR DESCRIPTION
Cargo 1.60.0-stable has been released, the test `invalid_workspace_root_manifest` begins to fail as you said in https://github.com/killercup/cargo-edit/pull/655#issuecomment-1054311061.

```
Testing tests/cmd/upgrade/invalid_workspace_root_manifest.toml ... failed
Exit: 1
stdout:


---- expected: stderr
++++ actual:   stderr
   1    1 | Error: Failed to get workspace metadata
   2    2 | 
   3    3 | Caused by:
   4    4 |     `cargo metadata` exited with an error: error: failed to parse manifest at `[CWD]/Cargo.toml`
   5    5 |     
   6    6 |     Caused by:
   7    7 |       could not parse input as TOML
   8    8 |     
   9    9 |     Caused by:
  10      -       expected an equals, found an identifier at line 1 column 6
       10 +       TOML parse error at line 1, column 6
       11 +         |
       12 +       1 | This is clearly not a valid Cargo.toml.
       13 +         |      ^
       14 +       Unexpected `i`
       15 +       Expected `.` or `=`

```

This PR fixed the problem by partially matching `stderr` for it.