### PR TITLE
chore: update toml_edit to v0.14

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -666,6 +666,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "kstring"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec3066350882a1cd6d950d055997f379ac37fd39f81cd4d8ed186032eb3c5747"
+dependencies = [
+ "static_assertions",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1365,6 +1374,7 @@ dependencies = [
  "combine",
  "indexmap",
  "itertools",
+ "kstring",
  "serde",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -143,7 +143,7 @@ dependencies = [
  "serde_json",
  "subprocess",
  "termcolor",
- "toml_edit 0.14.4",
+ "toml_edit",
  "trycmd",
  "ureq",
  "url",
@@ -663,15 +663,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a38fc24e30fd564ce974c02bf1d337caddff65be6cc4735a1f7eab22a7440f04"
 dependencies = [
  "wasm-bindgen",
-]
-
-[[package]]
-name = "kstring"
-version = "1.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b310ccceade8121d7d77fee406160e457c2f4e7c7982d589da3499bc7ea4526"
-dependencies = [
- "serde",
 ]
 
 [[package]]
@@ -1367,19 +1358,6 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "toml_edit"
-version = "0.13.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "744e9ed5b352340aa47ce033716991b5589e23781acb97cad37d4ea70560f55b"
-dependencies = [
- "combine",
- "indexmap",
- "itertools",
- "kstring",
- "serde",
-]
-
-[[package]]
-name = "toml_edit"
 version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5376256e44f2443f8896ac012507c19a012df0fe8758b55246ae51a2279db51f"
@@ -1392,9 +1370,9 @@ dependencies = [
 
 [[package]]
 name = "trycmd"
-version = "0.13.3"
+version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c21f68a540a24b162ca101e3f7f4ce3c8458f594f28080018f29da23ad8567b"
+checksum = "ffb4185126cc904642173a54c185083f410c86d1202ada6761aacf7c40829f13"
 dependencies = [
  "glob",
  "humantime",
@@ -1403,7 +1381,7 @@ dependencies = [
  "serde",
  "shlex",
  "snapbox",
- "toml_edit 0.13.4",
+ "toml_edit",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -143,7 +143,7 @@ dependencies = [
  "serde_json",
  "subprocess",
  "termcolor",
- "toml_edit",
+ "toml_edit 0.14.4",
  "trycmd",
  "ureq",
  "url",
@@ -1379,6 +1379,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml_edit"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5376256e44f2443f8896ac012507c19a012df0fe8758b55246ae51a2279db51f"
+dependencies = [
+ "combine",
+ "indexmap",
+ "itertools",
+ "serde",
+]
+
+[[package]]
 name = "trycmd"
 version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1391,7 +1403,7 @@ dependencies = [
  "serde",
  "shlex",
  "snapbox",
- "toml_edit",
+ "toml_edit 0.13.4",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,7 +73,7 @@ serde_json = "1.0.58"
 clap = { version = "3.1", features = ["derive", "wrap_help"], optional = true }
 subprocess = "0.2.6"
 termcolor = "1.1.0"
-toml_edit = { version = "0.13.3", features = ["easy"] }
+toml_edit = { version = "0.14.4", features = ["easy"] }
 indexmap = "1"
 url = "2.1.1"
 pathdiff = "0.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,7 +73,7 @@ serde_json = "1.0.58"
 clap = { version = "3.1", features = ["derive", "wrap_help"], optional = true }
 subprocess = "0.2.6"
 termcolor = "1.1.0"
-toml_edit = { version = "0.14.4", features = ["easy"] }
+toml_edit = { version = "0.14.4", features = ["easy", "perf"] }
 indexmap = "1"
 url = "2.1.1"
 pathdiff = "0.2"


### PR DESCRIPTION
I edited the Cargo.toml to update toml_edit version and I run `cargo update -p trycmd` so that users don't have to compile to versions of toml_edit