### PR TITLE
Clean up rm arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,17 +94,17 @@ ARGS:
     <DEP_ID>...    Dependencies to be removed
 
 OPTIONS:
-        --dry-run                 Don't actually write the manifest
-    -h, --help                    Print help information
         --manifest-path <PATH>    Path to the manifest to remove a dependency from
     -p, --package <PKGID>         Package id of the crate to remove this dependency from
-    -q, --quiet                   Do not print any output in case of success
-    -V, --version                 Print version information
     -Z <FLAG>                     Unstable (nightly-only) flags
+        --dry-run                 Don't actually write the manifest
+    -q, --quiet                   Do not print any output in case of success
+    -h, --help                    Print help information
+    -V, --version                 Print version information
 
 SECTION:
-    -B, --build              Remove crate as build dependency
     -D, --dev                Remove crate as development dependency
+    -B, --build              Remove crate as build dependency
         --target <TARGET>    Remove as dependency from the given target platform
 
 ```

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ ARGS:
 
 OPTIONS:
         --manifest-path <PATH>    Path to the manifest to remove a dependency from
-    -p, --package <PKGID>         Package id of the crate to remove this dependency from
+    -p, --package <PKGID>         Package to remove from
     -Z <FLAG>                     Unstable (nightly-only) flags
         --dry-run                 Don't actually write the manifest
     -q, --quiet                   Do not print any output in case of success
@@ -103,8 +103,8 @@ OPTIONS:
     -V, --version                 Print version information
 
 SECTION:
-    -D, --dev                Remove crate as development dependency
-    -B, --build              Remove crate as build dependency
+    -D, --dev                Remove as development dependency
+    -B, --build              Remove as build dependency
         --target <TARGET>    Remove as dependency from the given target platform
 
 ```

--- a/src/bin/rm/rm.rs
+++ b/src/bin/rm/rm.rs
@@ -11,27 +11,27 @@ use std::path::PathBuf;
 #[clap(version)]
 #[clap(setting = clap::AppSettings::DeriveDisplayOrder)]
 pub struct RmArgs {
-    /// Dependencies to be removed.
+    /// Dependencies to be removed
     #[clap(value_name = "DEP_ID", required = true)]
     crates: Vec<String>,
 
-    /// Remove crate as development dependency.
+    /// Remove as development dependency
     #[clap(long, short = 'D', conflicts_with = "build", help_heading = "SECTION")]
     dev: bool,
 
-    /// Remove crate as build dependency.
+    /// Remove as build dependency
     #[clap(long, short = 'B', conflicts_with = "dev", help_heading = "SECTION")]
     build: bool,
 
-    /// Remove as dependency from the given target platform.
+    /// Remove as dependency from the given target platform
     #[clap(long, forbid_empty_values = true, help_heading = "SECTION")]
     target: Option<String>,
 
-    /// Path to the manifest to remove a dependency from.
+    /// Path to the manifest to remove a dependency from
     #[clap(long, value_name = "PATH", parse(from_os_str))]
     manifest_path: Option<PathBuf>,
 
-    /// Package id of the crate to remove this dependency from.
+    /// Package to remove from
     #[clap(long = "package", short = 'p', value_name = "PKGID")]
     pkgid: Option<String>,
 
@@ -43,7 +43,7 @@ pub struct RmArgs {
     #[clap(long)]
     dry_run: bool,
 
-    /// Do not print any output in case of success.
+    /// Do not print any output in case of success
     #[clap(long, short)]
     quiet: bool,
 }

--- a/src/bin/rm/rm.rs
+++ b/src/bin/rm/rm.rs
@@ -9,6 +9,7 @@ use std::path::PathBuf;
 /// Remove a dependency from a Cargo.toml manifest file.
 #[derive(Debug, Args)]
 #[clap(version)]
+#[clap(setting = clap::AppSettings::DeriveDisplayOrder)]
 pub struct RmArgs {
     /// Dependencies to be removed.
     #[clap(value_name = "DEP_ID", required = true)]


### PR DESCRIPTION
- Use derive display ordering.
- Tweak help messages to be in line with Cargo.
  - Remove periods from doc strings (not sure I love this, but it does make it in line with cargo add).
  - Use consistent grammatical case.

Furthers #682.