### PR TITLE
feat(upgrade): Provide table view for upgrades 

### DIFF
--- a/src/bin/upgrade/upgrade.rs
+++ b/src/bin/upgrade/upgrade.rs
@@ -475,6 +475,17 @@ impl Dep {
             spec.set_fg(Some(Color::Yellow));
         } else if self.new_version_req != self.old_version_req {
             spec.set_fg(Some(Color::Green));
+            if let Some(latest_version) = self
+                .latest_version
+                .as_ref()
+                .and_then(|v| semver::Version::parse(v).ok())
+            {
+                if let Ok(new_version_req) = semver::VersionReq::parse(&self.new_version_req) {
+                    if !new_version_req.matches(&latest_version) {
+                        spec.set_fg(Some(Color::Yellow));
+                    }
+                }
+            }
         }
         spec
     }

--- a/src/bin/upgrade/upgrade.rs
+++ b/src/bin/upgrade/upgrade.rs
@@ -141,11 +141,7 @@ fn exec(args: UpgradeArgs) -> CargoResult<()> {
     }
 
     let manifests = args.resolve_targets()?;
-    let locked = args
-        .to_lockfile
-        .then(|| load_lockfile(&manifests, args.offline))
-        .transpose()?
-        .unwrap_or_default();
+    let locked = load_lockfile(&manifests, args.offline).unwrap_or_default();
 
     let selected_dependencies = args
         .dependency

--- a/src/bin/upgrade/upgrade.rs
+++ b/src/bin/upgrade/upgrade.rs
@@ -569,7 +569,7 @@ fn print_upgrade(mut deps: Vec<Dep>) -> CargoResult<()> {
         } else {
             ColorSpec::new()
         };
-        write_cell(&dep.latest_version(), width[3], &spec)?;
+        write_cell(dep.latest_version(), width[3], &spec)?;
         shell_write_stderr(" ", &ColorSpec::new())?;
 
         let spec = if is_header {
@@ -585,7 +585,7 @@ fn print_upgrade(mut deps: Vec<Dep>) -> CargoResult<()> {
         } else {
             dep.reason_spec()
         };
-        write_cell(&dep.reason(), width[5], &spec)?;
+        write_cell(dep.reason(), width[5], &spec)?;
         shell_write_stderr("\n", &ColorSpec::new())?;
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,6 +37,7 @@ pub use manifest::{find, get_dep_version, set_dep_version, LocalManifest, Manife
 pub use metadata::{manifest_from_pkgid, resolve_manifests, workspace_members};
 pub use registry::registry_url;
 pub use util::{
-    colorize_stderr, shell_note, shell_print, shell_status, shell_warn, Color, ColorChoice,
+    colorize_stderr, shell_note, shell_print, shell_status, shell_warn, shell_write_stderr, Color,
+    ColorChoice,
 };
 pub use version::{upgrade_requirement, VersionExt};

--- a/src/util.rs
+++ b/src/util.rs
@@ -48,3 +48,14 @@ pub fn shell_warn(message: &str) -> CargoResult<()> {
 pub fn shell_note(message: &str) -> CargoResult<()> {
     shell_print("note", message, Color::Cyan, false)
 }
+
+/// Print a part of a line with formatting
+pub fn shell_write_stderr(fragment: impl std::fmt::Display, spec: &ColorSpec) -> CargoResult<()> {
+    let color_choice = colorize_stderr();
+    let mut output = StandardStream::stderr(color_choice);
+
+    output.set_color(spec)?;
+    write!(output, "{}", fragment)?;
+    output.reset()?;
+    Ok(())
+}

--- a/tests/cargo-upgrade/alt_registry/stderr.log
+++ b/tests/cargo-upgrade/alt_registry/stderr.log
@@ -1,5 +1,7 @@
     Updating '[ROOTURL]/registry' index
     Checking none's dependencies
     Updating '[ROOTURL]/alternative-registry' index
-   Upgrading my-package1: v0.1.1 -> v99999.0.0
-   Upgrading my-package2: v0.2 -> v99999.0
+name        old req locked latest    new req   note
+====        ======= ====== ======    =======   ====
+my-package1 0.1.1   -      99999.0.0 99999.0.0     
+my-package2 0.2     -      99999.0.0 99999.0       

--- a/tests/cargo-upgrade/dry_run/stderr.log
+++ b/tests/cargo-upgrade/dry_run/stderr.log
@@ -1,4 +1,6 @@
     Updating '[ROOTURL]/registry' index
     Checking cargo-list-test-fixture's dependencies
-   Upgrading my-package: v0.1.1 -> v99999.0.0
+name       old req locked latest    new req   note
+====       ======= ====== ======    =======   ====
+my-package 0.1.1   -      99999.0.0 99999.0.0     
 warning: aborting upgrade due to dry run

--- a/tests/cargo-upgrade/exclude_dep/stderr.log
+++ b/tests/cargo-upgrade/exclude_dep/stderr.log
@@ -1,18 +1,20 @@
     Updating '[ROOTURL]/registry' index
     Checking None's dependencies
 warning: ignoring docopt, excluded by user
-   Upgrading pad: v0.1 -> v99999.0
-   Upgrading serde_json: v1.0 -> v99999.0
-   Upgrading syn: v0.11.10 -> v99999.0.0
-   Upgrading tar: v0.4 -> v99999.0
-   Upgrading ftp: v2.2.1 -> v99999.0.0
-   Upgrading te: v0.1.5 -> v99999.0.0
-   Upgrading semver: v0.7 -> v99999.0
-   Upgrading rn: v0.1 -> v99999.0
-   Upgrading assert_cli: v0.2.0 -> v99999.0.0
-   Upgrading tempdir: v0.3 -> v99999.0
-warning: ignoring serde, source is https://github.com/serde-rs/serde.git
-   Upgrading openssl: v0.9 -> v99999.0
-   Upgrading rget: v0.3.0 -> v99999.0.0
-   Upgrading geo: v0.7.0 -> v99999.0.0
-   Upgrading ftp: v2.2.1 -> v99999.0.0
+name       old req locked latest    new req   note
+====       ======= ====== ======    =======   ====
+pad        0.1     -      99999.0.0 99999.0       
+serde_json 1.0     -      99999.0.0 99999.0       
+syn        0.11.10 -      99999.0.0 99999.0.0     
+tar        0.4     -      99999.0.0 99999.0       
+ftp        2.2.1   -      99999.0.0 99999.0.0     
+te         0.1.5   -      99999.0.0 99999.0.0     
+semver     0.7     -      99999.0.0 99999.0       
+rn         0.1     -      99999.0.0 99999.0       
+assert_cli 0.2.0   -      99999.0.0 99999.0.0     
+tempdir    0.3     -      99999.0.0 99999.0       
+serde      1.0     -      -         1.0           
+openssl    0.9     -      99999.0.0 99999.0       
+rget       0.3.0   -      99999.0.0 99999.0.0     
+geo        0.7.0   -      99999.0.0 99999.0.0     
+ftp        2.2.1   -      99999.0.0 99999.0.0     

--- a/tests/cargo-upgrade/exclude_renamed/stderr.log
+++ b/tests/cargo-upgrade/exclude_renamed/stderr.log
@@ -1,5 +1,7 @@
     Updating '[ROOTURL]/registry' index
     Checking cargo-list-test-fixture's dependencies
-warning: ignoring te, renamed dependencies are pinned
 warning: ignoring rx, excluded by user
+name old req locked latest    new req note  
+==== ======= ====== ======    ======= ====  
+te   0.1.5   -      99999.0.0 0.1.5   pinned
 note: Re-run with `--pinned` to upgrade pinned version requirements

--- a/tests/cargo-upgrade/implicit_prerelease/stderr.log
+++ b/tests/cargo-upgrade/implicit_prerelease/stderr.log
@@ -1,4 +1,6 @@
     Updating '[ROOTURL]/registry' index
     Checking cargo-list-test-fixture's dependencies
-   Upgrading unrelated-crate: v1.0 -> v99999.0
-   Upgrading my-package: v0.1.1-alpha.1 -> v99999.1.0-alpha.1
+name            old req       locked latest            new req           note
+====            =======       ====== ======            =======           ====
+unrelated-crate 1.0           -      99999.0.0         99999.0               
+my-package      0.1.1-alpha.1 -      99999.1.0-alpha.1 99999.1.0-alpha.1     

--- a/tests/cargo-upgrade/locked/stderr.log
+++ b/tests/cargo-upgrade/locked/stderr.log
@@ -1,4 +1,6 @@
     Updating '[ROOTURL]/registry' index
     Checking cargo-list-test-fixture's dependencies
-   Upgrading my-package: v0.1.1 -> v99999.0.0
+name       old req locked latest    new req   note
+====       ======= ====== ======    =======   ====
+my-package 0.1.1   -      99999.0.0 99999.0.0     
 Error: cannot upgrade due to `--locked`

--- a/tests/cargo-upgrade/main.rs
+++ b/tests/cargo-upgrade/main.rs
@@ -124,6 +124,9 @@ fn add_registry_packages(alt: bool) {
     cargo_test_support::registry::Package::new("test_nonbreaking", "0.1.1")
         .alternative(alt)
         .publish();
+    cargo_test_support::registry::Package::new("test_nonbreaking", "0.1.2")
+        .alternative(alt)
+        .publish();
 
     // Normalization
     cargo_test_support::registry::Package::new("linked-hash-map", "0.5.4")

--- a/tests/cargo-upgrade/optional_dep/stderr.log
+++ b/tests/cargo-upgrade/optional_dep/stderr.log
@@ -1,3 +1,5 @@
     Updating '[ROOTURL]/registry' index
     Checking cargo-list-test-fixture's dependencies
-   Upgrading my-package: v0.1.1 -> v99999.0.0
+name       old req locked latest    new req   note
+====       ======= ====== ======    =======   ====
+my-package 0.1.1   -      99999.0.0 99999.0.0     

--- a/tests/cargo-upgrade/pinned/stderr.log
+++ b/tests/cargo-upgrade/pinned/stderr.log
@@ -1,13 +1,15 @@
     Updating '[ROOTURL]/registry' index
     Checking cargo-list-test-fixture's dependencies
-   Upgrading default: v1.0 -> v99999.0
-warning: ignoring exact, version (=2.0) is pinned
-warning: ignoring lessthan, version (<0.4) is pinned
-warning: ignoring lessorequal, version (<=3.0) is pinned
-   Upgrading caret: ^3.0 -> ^99999.0
-   Upgrading tilde: ~4.1.0 -> ~99999.0.0
-warning: ignoring greaterthan, version (>2.0) is compatible with 99999.0.0
-warning: ignoring greaterorequal, version (>=2.1.0) is compatible with 99999.0.0
-   Upgrading wildcard: v3.* -> v99999.*
+name           old req locked latest    new req    note      
+====           ======= ====== ======    =======    ====      
+default        1.0     -      99999.0.0 99999.0              
+exact          =2.0    -      99999.0.0 =2.0       pinned    
+lessthan       <0.4    -      99999.0.0 <0.4       pinned    
+lessorequal    <=3.0   -      99999.0.0 <=3.0      pinned    
+caret          ^3.0    -      99999.0.0 ^99999.0             
+tilde          ~4.1.0  -      99999.0.0 ~99999.0.0           
+greaterthan    >2.0    -      99999.0.0 >2.0       compatible
+greaterorequal >=2.1.0 -      99999.0.0 >=2.1.0    compatible
+wildcard       3.*     -      99999.0.0 99999.*              
 note: Re-run with `--pinned` to upgrade pinned version requirements
 note: Re-run with `--to-lockfile` to upgrade compatible version requirements

--- a/tests/cargo-upgrade/preserve_precision_major/stderr.log
+++ b/tests/cargo-upgrade/preserve_precision_major/stderr.log
@@ -1,3 +1,5 @@
     Updating '[ROOTURL]/registry' index
     Checking cargo-list-test-fixture's dependencies
-   Upgrading my-package: v0 -> v99999
+name       old req locked latest    new req note
+====       ======= ====== ======    ======= ====
+my-package 0       -      99999.0.0 99999       

--- a/tests/cargo-upgrade/preserve_precision_minor/stderr.log
+++ b/tests/cargo-upgrade/preserve_precision_minor/stderr.log
@@ -1,3 +1,5 @@
     Updating '[ROOTURL]/registry' index
     Checking cargo-list-test-fixture's dependencies
-   Upgrading my-package: v0.1 -> v99999.0
+name       old req locked latest    new req note
+====       ======= ====== ======    ======= ====
+my-package 0.1     -      99999.0.0 99999.0     

--- a/tests/cargo-upgrade/preserve_precision_patch/stderr.log
+++ b/tests/cargo-upgrade/preserve_precision_patch/stderr.log
@@ -1,3 +1,5 @@
     Updating '[ROOTURL]/registry' index
     Checking cargo-list-test-fixture's dependencies
-   Upgrading my-package: v0.1.1 -> v99999.0.0
+name       old req locked latest    new req   note
+====       ======= ====== ======    =======   ====
+my-package 0.1.1   -      99999.0.0 99999.0.0     

--- a/tests/cargo-upgrade/preserves_inline_table/stderr.log
+++ b/tests/cargo-upgrade/preserves_inline_table/stderr.log
@@ -1,3 +1,5 @@
     Updating '[ROOTURL]/registry' index
     Checking cargo-list-test-fixture's dependencies
-   Upgrading my-package: v0.1.1 -> v99999.0.0
+name       old req locked latest    new req   note
+====       ======= ====== ======    =======   ====
+my-package 0.1.1   -      99999.0.0 99999.0.0     

--- a/tests/cargo-upgrade/preserves_std_table/stderr.log
+++ b/tests/cargo-upgrade/preserves_std_table/stderr.log
@@ -1,3 +1,5 @@
     Updating '[ROOTURL]/registry' index
     Checking cargo-list-test-fixture's dependencies
-   Upgrading my-package: v0.1.1 -> v99999.0.0
+name       old req locked latest    new req   note
+====       ======= ====== ======    =======   ====
+my-package 0.1.1   -      99999.0.0 99999.0.0     

--- a/tests/cargo-upgrade/single_dep/stderr.log
+++ b/tests/cargo-upgrade/single_dep/stderr.log
@@ -1,3 +1,5 @@
     Updating '[ROOTURL]/registry' index
     Checking cargo-list-test-fixture's dependencies
-   Upgrading my-package: v0.1.1 -> v99999.0.0
+name       old req locked latest    new req   note
+====       ======= ====== ======    =======   ====
+my-package 0.1.1   -      99999.0.0 99999.0.0     

--- a/tests/cargo-upgrade/skip_compatible/in/Cargo.toml
+++ b/tests/cargo-upgrade/skip_compatible/in/Cargo.toml
@@ -4,4 +4,4 @@ version = "0.0.0"
 
 [dependencies]
 test_breaking = "0.1"
-test_nonbreaking = "0.1"
+test_nonbreaking = "0.1.0"

--- a/tests/cargo-upgrade/skip_compatible/out/Cargo.toml
+++ b/tests/cargo-upgrade/skip_compatible/out/Cargo.toml
@@ -4,4 +4,4 @@ version = "0.0.0"
 
 [dependencies]
 test_breaking = "0.2"
-test_nonbreaking = "0.1"
+test_nonbreaking = "0.1.0"

--- a/tests/cargo-upgrade/skip_compatible/stderr.log
+++ b/tests/cargo-upgrade/skip_compatible/stderr.log
@@ -1,5 +1,7 @@
     Updating '[ROOTURL]/registry' index
     Checking cargo-list-test-fixture's dependencies
-   Upgrading test_breaking: v0.1 -> v0.2
-warning: ignoring test_nonbreaking, version (0.1) is compatible with 0.1.1
+name             old req locked latest new req note      
+====             ======= ====== ====== ======= ====      
+test_breaking    0.1     -      0.2.0  0.2               
+test_nonbreaking 0.1     -      0.1.1  0.1     compatible
 note: Re-run with `--to-lockfile` to upgrade compatible version requirements

--- a/tests/cargo-upgrade/skip_compatible/stderr.log
+++ b/tests/cargo-upgrade/skip_compatible/stderr.log
@@ -3,5 +3,5 @@
 name             old req locked latest new req note      
 ====             ======= ====== ====== ======= ====      
 test_breaking    0.1     -      0.2.0  0.2               
-test_nonbreaking 0.1     -      0.1.1  0.1     compatible
+test_nonbreaking 0.1.0   -      0.1.2  0.1.0   compatible
 note: Re-run with `--to-lockfile` to upgrade compatible version requirements

--- a/tests/cargo-upgrade/specified/stderr.log
+++ b/tests/cargo-upgrade/specified/stderr.log
@@ -1,3 +1,5 @@
     Updating '[ROOTURL]/registry' index
     Checking cargo-list-test-fixture's dependencies
-   Upgrading my-package1: v0.1 -> v99999.0
+name        old req locked latest    new req note
+====        ======= ====== ======    ======= ====
+my-package1 0.1     -      99999.0.0 99999.0     

--- a/tests/cargo-upgrade/to_lockfile/stderr.log
+++ b/tests/cargo-upgrade/to_lockfile/stderr.log
@@ -1,9 +1,17 @@
     Checking one's dependencies
-   Upgrading my-package: v0.2.0 -> v0.2.3
-   Upgrading three: v0.1.0 -> v0.1.5
+name       old req locked           latest    new req note
+====       ======= ======           ======    ======= ====
+my-package 0.2.0   0.2.3+my-package 99999.0.0 0.2.3       
+three      0.1.0   0.1.5            -         0.1.5       
     Checking three's dependencies
-   Upgrading my-package: v0.2.0 -> v0.2.3
+name       old req locked           latest    new req note
+====       ======= ======           ======    ======= ====
+my-package 0.2.0   0.2.3+my-package 99999.0.0 0.2.3       
     Checking two's dependencies
-   Upgrading my-package: v0.2.0 -> v0.2.3
+name       old req locked           latest    new req note
+====       ======= ======           ======    ======= ====
+my-package 0.2.0   0.2.3+my-package 99999.0.0 0.2.3       
     Checking four's dependencies
-   Upgrading my-package: v0.2.0 -> v0.2.3
+name       old req locked           latest    new req note
+====       ======= ======           ======    ======= ====
+my-package 0.2.0   0.2.3+my-package 99999.0.0 0.2.3       

--- a/tests/cargo-upgrade/to_version/stderr.log
+++ b/tests/cargo-upgrade/to_version/stderr.log
@@ -1,3 +1,5 @@
     Updating '[ROOTURL]/registry' index
     Checking cargo-list-test-fixture's dependencies
-   Upgrading docopt: v0.8.0 -> v1000000.0.0
+name   old req locked latest    new req     note
+====   ======= ====== ======    =======     ====
+docopt 0.8.0   -      99999.0.0 1000000.0.0     

--- a/tests/cargo-upgrade/upgrade_all/stderr.log
+++ b/tests/cargo-upgrade/upgrade_all/stderr.log
@@ -1,10 +1,19 @@
 The flag `--all` has been deprecated in favor of `--workspace`
     Updating '[ROOTURL]/registry' index
     Checking one's dependencies
-   Upgrading my-package: v0.2.0 -> v99999.0.0
+name       old req locked latest    new req   note
+====       ======= ====== ======    =======   ====
+my-package 0.2.0   -      99999.0.0 99999.0.0     
+three      0.1.0   -      -         0.1.0         
     Checking three's dependencies
-   Upgrading my-package: v0.2.0 -> v99999.0.0
+name       old req locked latest    new req   note
+====       ======= ====== ======    =======   ====
+my-package 0.2.0   -      99999.0.0 99999.0.0     
     Checking two's dependencies
-   Upgrading my-package: v0.2.0 -> v99999.0.0
+name       old req locked latest    new req   note
+====       ======= ====== ======    =======   ====
+my-package 0.2.0   -      99999.0.0 99999.0.0     
     Checking four's dependencies
-   Upgrading my-package: v0.2.0 -> v99999.0.0
+name       old req locked latest    new req   note
+====       ======= ====== ======    =======   ====
+my-package 0.2.0   -      99999.0.0 99999.0.0     

--- a/tests/cargo-upgrade/upgrade_everything/stderr.log
+++ b/tests/cargo-upgrade/upgrade_everything/stderr.log
@@ -1,17 +1,20 @@
     Updating '[ROOTURL]/registry' index
     Checking None's dependencies
-   Upgrading docopt: v0.8 -> v99999.0
-   Upgrading pad: v0.1 -> v99999.0
-   Upgrading serde_json: v1.0 -> v99999.0
-   Upgrading syn: v0.11.10 -> v99999.0.0
-   Upgrading tar: v0.4 -> v99999.0
-   Upgrading ftp: v2.2.1 -> v99999.0.0
-   Upgrading te: v0.1.5 -> v99999.0.0
-   Upgrading semver: v0.7 -> v99999.0
-   Upgrading rn: v0.1 -> v99999.0
-   Upgrading assert_cli: v0.2.0 -> v99999.0.0
-   Upgrading tempdir: v0.3 -> v99999.0
-   Upgrading openssl: v0.9 -> v99999.0
-   Upgrading rget: v0.3.0 -> v99999.0.0
-   Upgrading geo: v0.7.0 -> v99999.0.0
-   Upgrading ftp: v2.2.1 -> v99999.0.0
+name       old req locked latest    new req   note
+====       ======= ====== ======    =======   ====
+docopt     0.8     -      99999.0.0 99999.0       
+pad        0.1     -      99999.0.0 99999.0       
+serde_json 1.0     -      99999.0.0 99999.0       
+syn        0.11.10 -      99999.0.0 99999.0.0     
+tar        0.4     -      99999.0.0 99999.0       
+ftp        2.2.1   -      99999.0.0 99999.0.0     
+te         0.1.5   -      99999.0.0 99999.0.0     
+semver     0.7     -      99999.0.0 99999.0       
+rn         0.1     -      99999.0.0 99999.0       
+assert_cli 0.2.0   -      99999.0.0 99999.0.0     
+tempdir    0.3     -      99999.0.0 99999.0       
+serde      1.0     -      -         1.0           
+openssl    0.9     -      99999.0.0 99999.0       
+rget       0.3.0   -      99999.0.0 99999.0.0     
+geo        0.7.0   -      99999.0.0 99999.0.0     
+ftp        2.2.1   -      99999.0.0 99999.0.0     

--- a/tests/cargo-upgrade/upgrade_renamed/stderr.log
+++ b/tests/cargo-upgrade/upgrade_renamed/stderr.log
@@ -1,4 +1,6 @@
     Updating '[ROOTURL]/registry' index
     Checking cargo-list-test-fixture's dependencies
-   Upgrading m1: v0.1.1 -> v99999.0.0
-   Upgrading m2: v0.2 -> v99999.0
+name old req locked latest    new req   note
+==== ======= ====== ======    =======   ====
+m1   0.1.1   -      99999.0.0 99999.0.0     
+m2   0.2     -      99999.0.0 99999.0       

--- a/tests/cargo-upgrade/upgrade_workspace/stderr.log
+++ b/tests/cargo-upgrade/upgrade_workspace/stderr.log
@@ -1,9 +1,18 @@
     Updating '[ROOTURL]/registry' index
     Checking one's dependencies
-   Upgrading my-package: v0.2.0 -> v99999.0.0
+name       old req locked latest    new req   note
+====       ======= ====== ======    =======   ====
+my-package 0.2.0   -      99999.0.0 99999.0.0     
+three      0.1.0   -      -         0.1.0         
     Checking three's dependencies
-   Upgrading my-package: v0.2.0 -> v99999.0.0
+name       old req locked latest    new req   note
+====       ======= ====== ======    =======   ====
+my-package 0.2.0   -      99999.0.0 99999.0.0     
     Checking two's dependencies
-   Upgrading my-package: v0.2.0 -> v99999.0.0
+name       old req locked latest    new req   note
+====       ======= ====== ======    =======   ====
+my-package 0.2.0   -      99999.0.0 99999.0.0     
     Checking four's dependencies
-   Upgrading my-package: v0.2.0 -> v99999.0.0
+name       old req locked latest    new req   note
+====       ======= ====== ======    =======   ====
+my-package 0.2.0   -      99999.0.0 99999.0.0     

--- a/tests/cargo-upgrade/virtual_manifest/stderr.log
+++ b/tests/cargo-upgrade/virtual_manifest/stderr.log
@@ -1,9 +1,18 @@
     Updating '[ROOTURL]/registry' index
     Checking one's dependencies
-   Upgrading my-package: v0.2.0 -> v99999.0.0
+name       old req locked latest    new req   note
+====       ======= ====== ======    =======   ====
+my-package 0.2.0   -      99999.0.0 99999.0.0     
+three      0.1.0   -      -         0.1.0         
     Checking three's dependencies
-   Upgrading my-package: v0.2.0 -> v99999.0.0
+name       old req locked latest    new req   note
+====       ======= ====== ======    =======   ====
+my-package 0.2.0   -      99999.0.0 99999.0.0     
     Checking two's dependencies
-   Upgrading my-package: v0.2.0 -> v99999.0.0
+name       old req locked latest    new req   note
+====       ======= ====== ======    =======   ====
+my-package 0.2.0   -      99999.0.0 99999.0.0     
     Checking four's dependencies
-   Upgrading my-package: v0.2.0 -> v99999.0.0
+name       old req locked latest    new req   note
+====       ======= ====== ======    =======   ====
+my-package 0.2.0   -      99999.0.0 99999.0.0     

--- a/tests/cargo-upgrade/workspace_member_cwd/stderr.log
+++ b/tests/cargo-upgrade/workspace_member_cwd/stderr.log
@@ -1,3 +1,5 @@
     Updating '[ROOTURL]/registry' index
     Checking one's dependencies
-   Upgrading my-package: v0.1.1 -> v99999.0.0
+name       old req locked latest    new req   note
+====       ======= ====== ======    =======   ====
+my-package 0.1.1   -      99999.0.0 99999.0.0     

--- a/tests/cargo-upgrade/workspace_member_manifest_path/stderr.log
+++ b/tests/cargo-upgrade/workspace_member_manifest_path/stderr.log
@@ -1,3 +1,5 @@
     Updating '[ROOTURL]/registry' index
     Checking one's dependencies
-   Upgrading my-package: v0.2.0 -> v99999.0.0
+name       old req locked latest    new req   note
+====       ======= ====== ======    =======   ====
+my-package 0.2.0   -      99999.0.0 99999.0.0     

--- a/tests/cmd/upgrade/alt_registry.toml
+++ b/tests/cmd/upgrade/alt_registry.toml
@@ -4,8 +4,10 @@ status = "success"
 stdout = ""
 stderr = """
     Checking none's dependencies
-   Upgrading toml_edit: v0.1.5 -> v99999.0.0
-   Upgrading regex: v0.2 -> v99999.0
+name      old req locked latest    new req   note
+====      ======= ====== ======    =======   ====
+toml_edit 0.1.5   -      99999.0.0 99999.0.0     
+regex     0.2     -      99999.0.0 99999.0       
 """
 fs.sandbox = true
 

--- a/tests/cmd/upgrade/dry_run.toml
+++ b/tests/cmd/upgrade/dry_run.toml
@@ -4,7 +4,9 @@ status = "success"
 stdout = ""
 stderr = """
     Checking cargo-list-test-fixture's dependencies
-   Upgrading docopt: v0.8.0 -> v99999.0.0
+name   old req locked latest    new req   note
+====   ======= ====== ======    =======   ====
+docopt 0.8.0   -      99999.0.0 99999.0.0     
 warning: aborting upgrade due to dry run
 """
 fs.sandbox = true

--- a/tests/cmd/upgrade/exclude_dep.toml
+++ b/tests/cmd/upgrade/exclude_dep.toml
@@ -5,21 +5,23 @@ stdout = ""
 stderr = """
     Checking None's dependencies
 warning: ignoring docopt, excluded by user
-   Upgrading pad: v0.1 -> v99999.0
-   Upgrading serde_json: v1.0 -> v99999.0
-   Upgrading syn: v0.11.10 -> v99999.0.0
-   Upgrading tar: v0.4 -> v99999.0
-   Upgrading ftp: v2.2.1 -> v99999.0.0
-   Upgrading te: v0.1.5 -> v99999.0.0
-   Upgrading semver: v0.7 -> v99999.0
-   Upgrading rn: v0.1 -> v99999.0
-   Upgrading assert_cli: v0.2.0 -> v99999.0.0
-   Upgrading tempdir: v0.3 -> v99999.0
-warning: ignoring serde, source is https://github.com/serde-rs/serde.git
-   Upgrading openssl: v0.9 -> v99999.0
-   Upgrading rget: v0.3.0 -> v99999.0.0
-   Upgrading geo: v0.7.0 -> v99999.0.0
-   Upgrading ftp: v2.2.1 -> v99999.0.0
+name       old req locked latest    new req   note
+====       ======= ====== ======    =======   ====
+pad        0.1     -      99999.0.0 99999.0       
+serde_json 1.0     -      99999.0.0 99999.0       
+syn        0.11.10 -      99999.0.0 99999.0.0     
+tar        0.4     -      99999.0.0 99999.0       
+ftp        2.2.1   -      99999.0.0 99999.0.0     
+te         0.1.5   -      99999.0.0 99999.0.0     
+semver     0.7     -      99999.0.0 99999.0       
+rn         0.1     -      99999.0.0 99999.0       
+assert_cli 0.2.0   -      99999.0.0 99999.0.0     
+tempdir    0.3     -      99999.0.0 99999.0       
+serde      1.0     -      -         1.0           
+openssl    0.9     -      99999.0.0 99999.0       
+rget       0.3.0   -      99999.0.0 99999.0.0     
+geo        0.7.0   -      99999.0.0 99999.0.0     
+ftp        2.2.1   -      99999.0.0 99999.0.0     
 """
 fs.sandbox = true
 

--- a/tests/cmd/upgrade/exclude_renamed.toml
+++ b/tests/cmd/upgrade/exclude_renamed.toml
@@ -4,8 +4,10 @@ status = "success"
 stdout = ""
 stderr = """
     Checking cargo-list-test-fixture's dependencies
-warning: ignoring te, renamed dependencies are pinned
 warning: ignoring rx, excluded by user
+name old req locked latest    new req note  
+==== ======= ====== ======    ======= ====  
+te   0.1.5   -      99999.0.0 0.1.5   pinned
 note: Re-run with `--pinned` to upgrade pinned version requirements
 """
 fs.sandbox = true

--- a/tests/cmd/upgrade/implicit_prerelease.toml
+++ b/tests/cmd/upgrade/implicit_prerelease.toml
@@ -4,8 +4,10 @@ status = "success"
 stdout = ""
 stderr = """
     Checking cargo-list-test-fixture's dependencies
-   Upgrading a: v1.0 -> v99999.0
-   Upgrading b: v0.8.0-alpha -> v99999.0.0-alpha.1
+name old req     locked latest            new req           note
+==== =======     ====== ======            =======           ====
+a    1.0         -      99999.0.0         99999.0               
+b    0.8.0-alpha -      99999.0.0-alpha.1 99999.0.0-alpha.1     
 """
 fs.sandbox = true
 

--- a/tests/cmd/upgrade/locked.toml
+++ b/tests/cmd/upgrade/locked.toml
@@ -4,7 +4,9 @@ status = "failed"
 stdout = ""
 stderr = """
     Checking cargo-list-test-fixture's dependencies
-   Upgrading docopt: v0.8.0 -> v99999.0.0
+name   old req locked latest    new req   note
+====   ======= ====== ======    =======   ====
+docopt 0.8.0   -      99999.0.0 99999.0.0     
 Error: cannot upgrade due to `--locked`
 """
 fs.sandbox = true

--- a/tests/cmd/upgrade/optional_dep.toml
+++ b/tests/cmd/upgrade/optional_dep.toml
@@ -4,7 +4,9 @@ status = "success"
 stdout = ""
 stderr = """
     Checking cargo-list-test-fixture's dependencies
-   Upgrading docopt: v0.8.0 -> v99999.0.0
+name   old req locked latest    new req   note
+====   ======= ====== ======    =======   ====
+docopt 0.8.0   -      99999.0.0 99999.0.0     
 """
 fs.sandbox = true
 

--- a/tests/cmd/upgrade/pinned.toml
+++ b/tests/cmd/upgrade/pinned.toml
@@ -4,15 +4,17 @@ status = "success"
 stdout = ""
 stderr = """
     Checking cargo-list-test-fixture's dependencies
-   Upgrading default: v1.0 -> v99999.0
-warning: ignoring exact, version (=2.0) is pinned
-warning: ignoring lessthan, version (<0.4) is pinned
-warning: ignoring lessorequal, version (<=3.0) is pinned
-   Upgrading caret: ^3.0 -> ^99999.0
-   Upgrading tilde: ~4.1.0 -> ~99999.0.0
-warning: ignoring greaterthan, version (>2.0) is compatible with 99999.0.0
-warning: ignoring greaterorequal, version (>=2.1.0) is compatible with 99999.0.0
-   Upgrading wildcard: v3.* -> v99999.*
+name           old req locked latest    new req    note      
+====           ======= ====== ======    =======    ====      
+default        1.0     -      99999.0.0 99999.0              
+exact          =2.0    -      99999.0.0 =2.0       pinned    
+lessthan       <0.4    -      99999.0.0 <0.4       pinned    
+lessorequal    <=3.0   -      99999.0.0 <=3.0      pinned    
+caret          ^3.0    -      99999.0.0 ^99999.0             
+tilde          ~4.1.0  -      99999.0.0 ~99999.0.0           
+greaterthan    >2.0    -      99999.0.0 >2.0       compatible
+greaterorequal >=2.1.0 -      99999.0.0 >=2.1.0    compatible
+wildcard       3.*     -      99999.0.0 99999.*              
 note: Re-run with `--pinned` to upgrade pinned version requirements
 note: Re-run with `--to-lockfile` to upgrade compatible version requirements
 """

--- a/tests/cmd/upgrade/preserve_precision_major.toml
+++ b/tests/cmd/upgrade/preserve_precision_major.toml
@@ -4,7 +4,9 @@ status = "success"
 stdout = ""
 stderr = """
     Checking cargo-list-test-fixture's dependencies
-   Upgrading docopt: v0 -> v99999
+name   old req locked latest    new req note
+====   ======= ====== ======    ======= ====
+docopt 0       -      99999.0.0 99999       
 """
 fs.sandbox = true
 

--- a/tests/cmd/upgrade/preserve_precision_minor.toml
+++ b/tests/cmd/upgrade/preserve_precision_minor.toml
@@ -4,7 +4,9 @@ status = "success"
 stdout = ""
 stderr = """
     Checking cargo-list-test-fixture's dependencies
-   Upgrading docopt: v0.8 -> v99999.0
+name   old req locked latest    new req note
+====   ======= ====== ======    ======= ====
+docopt 0.8     -      99999.0.0 99999.0     
 """
 fs.sandbox = true
 

--- a/tests/cmd/upgrade/preserve_precision_patch.toml
+++ b/tests/cmd/upgrade/preserve_precision_patch.toml
@@ -4,7 +4,9 @@ status = "success"
 stdout = ""
 stderr = """
     Checking cargo-list-test-fixture's dependencies
-   Upgrading docopt: v0.8.0 -> v99999.0.0
+name   old req locked latest    new req   note
+====   ======= ====== ======    =======   ====
+docopt 0.8.0   -      99999.0.0 99999.0.0     
 """
 fs.sandbox = true
 

--- a/tests/cmd/upgrade/preserves_inline_table.toml
+++ b/tests/cmd/upgrade/preserves_inline_table.toml
@@ -4,7 +4,9 @@ status = "success"
 stdout = ""
 stderr = """
     Checking cargo-list-test-fixture's dependencies
-   Upgrading docopt: v0.8.0 -> v99999.0.0
+name   old req locked latest    new req   note
+====   ======= ====== ======    =======   ====
+docopt 0.8.0   -      99999.0.0 99999.0.0     
 """
 fs.sandbox = true
 

--- a/tests/cmd/upgrade/preserves_std_table.toml
+++ b/tests/cmd/upgrade/preserves_std_table.toml
@@ -4,7 +4,9 @@ status = "success"
 stdout = ""
 stderr = """
     Checking cargo-list-test-fixture's dependencies
-   Upgrading docopt: v0.8.0 -> v99999.0.0
+name   old req locked latest    new req   note
+====   ======= ====== ======    =======   ====
+docopt 0.8.0   -      99999.0.0 99999.0.0     
 """
 fs.sandbox = true
 

--- a/tests/cmd/upgrade/single_dep.toml
+++ b/tests/cmd/upgrade/single_dep.toml
@@ -4,7 +4,9 @@ status = "success"
 stdout = ""
 stderr = """
     Checking cargo-list-test-fixture's dependencies
-   Upgrading docopt: v0.8.0 -> v99999.0.0
+name   old req locked latest    new req   note
+====   ======= ====== ======    =======   ====
+docopt 0.8.0   -      99999.0.0 99999.0.0     
 """
 fs.sandbox = true
 

--- a/tests/cmd/upgrade/skip_compatible.in/Cargo.toml
+++ b/tests/cmd/upgrade/skip_compatible.in/Cargo.toml
@@ -4,4 +4,4 @@ version = "0.0.0"
 
 [dependencies]
 test_breaking = "0.1"
-test_nonbreaking = "0.1"
+test_nonbreaking = "0.1.0"

--- a/tests/cmd/upgrade/skip_compatible.out/Cargo.toml
+++ b/tests/cmd/upgrade/skip_compatible.out/Cargo.toml
@@ -4,4 +4,4 @@ version = "0.0.0"
 
 [dependencies]
 test_breaking = "0.2"
-test_nonbreaking = "0.1"
+test_nonbreaking = "0.1.0"

--- a/tests/cmd/upgrade/skip_compatible.toml
+++ b/tests/cmd/upgrade/skip_compatible.toml
@@ -7,7 +7,7 @@ stderr = """
 name             old req locked latest new req note      
 ====             ======= ====== ====== ======= ====      
 test_breaking    0.1     -      0.2.0  0.2               
-test_nonbreaking 0.1     -      0.1.1  0.1     compatible
+test_nonbreaking 0.1.0   -      0.1.1  0.1.0   compatible
 note: Re-run with `--to-lockfile` to upgrade compatible version requirements
 """
 fs.sandbox = true

--- a/tests/cmd/upgrade/skip_compatible.toml
+++ b/tests/cmd/upgrade/skip_compatible.toml
@@ -4,8 +4,10 @@ status = "success"
 stdout = ""
 stderr = """
     Checking cargo-list-test-fixture's dependencies
-   Upgrading test_breaking: v0.1 -> v0.2
-warning: ignoring test_nonbreaking, version (0.1) is compatible with 0.1.1
+name             old req locked latest new req note      
+====             ======= ====== ====== ======= ====      
+test_breaking    0.1     -      0.2.0  0.2               
+test_nonbreaking 0.1     -      0.1.1  0.1     compatible
 note: Re-run with `--to-lockfile` to upgrade compatible version requirements
 """
 fs.sandbox = true

--- a/tests/cmd/upgrade/specified.toml
+++ b/tests/cmd/upgrade/specified.toml
@@ -4,7 +4,9 @@ status = "success"
 stdout = ""
 stderr = """
     Checking cargo-list-test-fixture's dependencies
-   Upgrading a: v1.0 -> v99999.0
+name old req locked latest    new req note
+==== ======= ====== ======    ======= ====
+a    1.0     -      99999.0.0 99999.0     
 """
 fs.sandbox = true
 

--- a/tests/cmd/upgrade/to_lockfile.toml
+++ b/tests/cmd/upgrade/to_lockfile.toml
@@ -4,16 +4,24 @@ status = "success"
 stdout = ""
 stderr = """
     Checking one's dependencies
-   Upgrading libc: v0.2.28 -> v0.2.62
-warning: ignoring rand, version (0.3) is unchanged
 warning: ignoring three, source is [CWD]/one/Cargo.toml/../implicit/three
+name old req locked latest    new req note
+==== ======= ====== ======    ======= ====
+libc 0.2.28  0.2.62 99999.0.0 0.2.62      
+rand 0.3     0.3.23 99999.0.0 0.3         
     Checking three's dependencies
-   Upgrading libc: v0.2.28 -> v0.2.62
+name old req locked latest    new req note
+==== ======= ====== ======    ======= ====
+libc 0.2.28  0.2.62 99999.0.0 0.2.62      
     Checking two's dependencies
-   Upgrading libc: v0.2.28 -> v0.2.62
-warning: ignoring rand, version (0.2) is unchanged
+name old req locked latest    new req note
+==== ======= ====== ======    ======= ====
+libc 0.2.28  0.2.62 99999.0.0 0.2.62      
+rand 0.2     0.2.1  99999.0.0 0.2         
     Checking four's dependencies
-   Upgrading libc: v0.2.28 -> v0.2.62
+name old req locked latest    new req note
+==== ======= ====== ======    ======= ====
+libc 0.2.28  0.2.62 99999.0.0 0.2.62      
 """
 fs.sandbox = true
 

--- a/tests/cmd/upgrade/to_version.toml
+++ b/tests/cmd/upgrade/to_version.toml
@@ -4,7 +4,9 @@ status = "success"
 stdout = ""
 stderr = """
     Checking cargo-list-test-fixture's dependencies
-   Upgrading docopt: v0.8.0 -> v1000000.0.0
+name   old req locked latest    new req     note
+====   ======= ====== ======    =======     ====
+docopt 0.8.0   -      99999.0.0 1000000.0.0     
 """
 fs.sandbox = true
 

--- a/tests/cmd/upgrade/upgrade_all.toml
+++ b/tests/cmd/upgrade/upgrade_all.toml
@@ -5,15 +5,23 @@ stdout = ""
 stderr = """
 The flag `--all` has been deprecated in favor of `--workspace`
     Checking one's dependencies
-   Upgrading libc: v0.2.28 -> v99999.0.0
-   Upgrading rand: v0.3 -> v99999.0
+name old req locked latest    new req   note
+==== ======= ====== ======    =======   ====
+libc 0.2.28  -      99999.0.0 99999.0.0     
+rand 0.3     -      99999.0.0 99999.0       
     Checking three's dependencies
-   Upgrading libc: v0.2.28 -> v99999.0.0
+name old req locked latest    new req   note
+==== ======= ====== ======    =======   ====
+libc 0.2.28  -      99999.0.0 99999.0.0     
     Checking two's dependencies
-   Upgrading libc: v0.2.28 -> v99999.0.0
-   Upgrading rand: v0.2 -> v99999.0
+name old req locked latest    new req   note
+==== ======= ====== ======    =======   ====
+libc 0.2.28  -      99999.0.0 99999.0.0     
+rand 0.2     -      99999.0.0 99999.0       
     Checking four's dependencies
-   Upgrading libc: v0.2.28 -> v99999.0.0
+name old req locked latest    new req   note
+==== ======= ====== ======    =======   ====
+libc 0.2.28  -      99999.0.0 99999.0.0     
 """
 fs.sandbox = true
 

--- a/tests/cmd/upgrade/upgrade_all.toml
+++ b/tests/cmd/upgrade/upgrade_all.toml
@@ -7,21 +7,21 @@ The flag `--all` has been deprecated in favor of `--workspace`
     Checking one's dependencies
 name old req locked latest    new req   note
 ==== ======= ====== ======    =======   ====
-libc 0.2.28  -      99999.0.0 99999.0.0     
-rand 0.3     -      99999.0.0 99999.0       
+libc 0.2.28  0.2.62 99999.0.0 99999.0.0     
+rand 0.3     0.3.23 99999.0.0 99999.0       
     Checking three's dependencies
 name old req locked latest    new req   note
 ==== ======= ====== ======    =======   ====
-libc 0.2.28  -      99999.0.0 99999.0.0     
+libc 0.2.28  0.2.62 99999.0.0 99999.0.0     
     Checking two's dependencies
 name old req locked latest    new req   note
 ==== ======= ====== ======    =======   ====
-libc 0.2.28  -      99999.0.0 99999.0.0     
-rand 0.2     -      99999.0.0 99999.0       
+libc 0.2.28  0.2.62 99999.0.0 99999.0.0     
+rand 0.2     0.2.1  99999.0.0 99999.0       
     Checking four's dependencies
 name old req locked latest    new req   note
 ==== ======= ====== ======    =======   ====
-libc 0.2.28  -      99999.0.0 99999.0.0     
+libc 0.2.28  0.2.62 99999.0.0 99999.0.0     
 """
 fs.sandbox = true
 

--- a/tests/cmd/upgrade/upgrade_everything.toml
+++ b/tests/cmd/upgrade/upgrade_everything.toml
@@ -4,21 +4,24 @@ status = "success"
 stdout = ""
 stderr = """
     Checking None's dependencies
-   Upgrading docopt: v0.8 -> v99999.0
-   Upgrading pad: v0.1 -> v99999.0
-   Upgrading serde_json: v1.0 -> v99999.0
-   Upgrading syn: v0.11.10 -> v99999.0.0
-   Upgrading tar: v0.4 -> v99999.0
-   Upgrading ftp: v2.2.1 -> v99999.0.0
-   Upgrading te: v0.1.5 -> v99999.0.0
-   Upgrading semver: v0.7 -> v99999.0
-   Upgrading rn: v0.1 -> v99999.0
-   Upgrading assert_cli: v0.2.0 -> v99999.0.0
-   Upgrading tempdir: v0.3 -> v99999.0
-   Upgrading openssl: v0.9 -> v99999.0
-   Upgrading rget: v0.3.0 -> v99999.0.0
-   Upgrading geo: v0.7.0 -> v99999.0.0
-   Upgrading ftp: v2.2.1 -> v99999.0.0
+name       old req locked latest    new req   note
+====       ======= ====== ======    =======   ====
+docopt     0.8     -      99999.0.0 99999.0       
+pad        0.1     -      99999.0.0 99999.0       
+serde_json 1.0     -      99999.0.0 99999.0       
+syn        0.11.10 -      99999.0.0 99999.0.0     
+tar        0.4     -      99999.0.0 99999.0       
+ftp        2.2.1   -      99999.0.0 99999.0.0     
+te         0.1.5   -      99999.0.0 99999.0.0     
+semver     0.7     -      99999.0.0 99999.0       
+rn         0.1     -      99999.0.0 99999.0       
+assert_cli 0.2.0   -      99999.0.0 99999.0.0     
+tempdir    0.3     -      99999.0.0 99999.0       
+serde      1.0     -      -         1.0           
+openssl    0.9     -      99999.0.0 99999.0       
+rget       0.3.0   -      99999.0.0 99999.0.0     
+geo        0.7.0   -      99999.0.0 99999.0.0     
+ftp        2.2.1   -      99999.0.0 99999.0.0     
 """
 fs.sandbox = true
 

--- a/tests/cmd/upgrade/upgrade_renamed.toml
+++ b/tests/cmd/upgrade/upgrade_renamed.toml
@@ -4,8 +4,10 @@ status = "success"
 stdout = ""
 stderr = """
     Checking cargo-list-test-fixture's dependencies
-   Upgrading te: v0.1.5 -> v99999.0.0
-   Upgrading rx: v0.2 -> v99999.0
+name old req locked latest    new req   note
+==== ======= ====== ======    =======   ====
+te   0.1.5   -      99999.0.0 99999.0.0     
+rx   0.2     -      99999.0.0 99999.0       
 """
 fs.sandbox = true
 

--- a/tests/cmd/upgrade/upgrade_workspace.toml
+++ b/tests/cmd/upgrade/upgrade_workspace.toml
@@ -4,15 +4,23 @@ status = "success"
 stdout = ""
 stderr = """
     Checking one's dependencies
-   Upgrading libc: v0.2.28 -> v99999.0.0
-   Upgrading rand: v0.3 -> v99999.0
+name old req locked latest    new req   note
+==== ======= ====== ======    =======   ====
+libc 0.2.28  -      99999.0.0 99999.0.0     
+rand 0.3     -      99999.0.0 99999.0       
     Checking three's dependencies
-   Upgrading libc: v0.2.28 -> v99999.0.0
+name old req locked latest    new req   note
+==== ======= ====== ======    =======   ====
+libc 0.2.28  -      99999.0.0 99999.0.0     
     Checking two's dependencies
-   Upgrading libc: v0.2.28 -> v99999.0.0
-   Upgrading rand: v0.2 -> v99999.0
+name old req locked latest    new req   note
+==== ======= ====== ======    =======   ====
+libc 0.2.28  -      99999.0.0 99999.0.0     
+rand 0.2     -      99999.0.0 99999.0       
     Checking four's dependencies
-   Upgrading libc: v0.2.28 -> v99999.0.0
+name old req locked latest    new req   note
+==== ======= ====== ======    =======   ====
+libc 0.2.28  -      99999.0.0 99999.0.0     
 """
 fs.sandbox = true
 

--- a/tests/cmd/upgrade/upgrade_workspace.toml
+++ b/tests/cmd/upgrade/upgrade_workspace.toml
@@ -6,21 +6,21 @@ stderr = """
     Checking one's dependencies
 name old req locked latest    new req   note
 ==== ======= ====== ======    =======   ====
-libc 0.2.28  -      99999.0.0 99999.0.0     
-rand 0.3     -      99999.0.0 99999.0       
+libc 0.2.28  0.2.62 99999.0.0 99999.0.0     
+rand 0.3     0.3.23 99999.0.0 99999.0       
     Checking three's dependencies
 name old req locked latest    new req   note
 ==== ======= ====== ======    =======   ====
-libc 0.2.28  -      99999.0.0 99999.0.0     
+libc 0.2.28  0.2.62 99999.0.0 99999.0.0     
     Checking two's dependencies
 name old req locked latest    new req   note
 ==== ======= ====== ======    =======   ====
-libc 0.2.28  -      99999.0.0 99999.0.0     
-rand 0.2     -      99999.0.0 99999.0       
+libc 0.2.28  0.2.62 99999.0.0 99999.0.0     
+rand 0.2     0.2.1  99999.0.0 99999.0       
     Checking four's dependencies
 name old req locked latest    new req   note
 ==== ======= ====== ======    =======   ====
-libc 0.2.28  -      99999.0.0 99999.0.0     
+libc 0.2.28  0.2.62 99999.0.0 99999.0.0     
 """
 fs.sandbox = true
 

--- a/tests/cmd/upgrade/virtual_manifest.toml
+++ b/tests/cmd/upgrade/virtual_manifest.toml
@@ -4,15 +4,23 @@ status = "success"
 stdout = ""
 stderr = """
     Checking one's dependencies
-   Upgrading libc: v0.2.28 -> v99999.0.0
-   Upgrading rand: v0.3 -> v99999.0
+name old req locked latest    new req   note
+==== ======= ====== ======    =======   ====
+libc 0.2.28  -      99999.0.0 99999.0.0     
+rand 0.3     -      99999.0.0 99999.0       
     Checking three's dependencies
-   Upgrading libc: v0.2.28 -> v99999.0.0
+name old req locked latest    new req   note
+==== ======= ====== ======    =======   ====
+libc 0.2.28  -      99999.0.0 99999.0.0     
     Checking two's dependencies
-   Upgrading libc: v0.2.28 -> v99999.0.0
-   Upgrading rand: v0.2 -> v99999.0
+name old req locked latest    new req   note
+==== ======= ====== ======    =======   ====
+libc 0.2.28  -      99999.0.0 99999.0.0     
+rand 0.2     -      99999.0.0 99999.0       
     Checking four's dependencies
-   Upgrading libc: v0.2.28 -> v99999.0.0
+name old req locked latest    new req   note
+==== ======= ====== ======    =======   ====
+libc 0.2.28  -      99999.0.0 99999.0.0     
 """
 fs.sandbox = true
 

--- a/tests/cmd/upgrade/virtual_manifest.toml
+++ b/tests/cmd/upgrade/virtual_manifest.toml
@@ -6,21 +6,21 @@ stderr = """
     Checking one's dependencies
 name old req locked latest    new req   note
 ==== ======= ====== ======    =======   ====
-libc 0.2.28  -      99999.0.0 99999.0.0     
-rand 0.3     -      99999.0.0 99999.0       
+libc 0.2.28  0.2.62 99999.0.0 99999.0.0     
+rand 0.3     0.3.23 99999.0.0 99999.0       
     Checking three's dependencies
 name old req locked latest    new req   note
 ==== ======= ====== ======    =======   ====
-libc 0.2.28  -      99999.0.0 99999.0.0     
+libc 0.2.28  0.2.62 99999.0.0 99999.0.0     
     Checking two's dependencies
 name old req locked latest    new req   note
 ==== ======= ====== ======    =======   ====
-libc 0.2.28  -      99999.0.0 99999.0.0     
-rand 0.2     -      99999.0.0 99999.0       
+libc 0.2.28  0.2.62 99999.0.0 99999.0.0     
+rand 0.2     0.2.1  99999.0.0 99999.0       
     Checking four's dependencies
 name old req locked latest    new req   note
 ==== ======= ====== ======    =======   ====
-libc 0.2.28  -      99999.0.0 99999.0.0     
+libc 0.2.28  0.2.62 99999.0.0 99999.0.0     
 """
 fs.sandbox = true
 

--- a/tests/cmd/upgrade/workspace_member_cwd.toml
+++ b/tests/cmd/upgrade/workspace_member_cwd.toml
@@ -4,7 +4,9 @@ status = "success"
 stdout = ""
 stderr = """
     Checking one's dependencies
-   Upgrading libc: v0.2.28 -> v99999.0.0
+name old req locked latest    new req   note
+==== ======= ====== ======    =======   ====
+libc 0.2.28  -      99999.0.0 99999.0.0     
 """
 fs.sandbox = true
 fs.cwd = "workspace_member_cwd.in/one"

--- a/tests/cmd/upgrade/workspace_member_cwd.toml
+++ b/tests/cmd/upgrade/workspace_member_cwd.toml
@@ -6,7 +6,7 @@ stderr = """
     Checking one's dependencies
 name old req locked latest    new req   note
 ==== ======= ====== ======    =======   ====
-libc 0.2.28  -      99999.0.0 99999.0.0     
+libc 0.2.28  0.2.62 99999.0.0 99999.0.0     
 """
 fs.sandbox = true
 fs.cwd = "workspace_member_cwd.in/one"

--- a/tests/cmd/upgrade/workspace_member_manifest_path.toml
+++ b/tests/cmd/upgrade/workspace_member_manifest_path.toml
@@ -4,7 +4,9 @@ status = "success"
 stdout = ""
 stderr = """
     Checking one's dependencies
-   Upgrading libc: v0.2.28 -> v99999.0.0
+name old req locked latest    new req   note
+==== ======= ====== ======    =======   ====
+libc 0.2.28  -      99999.0.0 99999.0.0     
 """
 fs.sandbox = true
 fs.cwd = "workspace_member_cwd.in/one"

--- a/tests/cmd/upgrade/workspace_member_manifest_path.toml
+++ b/tests/cmd/upgrade/workspace_member_manifest_path.toml
@@ -6,7 +6,7 @@ stderr = """
     Checking one's dependencies
 name old req locked latest    new req   note
 ==== ======= ====== ======    =======   ====
-libc 0.2.28  -      99999.0.0 99999.0.0     
+libc 0.2.28  0.2.62 99999.0.0 99999.0.0     
 """
 fs.sandbox = true
 fs.cwd = "workspace_member_cwd.in/one"


### PR DESCRIPTION
This provides a `cargo outdated`-like UI, reducing the need for one
extra tool and helps raise visibility into cargo-upgrades decisions in a
pretty way (compared to lines and lines of warnings).

In doing so, I noticed that we mark more dependencies as compatible than we should so shifted the order of things so we wouldn't do so when the version req will remain unchanged.

I also tweaked some of the error handling language to open it up to errors possibly being functionality gaps in cargo-upgrade.

I do wonder if we should sometimes elide dependencies (and suggest `--verbose` to show them).

For clap:
```
    Updating 'https://github.com/rust-lang/crates.io-index' index
    Checking clap's dependencies
name              old req        locked latest new req        note
====              =======        ====== ====== =======        ====
clap_derive       =4.0.0-alpha.0 -      -      =4.0.0-alpha.0 pinned
clap_lex          0.2.2          -      -      0.2.2
bitflags          1.2            1.3.2  1.3.2  1.2            compatible
textwrap          0.15.0         0.15.0 0.15.0 0.15.0
unicase           2.6            2.6.0  2.6.0  2.6
indexmap          1.0            1.9.1  1.9.1  1.0            compatible
strsim            0.10           0.10.0 0.10.0 0.10
atty              0.2            0.2.14 0.2.14 0.2
termcolor         1.1.1          1.1.3  1.1.3  1.1.1          compatible
terminal_size     0.1.12         0.1.17 0.2.1  0.2.1
backtrace         0.3            0.3.66 0.3.66 0.3
once_cell         1.12.0         1.13.0 1.13.0 1.12.0         compatible
trybuild          1.0.18         1.0.63 1.0.63 1.0.18         compatible
rustversion       1              1.0.8  1.0.8  1
trycmd            0.13           0.13.4 0.13.4 0.13
humantime         2              2.1.0  2.1.0  2
snapbox           0.2.9          0.2.10 0.2.10 0.2.9          compatible
shlex             1.1.0          1.1.0  1.1.0  1.1.0
static_assertions 1.1.0          1.1.0  1.1.0  1.1.0
note: Re-run with `--pinned` to upgrade pinned version requirements
note: Re-run with `--to-lockfile` to upgrade compatible version requirements
warning: aborting upgrade due to dry run
```

Fixes #750