### PR TITLE
fix(set-version): Don't overwrite dependency updates 

### DIFF
--- a/src/bin/set-version/set_version.rs
+++ b/src/bin/set-version/set_version.rs
@@ -148,6 +148,7 @@ fn exec(args: VersionArgs) -> CargoResult<()> {
                 dunce::canonicalize(manifest.path.parent().expect("at least a parent"))?;
             for member in workspace_members.iter() {
                 let mut dep_manifest = LocalManifest::try_new(member.manifest_path.as_std_path())?;
+                let mut changed = false;
                 let dep_crate_root = dep_manifest
                     .path
                     .parent()
@@ -176,9 +177,10 @@ fn exec(args: VersionArgs) -> CargoResult<()> {
                     if let Some(new_req) = upgrade_requirement(old_req, &next)? {
                         upgrade_dependent_message(member.name.as_str(), old_req, &new_req)?;
                         dep.insert("version", toml_edit::value(new_req));
+                        changed = true;
                     }
                 }
-                if !dry_run {
+                if changed && !dry_run {
                     dep_manifest.write()?;
                 }
             }

--- a/src/bin/set-version/set_version.rs
+++ b/src/bin/set-version/set_version.rs
@@ -130,22 +130,25 @@ fn exec(args: VersionArgs) -> CargoResult<()> {
 
     let workspace_members = workspace_members(manifest_path.as_deref())?;
 
-    for (mut manifest, package) in manifests.0 {
+    for package in manifests.0 {
         if exclude.contains(&package.name) {
             continue;
         }
         let current = &package.version;
         let next = target.bump(current, metadata.as_deref())?;
         if let Some(next) = next {
-            manifest.set_package_version(&next);
+            {
+                let mut manifest = LocalManifest::try_new(Path::new(&package.manifest_path))?;
+                manifest.set_package_version(&next);
 
-            upgrade_message(package.name.as_str(), current, &next)?;
-            if !dry_run {
-                manifest.write()?;
+                upgrade_message(package.name.as_str(), current, &next)?;
+                if !dry_run {
+                    manifest.write()?;
+                }
             }
 
             let crate_root =
-                dunce::canonicalize(manifest.path.parent().expect("at least a parent"))?;
+                dunce::canonicalize(package.manifest_path.parent().expect("at least a parent"))?;
             for member in workspace_members.iter() {
                 let mut dep_manifest = LocalManifest::try_new(member.manifest_path.as_std_path())?;
                 let mut changed = false;
@@ -191,7 +194,7 @@ fn exec(args: VersionArgs) -> CargoResult<()> {
 }
 
 /// A collection of manifests.
-struct Manifests(Vec<(LocalManifest, cargo_metadata::Package)>);
+struct Manifests(Vec<cargo_metadata::Package>);
 
 impl Manifests {
     /// Get all manifests in the workspace.
@@ -204,31 +207,18 @@ impl Manifests {
         let result = cmd
             .exec()
             .with_context(|| "Failed to get workspace metadata")?;
-        result
-            .packages
-            .into_iter()
-            .map(|package| {
-                Ok((
-                    LocalManifest::try_new(Path::new(&package.manifest_path))?,
-                    package,
-                ))
-            })
-            .collect::<CargoResult<Vec<_>>>()
-            .map(Manifests)
+        Ok(Self(result.packages))
     }
 
     fn get_pkgid(manifest_path: Option<&Path>, pkgid: &str) -> CargoResult<Self> {
         let package = manifest_from_pkgid(manifest_path, pkgid)?;
-        let manifest = LocalManifest::try_new(Path::new(&package.manifest_path))?;
-        Ok(Manifests(vec![(manifest, package)]))
+        Ok(Manifests(vec![package]))
     }
 
     /// Get the manifest specified by the manifest path. Try to make an educated guess if no path is
     /// provided.
     fn get_local_one(manifest_path: Option<&Path>) -> CargoResult<Self> {
         let resolved_manifest_path: String = find(manifest_path)?.to_string_lossy().into();
-
-        let manifest = LocalManifest::find(manifest_path)?;
 
         let mut cmd = cargo_metadata::MetadataCommand::new();
         cmd.no_deps();
@@ -247,7 +237,7 @@ impl Manifests {
                  actual package in this workspace. Try adding `--workspace`."
             })?;
 
-        Ok(Manifests(vec![(manifest, package.to_owned())]))
+        Ok(Manifests(vec![package.to_owned()]))
     }
 }
 

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -30,7 +30,7 @@ pub fn workspace_members(manifest_path: Option<&Path>) -> CargoResult<Vec<Packag
         cmd.manifest_path(manifest_path);
     }
     let result = cmd.exec().with_context(|| "Invalid manifest")?;
-    let workspace_members: std::collections::HashSet<_> =
+    let workspace_members: std::collections::BTreeSet<_> =
         result.workspace_members.into_iter().collect();
     let workspace_members: Vec<_> = result
         .packages

--- a/tests/cmd/set-version/upgrade_workspace.in
+++ b/tests/cmd/set-version/upgrade_workspace.in
@@ -1,0 +1,1 @@
+set-version-workspace.in/

--- a/tests/cmd/set-version/upgrade_workspace.out/Cargo.toml
+++ b/tests/cmd/set-version/upgrade_workspace.out/Cargo.toml
@@ -1,0 +1,2 @@
+[workspace]
+members = ["primary", "dependency"]

--- a/tests/cmd/set-version/upgrade_workspace.out/dependency/Cargo.toml
+++ b/tests/cmd/set-version/upgrade_workspace.out/dependency/Cargo.toml
@@ -1,0 +1,3 @@
+[package]
+name = "cargo-list-test-fixture-dependency"
+version = "2.0.0"

--- a/tests/cmd/set-version/upgrade_workspace.out/primary/Cargo.toml
+++ b/tests/cmd/set-version/upgrade_workspace.out/primary/Cargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "cargo-list-test-fixture"
+version = "2.0.0"
+
+[dependencies]
+cargo-list-test-fixture-dependency = { version = "2.0.0", path = "../dependency" }

--- a/tests/cmd/set-version/upgrade_workspace.toml
+++ b/tests/cmd/set-version/upgrade_workspace.toml
@@ -1,0 +1,13 @@
+bin.name = "cargo-set-version"
+args = ["set-version", "2.0.0", "--workspace"]
+status = "success"
+stdout = ""
+stderr = """
+    Upgraded cargo-list-test-fixture from 0.0.0 to 2.0.0
+    Upgraded cargo-list-test-fixture-dependency from 0.4.3 to 2.0.0
+Updated dependency cargo-list-test-fixture from 0.4.3 to 2.0.0
+"""
+fs.sandbox = true
+
+[env.add]
+CARGO_IS_TEST="1"


### PR DESCRIPTION
We load all manifests up front and and then iteratively update and write
them out.  The problem is between load and update/write, we might have
processed another manifest and updated the dependency table in the other
manifest, causing the last writer to win and updates to be lost.

Our tests haven't forced this situation yet.  We inherited this from
`upgrade` but since it only write to one at a time, it doesn't have the
last-writer-wins problem.

Fixes #702 