### PR TITLE
Clean up custom console output with utils

### DIFF
--- a/src/bin/upgrade/upgrade.rs
+++ b/src/bin/upgrade/upgrade.rs
@@ -3,7 +3,7 @@ use std::io::Write;
 use std::path::{Path, PathBuf};
 
 use cargo_edit::{
-    colorize_stderr, find, get_latest_dependency, manifest_from_pkgid, registry_url,
+    colorize_stderr, find, get_latest_dependency, manifest_from_pkgid, registry_url, shell_warn,
     update_registry_index, CargoResult, Context, CrateSpec, Dependency, LocalManifest,
 };
 use clap::Args;
@@ -191,7 +191,7 @@ fn exec(args: UpgradeArgs) -> CargoResult<()> {
     }
 
     if args.dry_run {
-        dry_run_message()?;
+        shell_warn("aborting upgrade due to dry run")?;
     }
 
     Ok(())
@@ -515,20 +515,5 @@ fn deprecated_message(message: &str) -> CargoResult<()> {
     output
         .set_color(&ColorSpec::new())
         .with_context(|| "Failed to clear output colour")?;
-    Ok(())
-}
-
-fn dry_run_message() -> CargoResult<()> {
-    let colorchoice = colorize_stderr();
-    let mut output = StandardStream::stderr(colorchoice);
-    output
-        .set_color(ColorSpec::new().set_fg(Some(Color::Yellow)).set_bold(true))
-        .with_context(|| "Failed to set output colour")?;
-    write!(output, "warning").with_context(|| "Failed to write dry run message")?;
-    output
-        .set_color(&ColorSpec::new())
-        .with_context(|| "Failed to clear output colour")?;
-    writeln!(output, ": aborting upgrade due to dry run")
-        .with_context(|| "Failed to write dry run message")?;
     Ok(())
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,5 +36,5 @@ pub use fetch::{
 pub use manifest::{find, LocalManifest, Manifest};
 pub use metadata::{manifest_from_pkgid, workspace_members};
 pub use registry::registry_url;
-pub use util::{colorize_stderr, ColorChoice};
+pub use util::{colorize_stderr, shell_print, shell_status, shell_warn, Color, ColorChoice};
 pub use version::{upgrade_requirement, VersionExt};

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -709,7 +709,7 @@ fn print_upgrade_if_necessary(
     buffer
         .set_color(ColorSpec::new().set_fg(Some(Color::Green)).set_bold(true))
         .with_context(|| "Failed to set output colour")?;
-    write!(&mut buffer, "    Upgrading ").with_context(|| "Failed to write upgrade message")?;
+    write!(&mut buffer, "   Upgrading ").with_context(|| "Failed to write upgrade message")?;
     buffer
         .set_color(&ColorSpec::new())
         .with_context(|| "Failed to clear output colour")?;

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -1,15 +1,14 @@
 use std::collections::BTreeMap;
 use std::fs;
-use std::io::Write;
 use std::ops::{Deref, DerefMut};
 use std::path::{Path, PathBuf};
 use std::{env, str};
 
 use semver::{Version, VersionReq};
-use termcolor::{BufferWriter, Color, ColorSpec, WriteColor};
 
 use super::dependency::Dependency;
 use super::errors::*;
+use super::shell_status;
 
 const MANIFEST_FILENAME: &str = "Cargo.toml";
 const DEP_TABLES: &[&str] = &["dependencies", "dev-dependencies", "build-dependencies"];
@@ -703,25 +702,10 @@ fn print_upgrade_if_necessary(
         return Ok(());
     }
 
-    let colorchoice = super::colorize_stderr();
-    let bufwtr = BufferWriter::stderr(colorchoice);
-    let mut buffer = bufwtr.buffer();
-    buffer
-        .set_color(ColorSpec::new().set_fg(Some(Color::Green)).set_bold(true))
-        .with_context(|| "Failed to set output colour")?;
-    write!(&mut buffer, "   Upgrading ").with_context(|| "Failed to write upgrade message")?;
-    buffer
-        .set_color(&ColorSpec::new())
-        .with_context(|| "Failed to clear output colour")?;
-    writeln!(
-        &mut buffer,
-        "{} v{} -> v{}",
-        crate_name, old_version, new_version,
-    )
-    .with_context(|| "Failed to write upgrade versions")?;
-    bufwtr
-        .print(&buffer)
-        .with_context(|| "Failed to print upgrade message")?;
+    shell_status(
+        "Upgrading",
+        &format!("{crate_name} v{old_version} -> v{new_version}"),
+    )?;
 
     Ok(())
 }

--- a/tests/cmd/upgrade/alt_registry.toml
+++ b/tests/cmd/upgrade/alt_registry.toml
@@ -5,8 +5,8 @@ stdout = """
 none:
 """
 stderr = """
-    Upgrading regex v0.2 -> v99999.0.0
-    Upgrading toml_edit v0.1.5 -> v99999.0.0
+   Upgrading regex v0.2 -> v99999.0.0
+   Upgrading toml_edit v0.1.5 -> v99999.0.0
 """
 fs.sandbox = true
 

--- a/tests/cmd/upgrade/dry_run.toml
+++ b/tests/cmd/upgrade/dry_run.toml
@@ -5,7 +5,7 @@ stdout = """
 cargo-list-test-fixture:
 """
 stderr = """
-    Upgrading docopt v0.8.0 -> v99999.0.0
+   Upgrading docopt v0.8.0 -> v99999.0.0
 warning: aborting upgrade due to dry run
 """
 fs.sandbox = true

--- a/tests/cmd/upgrade/dry_run_prerelease.toml
+++ b/tests/cmd/upgrade/dry_run_prerelease.toml
@@ -5,7 +5,7 @@ stdout = """
 cargo-list-test-fixture:
 """
 stderr = """
-    Upgrading docopt v0.8.0 -> v99999.0.0-alpha.1
+   Upgrading docopt v0.8.0 -> v99999.0.0-alpha.1
 warning: aborting upgrade due to dry run
 """
 fs.sandbox = true

--- a/tests/cmd/upgrade/exclude_dep.toml
+++ b/tests/cmd/upgrade/exclude_dep.toml
@@ -5,20 +5,20 @@ stdout = """
 None:
 """
 stderr = """
-    Upgrading assert_cli v0.2.0 -> v99999.0.0
-    Upgrading ftp v2.2.1 -> v99999.0.0
-    Upgrading ftp v2.2.1 -> v99999.0.0
-    Upgrading geo v0.7.0 -> v99999.0.0
-    Upgrading openssl v0.9 -> v99999.0.0
-    Upgrading pad v0.1 -> v99999.0.0
-    Upgrading renamed v0.1 -> v99999.0.0
-    Upgrading rget v0.3.0 -> v99999.0.0
-    Upgrading semver v0.7 -> v99999.0.0
-    Upgrading serde_json v1.0 -> v99999.0.0
-    Upgrading syn v0.11.10 -> v99999.0.0
-    Upgrading tar v0.4 -> v99999.0.0
-    Upgrading tempdir v0.3 -> v99999.0.0
-    Upgrading toml_edit v0.1.5 -> v99999.0.0
+   Upgrading assert_cli v0.2.0 -> v99999.0.0
+   Upgrading ftp v2.2.1 -> v99999.0.0
+   Upgrading ftp v2.2.1 -> v99999.0.0
+   Upgrading geo v0.7.0 -> v99999.0.0
+   Upgrading openssl v0.9 -> v99999.0.0
+   Upgrading pad v0.1 -> v99999.0.0
+   Upgrading renamed v0.1 -> v99999.0.0
+   Upgrading rget v0.3.0 -> v99999.0.0
+   Upgrading semver v0.7 -> v99999.0.0
+   Upgrading serde_json v1.0 -> v99999.0.0
+   Upgrading syn v0.11.10 -> v99999.0.0
+   Upgrading tar v0.4 -> v99999.0.0
+   Upgrading tempdir v0.3 -> v99999.0.0
+   Upgrading toml_edit v0.1.5 -> v99999.0.0
 """
 fs.sandbox = true
 

--- a/tests/cmd/upgrade/exclude_renamed.toml
+++ b/tests/cmd/upgrade/exclude_renamed.toml
@@ -5,7 +5,7 @@ stdout = """
 cargo-list-test-fixture:
 """
 stderr = """
-    Upgrading toml_edit v0.1.5 -> v99999.0.0
+   Upgrading toml_edit v0.1.5 -> v99999.0.0
 """
 fs.sandbox = true
 

--- a/tests/cmd/upgrade/implicit_prerelease.toml
+++ b/tests/cmd/upgrade/implicit_prerelease.toml
@@ -5,8 +5,8 @@ stdout = """
 cargo-list-test-fixture:
 """
 stderr = """
-    Upgrading a v1.0 -> v99999.0.0
-    Upgrading b v0.8.0-alpha -> v99999.0.0-alpha.1
+   Upgrading a v1.0 -> v99999.0.0
+   Upgrading b v0.8.0-alpha -> v99999.0.0-alpha.1
 """
 fs.sandbox = true
 

--- a/tests/cmd/upgrade/optional_dep.toml
+++ b/tests/cmd/upgrade/optional_dep.toml
@@ -5,7 +5,7 @@ stdout = """
 cargo-list-test-fixture:
 """
 stderr = """
-    Upgrading docopt v0.8.0 -> v99999.0.0
+   Upgrading docopt v0.8.0 -> v99999.0.0
 """
 fs.sandbox = true
 

--- a/tests/cmd/upgrade/prerelease.toml
+++ b/tests/cmd/upgrade/prerelease.toml
@@ -5,7 +5,7 @@ stdout = """
 cargo-list-test-fixture:
 """
 stderr = """
-    Upgrading docopt v0.8.0 -> v99999.0.0-alpha.1
+   Upgrading docopt v0.8.0 -> v99999.0.0-alpha.1
 """
 fs.sandbox = true
 

--- a/tests/cmd/upgrade/preserve_precision_major.toml
+++ b/tests/cmd/upgrade/preserve_precision_major.toml
@@ -5,7 +5,7 @@ stdout = """
 cargo-list-test-fixture:
 """
 stderr = """
-    Upgrading docopt v0 -> v99999
+   Upgrading docopt v0 -> v99999
 """
 fs.sandbox = true
 

--- a/tests/cmd/upgrade/preserve_precision_minor.toml
+++ b/tests/cmd/upgrade/preserve_precision_minor.toml
@@ -5,7 +5,7 @@ stdout = """
 cargo-list-test-fixture:
 """
 stderr = """
-    Upgrading docopt v0.8 -> v99999.0
+   Upgrading docopt v0.8 -> v99999.0
 """
 fs.sandbox = true
 

--- a/tests/cmd/upgrade/preserve_precision_patch.toml
+++ b/tests/cmd/upgrade/preserve_precision_patch.toml
@@ -5,7 +5,7 @@ stdout = """
 cargo-list-test-fixture:
 """
 stderr = """
-    Upgrading docopt v0.8.0 -> v99999.0.0
+   Upgrading docopt v0.8.0 -> v99999.0.0
 """
 fs.sandbox = true
 

--- a/tests/cmd/upgrade/single_dep.toml
+++ b/tests/cmd/upgrade/single_dep.toml
@@ -5,7 +5,7 @@ stdout = """
 cargo-list-test-fixture:
 """
 stderr = """
-    Upgrading docopt v0.8.0 -> v99999.0.0
+   Upgrading docopt v0.8.0 -> v99999.0.0
 """
 fs.sandbox = true
 

--- a/tests/cmd/upgrade/skip_compatible.toml
+++ b/tests/cmd/upgrade/skip_compatible.toml
@@ -5,7 +5,7 @@ stdout = """
 cargo-list-test-fixture:
 """
 stderr = """
-    Upgrading test_breaking v0.1 -> v0.2.0
+   Upgrading test_breaking v0.1 -> v0.2.0
 """
 fs.sandbox = true
 

--- a/tests/cmd/upgrade/skip_pinned.toml
+++ b/tests/cmd/upgrade/skip_pinned.toml
@@ -5,12 +5,12 @@ stdout = """
 cargo-list-test-fixture:
 """
 stderr = """
-    Upgrading caret v^3.0 -> v99999.0.0
-    Upgrading default v1.0 -> v99999.0.0
-    Upgrading greaterorequal v>=2.1.0 -> v99999.0.0
-    Upgrading greaterthan v>2.0 -> v99999.0.0
-    Upgrading tilde v~4.1.0 -> v99999.0.0
-    Upgrading wildcard v3.* -> v99999.0.0
+   Upgrading caret v^3.0 -> v99999.0.0
+   Upgrading default v1.0 -> v99999.0.0
+   Upgrading greaterorequal v>=2.1.0 -> v99999.0.0
+   Upgrading greaterthan v>2.0 -> v99999.0.0
+   Upgrading tilde v~4.1.0 -> v99999.0.0
+   Upgrading wildcard v3.* -> v99999.0.0
 """
 fs.sandbox = true
 

--- a/tests/cmd/upgrade/specified.toml
+++ b/tests/cmd/upgrade/specified.toml
@@ -5,7 +5,7 @@ stdout = """
 cargo-list-test-fixture:
 """
 stderr = """
-    Upgrading a v1.0 -> v99999.0.0
+   Upgrading a v1.0 -> v99999.0.0
 """
 fs.sandbox = true
 

--- a/tests/cmd/upgrade/to_lockfile.toml
+++ b/tests/cmd/upgrade/to_lockfile.toml
@@ -8,12 +8,12 @@ two:
 four:
 """
 stderr = """
-    Upgrading libc v0.2.28 -> v0.2.62
-    Upgrading rand v0.3 -> v0.3.23
-    Upgrading libc v0.2.28 -> v0.2.62
-    Upgrading libc v0.2.28 -> v0.2.62
-    Upgrading rand v0.2 -> v0.2.1
-    Upgrading libc v0.2.28 -> v0.2.62
+   Upgrading libc v0.2.28 -> v0.2.62
+   Upgrading rand v0.3 -> v0.3.23
+   Upgrading libc v0.2.28 -> v0.2.62
+   Upgrading libc v0.2.28 -> v0.2.62
+   Upgrading rand v0.2 -> v0.2.1
+   Upgrading libc v0.2.28 -> v0.2.62
 """
 fs.sandbox = true
 

--- a/tests/cmd/upgrade/to_version.toml
+++ b/tests/cmd/upgrade/to_version.toml
@@ -5,7 +5,7 @@ stdout = """
 cargo-list-test-fixture:
 """
 stderr = """
-    Upgrading docopt v0.8.0 -> v1000000.0.0
+   Upgrading docopt v0.8.0 -> v1000000.0.0
 """
 fs.sandbox = true
 

--- a/tests/cmd/upgrade/upgrade_all.toml
+++ b/tests/cmd/upgrade/upgrade_all.toml
@@ -9,12 +9,12 @@ four:
 """
 stderr = """
 The flag `--all` has been deprecated in favor of `--workspace`
-    Upgrading libc v0.2.28 -> v99999.0.0
-    Upgrading rand v0.3 -> v99999.0.0
-    Upgrading libc v0.2.28 -> v99999.0.0
-    Upgrading libc v0.2.28 -> v99999.0.0
-    Upgrading rand v0.2 -> v99999.0.0
-    Upgrading libc v0.2.28 -> v99999.0.0
+   Upgrading libc v0.2.28 -> v99999.0.0
+   Upgrading rand v0.3 -> v99999.0.0
+   Upgrading libc v0.2.28 -> v99999.0.0
+   Upgrading libc v0.2.28 -> v99999.0.0
+   Upgrading rand v0.2 -> v99999.0.0
+   Upgrading libc v0.2.28 -> v99999.0.0
 """
 fs.sandbox = true
 

--- a/tests/cmd/upgrade/upgrade_everything.toml
+++ b/tests/cmd/upgrade/upgrade_everything.toml
@@ -5,21 +5,21 @@ stdout = """
 None:
 """
 stderr = """
-    Upgrading assert_cli v0.2.0 -> v99999.0.0
-    Upgrading docopt v0.8 -> v99999.0.0
-    Upgrading ftp v2.2.1 -> v99999.0.0
-    Upgrading ftp v2.2.1 -> v99999.0.0
-    Upgrading geo v0.7.0 -> v99999.0.0
-    Upgrading openssl v0.9 -> v99999.0.0
-    Upgrading pad v0.1 -> v99999.0.0
-    Upgrading renamed v0.1 -> v99999.0.0
-    Upgrading rget v0.3.0 -> v99999.0.0
-    Upgrading semver v0.7 -> v99999.0.0
-    Upgrading serde_json v1.0 -> v99999.0.0
-    Upgrading syn v0.11.10 -> v99999.0.0
-    Upgrading tar v0.4 -> v99999.0.0
-    Upgrading tempdir v0.3 -> v99999.0.0
-    Upgrading toml_edit v0.1.5 -> v99999.0.0
+   Upgrading assert_cli v0.2.0 -> v99999.0.0
+   Upgrading docopt v0.8 -> v99999.0.0
+   Upgrading ftp v2.2.1 -> v99999.0.0
+   Upgrading ftp v2.2.1 -> v99999.0.0
+   Upgrading geo v0.7.0 -> v99999.0.0
+   Upgrading openssl v0.9 -> v99999.0.0
+   Upgrading pad v0.1 -> v99999.0.0
+   Upgrading renamed v0.1 -> v99999.0.0
+   Upgrading rget v0.3.0 -> v99999.0.0
+   Upgrading semver v0.7 -> v99999.0.0
+   Upgrading serde_json v1.0 -> v99999.0.0
+   Upgrading syn v0.11.10 -> v99999.0.0
+   Upgrading tar v0.4 -> v99999.0.0
+   Upgrading tempdir v0.3 -> v99999.0.0
+   Upgrading toml_edit v0.1.5 -> v99999.0.0
 """
 fs.sandbox = true
 

--- a/tests/cmd/upgrade/upgrade_renamed.toml
+++ b/tests/cmd/upgrade/upgrade_renamed.toml
@@ -5,8 +5,8 @@ stdout = """
 cargo-list-test-fixture:
 """
 stderr = """
-    Upgrading regex v0.2 -> v99999.0.0
-    Upgrading toml_edit v0.1.5 -> v99999.0.0
+   Upgrading regex v0.2 -> v99999.0.0
+   Upgrading toml_edit v0.1.5 -> v99999.0.0
 """
 fs.sandbox = true
 

--- a/tests/cmd/upgrade/upgrade_workspace.toml
+++ b/tests/cmd/upgrade/upgrade_workspace.toml
@@ -8,12 +8,12 @@ two:
 four:
 """
 stderr = """
-    Upgrading libc v0.2.28 -> v99999.0.0
-    Upgrading rand v0.3 -> v99999.0.0
-    Upgrading libc v0.2.28 -> v99999.0.0
-    Upgrading libc v0.2.28 -> v99999.0.0
-    Upgrading rand v0.2 -> v99999.0.0
-    Upgrading libc v0.2.28 -> v99999.0.0
+   Upgrading libc v0.2.28 -> v99999.0.0
+   Upgrading rand v0.3 -> v99999.0.0
+   Upgrading libc v0.2.28 -> v99999.0.0
+   Upgrading libc v0.2.28 -> v99999.0.0
+   Upgrading rand v0.2 -> v99999.0.0
+   Upgrading libc v0.2.28 -> v99999.0.0
 """
 fs.sandbox = true
 

--- a/tests/cmd/upgrade/workspace_member_cwd.toml
+++ b/tests/cmd/upgrade/workspace_member_cwd.toml
@@ -5,7 +5,7 @@ stdout = """
 one:
 """
 stderr = """
-    Upgrading libc v0.2.28 -> v99999.0.0
+   Upgrading libc v0.2.28 -> v99999.0.0
 """
 fs.sandbox = true
 fs.cwd = "workspace_member_cwd.in/one"


### PR DESCRIPTION
Use utility functions to simplify styling and make the existing styling and indentation more consistent.

A few instances of manual styling remain:
- In the deprecation messages in `set_version.rs` and `upgrade.rs` (these could use an aesthetic pass too though, since they look out of place).
- In the feature activation list of `set_version`.
- In cargo add, per review discussion.

This also serves as a step towards #682, as these utilities functions are similar in form to Cargo's shell output.