### PR TITLE
Add `--target` flag to cargo-rm

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,14 +156,17 @@ ARGS:
     <CRATE>...    Crates to be removed
 
 OPTIONS:
-    -B, --build                   Remove crate as build dependency
-    -D, --dev                     Remove crate as development dependency
     -h, --help                    Print help information
         --manifest-path <PATH>    Path to the manifest to remove a dependency from
     -p, --package <PKGID>         Package id of the crate to remove this dependency from
     -q, --quiet                   Do not print any output in case of success
     -V, --version                 Print version information
     -Z <FLAG>                     Unstable (nightly-only) flags
+
+SECTION:
+    -B, --build              Remove crate as build dependency
+    -D, --dev                Remove crate as development dependency
+        --target <TARGET>    Remove as dependency from the given target platform
 
 ```
 

--- a/src/bin/add/add.rs
+++ b/src/bin/add/add.rs
@@ -618,7 +618,7 @@ fn exec(mut args: AddArgs) -> CargoResult<()> {
 
     if was_sorted {
         if let Some(table) = manifest
-            .get_table_mut(&args.get_section())
+            .get_table_mut(&args.get_section(), true)
             .ok()
             .and_then(TomlItem::as_table_like_mut)
         {

--- a/src/bin/rm/rm.rs
+++ b/src/bin/rm/rm.rs
@@ -15,12 +15,33 @@ pub struct RmArgs {
     crates: Vec<String>,
 
     /// Remove crate as development dependency.
-    #[clap(long, short = 'D', conflicts_with = "build")]
+    #[clap(
+        long,
+        short = 'D',
+        conflicts_with = "build",
+        help_heading = "SECTION",
+        group = "SECTION"
+    )]
     dev: bool,
 
     /// Remove crate as build dependency.
-    #[clap(long, short = 'B', conflicts_with = "dev")]
+    #[clap(
+        long,
+        short = 'B',
+        conflicts_with = "dev",
+        help_heading = "SECTION",
+        group = "SECTION"
+    )]
     build: bool,
+
+    /// Remove as dependency from the given target platform.
+    #[clap(
+        long,
+        forbid_empty_values = true,
+        help_heading = "SECTION",
+        group = "section"
+    )]
+    target: Option<String>,
 
     /// Path to the manifest to remove a dependency from.
     #[clap(
@@ -54,14 +75,26 @@ impl RmArgs {
         exec(self)
     }
 
-    /// Get depenency section
-    pub fn get_section(&self) -> &'static str {
-        if self.dev {
+    /// Get dependency section
+    pub fn get_section(&self) -> Vec<String> {
+        let section_name = if self.dev {
             "dev-dependencies"
         } else if self.build {
             "build-dependencies"
         } else {
             "dependencies"
+        };
+
+        if let Some(ref target) = self.target {
+            assert!(!target.is_empty(), "Target specification may not be empty");
+
+            vec![
+                "target".to_owned(),
+                target.clone(),
+                section_name.to_owned(),
+            ]
+        } else {
+            vec![section_name.to_owned()]
         }
     }
 }
@@ -69,12 +102,17 @@ impl RmArgs {
 #[derive(Copy, Clone, Debug, PartialEq, Eq, clap::ArgEnum)]
 enum UnstableOptions {}
 
-fn print_msg(name: &str, section: &str) -> CargoResult<()> {
+fn print_msg(name: &str, section: &[String]) -> CargoResult<()> {
     let colorchoice = colorize_stderr();
     let mut output = StandardStream::stderr(colorchoice);
     output.set_color(ColorSpec::new().set_fg(Some(Color::Green)).set_bold(true))?;
     write!(output, "{:>12}", "Removing")?;
     output.reset()?;
+    let section = if section.len() == 1 {
+        section[0].clone()
+    } else {
+        format!("{} for target `{}`", &section[2], &section[1])
+    };
     writeln!(output, " {} from {}", name, section)?;
     Ok(())
 }
@@ -92,10 +130,10 @@ fn exec(args: &RmArgs) -> CargoResult<()> {
     deps.iter()
         .map(|dep| {
             if !args.quiet {
-                print_msg(dep, args.get_section())?;
+                print_msg(dep, &args.get_section())?;
             }
             let result = manifest
-                .remove_from_table(args.get_section(), dep)
+                .remove_from_table(&args.get_section(), dep)
                 .map_err(Into::into);
 
             // Now that we have removed the crate, if that was the last reference to that crate,

--- a/tests/cmd/rm/invalid_rm_target.in
+++ b/tests/cmd/rm/invalid_rm_target.in
@@ -1,0 +1,1 @@
+rm_target.in

--- a/tests/cmd/rm/invalid_rm_target.out/Cargo.toml
+++ b/tests/cmd/rm/invalid_rm_target.out/Cargo.toml
@@ -1,0 +1,35 @@
+[package]
+name = "cargo-rm-target-test-fixture"
+version = "0.1.0"
+
+[[bin]]
+name = "main"
+path = "src/main.rs"
+
+[target.x86_64-unknown-freebsd.build-dependencies]
+semver = "0.1.0"
+
+[target.x86_64-unknown-linux-gnu.build-dependencies]
+semver = "0.1.0"
+
+[dependencies]
+docopt = "0.6"
+pad = "0.1"
+rustc-serialize = "0.3"
+semver = "0.1"
+toml = "0.1"
+clippy = {git = "https://github.com/Manishearth/rust-clippy.git", optional = true}
+
+[target.x86_64-unknown-linux-gnu.dependencies]
+dbus = "0.9.5"
+
+[dev-dependencies]
+regex = "0.1.41"
+serde = "1.0.90"
+
+[target.x86_64-unknown-linux-gnu.dev-dependencies]
+ncurses = "5.101"
+
+[features]
+std = ["serde/std", "semver/std"]
+annoy = ["clippy"]

--- a/tests/cmd/rm/invalid_rm_target.toml
+++ b/tests/cmd/rm/invalid_rm_target.toml
@@ -1,0 +1,15 @@
+bin.name = "cargo-rm"
+args = ["rm", "--target", "powerpc-unknown-linux-gnu", "dbus"]
+status.code = 1
+stdout = ""
+stderr = """
+    Removing dbus from dependencies for target `powerpc-unknown-linux-gnu`
+Could not edit `Cargo.toml`.
+
+ERROR: The table `powerpc-unknown-linux-gnu` could not be found.
+Error: The table `powerpc-unknown-linux-gnu` could not be found.
+"""
+fs.sandbox = true
+
+[env.add]
+CARGO_IS_TEST="1"

--- a/tests/cmd/rm/invalid_rm_target_dep.in
+++ b/tests/cmd/rm/invalid_rm_target_dep.in
@@ -1,0 +1,1 @@
+rm_target.in

--- a/tests/cmd/rm/invalid_rm_target_dep.out/Cargo.toml
+++ b/tests/cmd/rm/invalid_rm_target_dep.out/Cargo.toml
@@ -1,0 +1,35 @@
+[package]
+name = "cargo-rm-target-test-fixture"
+version = "0.1.0"
+
+[[bin]]
+name = "main"
+path = "src/main.rs"
+
+[target.x86_64-unknown-freebsd.build-dependencies]
+semver = "0.1.0"
+
+[target.x86_64-unknown-linux-gnu.build-dependencies]
+semver = "0.1.0"
+
+[dependencies]
+docopt = "0.6"
+pad = "0.1"
+rustc-serialize = "0.3"
+semver = "0.1"
+toml = "0.1"
+clippy = {git = "https://github.com/Manishearth/rust-clippy.git", optional = true}
+
+[target.x86_64-unknown-linux-gnu.dependencies]
+dbus = "0.9.5"
+
+[dev-dependencies]
+regex = "0.1.41"
+serde = "1.0.90"
+
+[target.x86_64-unknown-linux-gnu.dev-dependencies]
+ncurses = "5.101"
+
+[features]
+std = ["serde/std", "semver/std"]
+annoy = ["clippy"]

--- a/tests/cmd/rm/invalid_rm_target_dep.toml
+++ b/tests/cmd/rm/invalid_rm_target_dep.toml
@@ -1,0 +1,15 @@
+bin.name = "cargo-rm"
+args = ["rm", "--target", "x86_64-unknown-linux-gnu", "toml"]
+status.code = 1
+stdout = ""
+stderr = """
+    Removing toml from dependencies for target `x86_64-unknown-linux-gnu`
+Could not edit `Cargo.toml`.
+
+ERROR: The dependency `toml` could not be found in `target.x86_64-unknown-linux-gnu.dependencies`.
+Error: The dependency `toml` could not be found in `target.x86_64-unknown-linux-gnu.dependencies`.
+"""
+fs.sandbox = true
+
+[env.add]
+CARGO_IS_TEST="1"

--- a/tests/cmd/rm/rm_target.in/Cargo.toml
+++ b/tests/cmd/rm/rm_target.in/Cargo.toml
@@ -1,0 +1,35 @@
+[package]
+name = "cargo-rm-target-test-fixture"
+version = "0.1.0"
+
+[[bin]]
+name = "main"
+path = "src/main.rs"
+
+[target.x86_64-unknown-freebsd.build-dependencies]
+semver = "0.1.0"
+
+[target.x86_64-unknown-linux-gnu.build-dependencies]
+semver = "0.1.0"
+
+[dependencies]
+docopt = "0.6"
+pad = "0.1"
+rustc-serialize = "0.3"
+semver = "0.1"
+toml = "0.1"
+clippy = {git = "https://github.com/Manishearth/rust-clippy.git", optional = true}
+
+[target.x86_64-unknown-linux-gnu.dependencies]
+dbus = "0.9.5"
+
+[dev-dependencies]
+regex = "0.1.41"
+serde = "1.0.90"
+
+[target.x86_64-unknown-linux-gnu.dev-dependencies]
+ncurses = "5.101"
+
+[features]
+std = ["serde/std", "semver/std"]
+annoy = ["clippy"]

--- a/tests/cmd/rm/rm_target.out/Cargo.toml
+++ b/tests/cmd/rm/rm_target.out/Cargo.toml
@@ -1,0 +1,32 @@
+[package]
+name = "cargo-rm-target-test-fixture"
+version = "0.1.0"
+
+[[bin]]
+name = "main"
+path = "src/main.rs"
+
+[target.x86_64-unknown-freebsd.build-dependencies]
+semver = "0.1.0"
+
+[target.x86_64-unknown-linux-gnu.build-dependencies]
+semver = "0.1.0"
+
+[dependencies]
+docopt = "0.6"
+pad = "0.1"
+rustc-serialize = "0.3"
+semver = "0.1"
+toml = "0.1"
+clippy = {git = "https://github.com/Manishearth/rust-clippy.git", optional = true}
+
+[dev-dependencies]
+regex = "0.1.41"
+serde = "1.0.90"
+
+[target.x86_64-unknown-linux-gnu.dev-dependencies]
+ncurses = "5.101"
+
+[features]
+std = ["serde/std", "semver/std"]
+annoy = ["clippy"]

--- a/tests/cmd/rm/rm_target.toml
+++ b/tests/cmd/rm/rm_target.toml
@@ -1,0 +1,11 @@
+bin.name = "cargo-rm"
+args = ["rm", "--target", "x86_64-unknown-linux-gnu", "dbus"]
+status = "success"
+stdout = ""
+stderr = """
+    Removing dbus from dependencies for target `x86_64-unknown-linux-gnu`
+"""
+fs.sandbox = true
+
+[env.add]
+CARGO_IS_TEST="1"

--- a/tests/cmd/rm/rm_target_build.in
+++ b/tests/cmd/rm/rm_target_build.in
@@ -1,0 +1,1 @@
+rm_target.in

--- a/tests/cmd/rm/rm_target_build.out/Cargo.toml
+++ b/tests/cmd/rm/rm_target_build.out/Cargo.toml
@@ -1,0 +1,32 @@
+[package]
+name = "cargo-rm-target-test-fixture"
+version = "0.1.0"
+
+[[bin]]
+name = "main"
+path = "src/main.rs"
+
+[target.x86_64-unknown-freebsd.build-dependencies]
+semver = "0.1.0"
+
+[dependencies]
+docopt = "0.6"
+pad = "0.1"
+rustc-serialize = "0.3"
+semver = "0.1"
+toml = "0.1"
+clippy = {git = "https://github.com/Manishearth/rust-clippy.git", optional = true}
+
+[target.x86_64-unknown-linux-gnu.dependencies]
+dbus = "0.9.5"
+
+[dev-dependencies]
+regex = "0.1.41"
+serde = "1.0.90"
+
+[target.x86_64-unknown-linux-gnu.dev-dependencies]
+ncurses = "5.101"
+
+[features]
+std = ["serde/std", "semver/std"]
+annoy = ["clippy"]

--- a/tests/cmd/rm/rm_target_build.toml
+++ b/tests/cmd/rm/rm_target_build.toml
@@ -1,0 +1,11 @@
+bin.name = "cargo-rm"
+args = ["rm", "--build", "--target", "x86_64-unknown-linux-gnu", "semver"]
+status = "success"
+stdout = ""
+stderr = """
+    Removing semver from build-dependencies for target `x86_64-unknown-linux-gnu`
+"""
+fs.sandbox = true
+
+[env.add]
+CARGO_IS_TEST="1"

--- a/tests/cmd/rm/rm_target_dev.in
+++ b/tests/cmd/rm/rm_target_dev.in
@@ -1,0 +1,1 @@
+rm_target.in

--- a/tests/cmd/rm/rm_target_dev.out/Cargo.toml
+++ b/tests/cmd/rm/rm_target_dev.out/Cargo.toml
@@ -1,0 +1,32 @@
+[package]
+name = "cargo-rm-target-test-fixture"
+version = "0.1.0"
+
+[[bin]]
+name = "main"
+path = "src/main.rs"
+
+[target.x86_64-unknown-freebsd.build-dependencies]
+semver = "0.1.0"
+
+[target.x86_64-unknown-linux-gnu.build-dependencies]
+semver = "0.1.0"
+
+[dependencies]
+docopt = "0.6"
+pad = "0.1"
+rustc-serialize = "0.3"
+semver = "0.1"
+toml = "0.1"
+clippy = {git = "https://github.com/Manishearth/rust-clippy.git", optional = true}
+
+[target.x86_64-unknown-linux-gnu.dependencies]
+dbus = "0.9.5"
+
+[dev-dependencies]
+regex = "0.1.41"
+serde = "1.0.90"
+
+[features]
+std = ["serde/std", "semver/std"]
+annoy = ["clippy"]

--- a/tests/cmd/rm/rm_target_dev.toml
+++ b/tests/cmd/rm/rm_target_dev.toml
@@ -1,0 +1,11 @@
+bin.name = "cargo-rm"
+args = ["rm", "--dev", "--target", "x86_64-unknown-linux-gnu", "ncurses"]
+status = "success"
+stdout = ""
+stderr = """
+    Removing ncurses from dev-dependencies for target `x86_64-unknown-linux-gnu`
+"""
+fs.sandbox = true
+
+[env.add]
+CARGO_IS_TEST="1"


### PR DESCRIPTION
This PR adds a `--target` flag to the cargo-rm command in the style of cargo-add's equivalent, with the only difference in usage being that this flag can be used in conjunction with `--dev` or `--build`.