### PR TITLE
fix(upgrade): Report when pinned are present

### DIFF
--- a/src/bin/upgrade/upgrade.rs
+++ b/src/bin/upgrade/upgrade.rs
@@ -160,6 +160,7 @@ fn exec(args: UpgradeArgs) -> CargoResult<()> {
     let mut updated_registries = BTreeSet::new();
     let mut any_crate_modified = false;
     let mut compatible_present = false;
+    let mut pinned_present = false;
     for package in manifests {
         let mut manifest = LocalManifest::try_new(package.manifest_path.as_std_path())?;
         let mut crate_modified = false;
@@ -214,6 +215,7 @@ fn exec(args: UpgradeArgs) -> CargoResult<()> {
                                 dependency.toml_key(),
                             ))
                         })?;
+                        pinned_present = true;
                         continue;
                     }
 
@@ -228,6 +230,7 @@ fn exec(args: UpgradeArgs) -> CargoResult<()> {
                                     old_version_req
                                 ))
                             })?;
+                            pinned_present = true;
                             continue;
                         }
                     }
@@ -373,6 +376,9 @@ fn exec(args: UpgradeArgs) -> CargoResult<()> {
         _ => anyhow::bail!("dependencies {} don't exist", unused.join(", ")),
     }
 
+    if pinned_present {
+        shell_note("Re-run with `--pinned` to upgrade pinned version requirements")?;
+    }
     if compatible_present {
         shell_note("Re-run with `--to-lockfile` to upgrade compatible version requirements")?;
     }

--- a/tests/cmd/upgrade/exclude_renamed.toml
+++ b/tests/cmd/upgrade/exclude_renamed.toml
@@ -6,6 +6,7 @@ stderr = """
     Checking cargo-list-test-fixture's dependencies
 warning: ignoring te, renamed dependencies are pinned
 warning: ignoring rx, excluded by user
+note: Re-run with `--pinned` to upgrade pinned version requirements
 """
 fs.sandbox = true
 

--- a/tests/cmd/upgrade/pinned.toml
+++ b/tests/cmd/upgrade/pinned.toml
@@ -13,6 +13,7 @@ warning: ignoring lessorequal, version (<=3.0) is pinned
 warning: ignoring greaterthan, version (>2.0) is compatible with 99999.0.0
 warning: ignoring greaterorequal, version (>=2.1.0) is compatible with 99999.0.0
    Upgrading wildcard: v3.* -> v99999.*
+note: Re-run with `--pinned` to upgrade pinned version requirements
 note: Re-run with `--to-lockfile` to upgrade compatible version requirements
 """
 fs.sandbox = true


### PR DESCRIPTION
Like with compatible requirements, this provides a way to let people
know that some version reqs were unchanged in a succinct way.