### PR TITLE
Reject crate names that are single '+'

### DIFF
--- a/src/bin/add/add.rs
+++ b/src/bin/add/add.rs
@@ -227,6 +227,10 @@ impl AddArgs {
 
         let mut deps: Vec<Dependency> = Vec::new();
         for crate_spec in &self.crates {
+            if crate_spec == "+" {
+                anyhow::bail!("`+` is not a valid pkgid - Did you add a space before a feature?");
+            }
+
             if let Some(features) = crate_spec.strip_prefix('+') {
                 if !self.unstable_features.contains(&UnstableOptions::InlineAdd) {
                     inline_add_message()?;

--- a/tests/cmd/add/invalid_name_plus.in
+++ b/tests/cmd/add/invalid_name_plus.in
@@ -1,0 +1,1 @@
+add-basic.in/

--- a/tests/cmd/add/invalid_name_plus.toml
+++ b/tests/cmd/add/invalid_name_plus.toml
@@ -1,0 +1,11 @@
+bin.name = "cargo-add"
+args = ["add", "my-package", "+"]
+status.code = 1
+stdout = ""
+stderr = """
+Error: `+` is not a valid pkgid - Did you add a space before a feature?
+"""
+fs.sandbox = true
+
+[env.add]
+CARGO_IS_TEST="1"

--- a/tests/cmd/add/invalid_name_plus_space_feature.in
+++ b/tests/cmd/add/invalid_name_plus_space_feature.in
@@ -1,0 +1,1 @@
+add-basic.in/

--- a/tests/cmd/add/invalid_name_plus_space_feature.toml
+++ b/tests/cmd/add/invalid_name_plus_space_feature.toml
@@ -1,0 +1,11 @@
+bin.name = "cargo-add"
+args = ["add", "my-package", "+", "my-feature"]
+status.code = 1
+stdout = ""
+stderr = """
+Error: `+` is not a valid pkgid - Did you add a space before a feature?
+"""
+fs.sandbox = true
+
+[env.add]
+CARGO_IS_TEST="1"


### PR DESCRIPTION
When using `cargo add` to add crates with features, a user can make a mistake and accidentally add a space between the + and the feature name, e.g.:
```
$ cargo add tokio + full
    Updating 'https://github.com/rust-lang/crates.io-index' index
    Warning: `+<feature>` is unstable and requires `-Z inline-add`
      Adding tokio v1.18.2 to dependencies.
             Features:
             - bytes
             - fs
             - full
             - io-std
             - io-util
             - libc
             - macros
             - memchr
             - mio
             - net
             - num_cpus
             - once_cell
             - parking_lot
             - process
             - rt
             - rt-multi-thread
             - signal
             - signal-hook-registry
             - socket2
             - stats
             - sync
             - test-util
             - time
             - tokio-macros
             - tracing
             - winapi
      Adding full v0.1.0 to dependencies.
```

Notice how this adds the `full` package, which was not intended.

This has security implications: A malicious actor could create malicious crates with the names of common features and simply wait for this mistake to be made. Even if the user notices their mistake and immediately removes the dependency, it is likely that rust-analyzer has already run the `build.rs`.

Assuming that the user is generally competent and trusts the crates that they add, we can still help alleviate this issue: `+` is an invalid crate name, so no user would ever want to add `+`, so no mistake-free input of `cargo add` should ever include `+`.