### PR TITLE
fix(upgrade): Provide hint when nothing happens

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,5 +36,7 @@ pub use fetch::{get_latest_dependency, update_registry_index};
 pub use manifest::{find, get_dep_version, set_dep_version, LocalManifest, Manifest};
 pub use metadata::{manifest_from_pkgid, resolve_manifests, workspace_members};
 pub use registry::registry_url;
-pub use util::{colorize_stderr, shell_print, shell_status, shell_warn, Color, ColorChoice};
+pub use util::{
+    colorize_stderr, shell_note, shell_print, shell_status, shell_warn, Color, ColorChoice,
+};
 pub use version::{upgrade_requirement, VersionExt};

--- a/src/util.rs
+++ b/src/util.rs
@@ -43,3 +43,8 @@ pub fn shell_status(action: &str, message: &str) -> CargoResult<()> {
 pub fn shell_warn(message: &str) -> CargoResult<()> {
     shell_print("warning", message, Color::Yellow, false)
 }
+
+/// Print a styled warning message.
+pub fn shell_note(message: &str) -> CargoResult<()> {
+    shell_print("note", message, Color::Cyan, false)
+}

--- a/tests/cmd/upgrade/pinned.toml
+++ b/tests/cmd/upgrade/pinned.toml
@@ -13,6 +13,7 @@ warning: ignoring lessorequal, version (<=3.0) is pinned
 warning: ignoring greaterthan, version (>2.0) is compatible with 99999.0.0
 warning: ignoring greaterorequal, version (>=2.1.0) is compatible with 99999.0.0
    Upgrading wildcard: v3.* -> v99999.*
+note: Re-run with `--to-lockfile` to upgrade compatible version requirements
 """
 fs.sandbox = true
 

--- a/tests/cmd/upgrade/skip_compatible.toml
+++ b/tests/cmd/upgrade/skip_compatible.toml
@@ -6,6 +6,7 @@ stderr = """
     Checking cargo-list-test-fixture's dependencies
    Upgrading test_breaking: v0.1 -> v0.2
 warning: ignoring test_nonbreaking, version (0.1) is compatible with 0.1.1
+note: Re-run with `--to-lockfile` to upgrade compatible version requirements
 """
 fs.sandbox = true
 


### PR DESCRIPTION
I was surprised to see nothing happen and I realized users could use a
hint that `--to-lockfile` is a thing to upgrade all version reqs.