### PR TITLE
Use clap builder instead of derive, restructure a bit to look like cargo

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ $ cargo rm regex --build
 
 #### Usage
 
-```console
+```console,ignore
 $ cargo-rm rm --help
 cargo-rm [..]
 Remove a dependency from a Cargo.toml manifest file

--- a/crates/cargo-rm/Cargo.toml
+++ b/crates/cargo-rm/Cargo.toml
@@ -38,7 +38,7 @@ anyhow = "1.0"
 cargo-util.git = "https://github.com/rust-lang/cargo"
 cargo.git = "https://github.com/rust-lang/cargo"
 cargo_metadata = "0.15.0"
-clap = { version = "3.2", features = ["derive", "wrap_help"], optional = true }
+clap = { version = "3.2", features = ["wrap_help"], optional = true }
 concolor-control = { version = "0.0.7", default-features = false }
 crates-index = "0.18.9"
 dirs-next = "2.0.0"

--- a/crates/cargo-rm/src/bin/cargo/cli.rs
+++ b/crates/cargo-rm/src/bin/cargo/cli.rs
@@ -1,5 +1,12 @@
-use cargo_rm::CargoResult;
+use cargo::util::command_prelude::*;
+use cargo::CargoResult;
 use clap::{Parser, Subcommand};
+
+pub fn main(config: &mut Config) -> CliResult {
+    let args = Cli::try_parse()?;
+    execute_subcommand(config, &args)?;
+    Ok(())
+}
 
 #[derive(Debug, Parser)]
 #[clap(bin_name = "cargo")]
@@ -12,19 +19,13 @@ pub struct Cli {
     subcommand: Command,
 }
 
-impl Cli {
-    pub fn exec(self) -> CargoResult<()> {
-        self.subcommand.exec()
-    }
-}
-
 #[derive(Debug, Subcommand)]
 pub enum Command {
     Rm(crate::commands::rm::RmArgs),
 }
 
 impl Command {
-    pub fn exec(self) -> CargoResult<()> {
+    pub fn exec(&self) -> CargoResult<()> {
         match self {
             Self::Rm(rm) => rm.exec(),
         }
@@ -33,6 +34,11 @@ impl Command {
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq, clap::ArgEnum)]
 enum UnstableOptions {}
+
+fn execute_subcommand(_config: &mut Config, args: &Cli) -> CliResult {
+    args.subcommand.exec()?;
+    Ok(())
+}
 
 #[test]
 fn verify_app() {

--- a/crates/cargo-rm/src/bin/cargo/cli.rs
+++ b/crates/cargo-rm/src/bin/cargo/cli.rs
@@ -1,8 +1,24 @@
 use cargo_rm::CargoResult;
-use clap::Parser;
+use clap::{Parser, Subcommand};
 
 #[derive(Debug, Parser)]
 #[clap(bin_name = "cargo")]
+pub struct Cli {
+    /// Unstable (nightly-only) flags
+    #[clap(short = 'Z', value_name = "FLAG", global = true, arg_enum)]
+    unstable_features: Vec<UnstableOptions>,
+
+    #[clap(subcommand)]
+    subcommand: Command,
+}
+
+impl Cli {
+    pub fn exec(self) -> CargoResult<()> {
+        self.subcommand.exec()
+    }
+}
+
+#[derive(Debug, Subcommand)]
 pub enum Command {
     Rm(crate::commands::rm::RmArgs),
 }
@@ -10,13 +26,16 @@ pub enum Command {
 impl Command {
     pub fn exec(self) -> CargoResult<()> {
         match self {
-            Self::Rm(add) => add.exec(),
+            Self::Rm(rm) => rm.exec(),
         }
     }
 }
 
+#[derive(Copy, Clone, Debug, PartialEq, Eq, clap::ArgEnum)]
+enum UnstableOptions {}
+
 #[test]
 fn verify_app() {
     use clap::CommandFactory;
-    Command::command().debug_assert()
+    Cli::command().debug_assert()
 }

--- a/crates/cargo-rm/src/bin/cargo/commands/mod.rs
+++ b/crates/cargo-rm/src/bin/cargo/commands/mod.rs
@@ -1,1 +1,15 @@
+use cargo::CliResult;
+
 pub mod rm;
+
+pub fn builtin() -> [clap::Command<'static>; 1] {
+    [rm::cli()]
+}
+
+pub fn builtin_exec(cmd: &str) -> Option<fn(&mut cargo::Config, &clap::ArgMatches) -> CliResult> {
+    let f = match cmd {
+        "rm" => rm::exec,
+        _ => return None,
+    };
+    Some(f)
+}

--- a/crates/cargo-rm/src/bin/cargo/commands/rm.rs
+++ b/crates/cargo-rm/src/bin/cargo/commands/rm.rs
@@ -1,6 +1,6 @@
+use cargo::CargoResult;
 use cargo_rm::shell_status;
 use cargo_rm::shell_warn;
-use cargo_rm::CargoResult;
 use cargo_rm::{manifest_from_pkgid, LocalManifest};
 use clap::Args;
 use std::borrow::Cow;

--- a/crates/cargo-rm/src/bin/cargo/commands/rm.rs
+++ b/crates/cargo-rm/src/bin/cargo/commands/rm.rs
@@ -1,54 +1,34 @@
+use cargo::util::command_prelude::*;
 use cargo::CargoResult;
 use cargo_rm::shell_status;
 use cargo_rm::shell_warn;
 use cargo_rm::{manifest_from_pkgid, LocalManifest};
-use clap::Args;
+
 use std::borrow::Cow;
 use std::path::PathBuf;
 
 /// Remove a dependency from a Cargo.toml manifest file.
-#[derive(Debug, Args)]
-#[clap(version)]
-#[clap(setting = clap::AppSettings::DeriveDisplayOrder)]
-pub struct RmArgs {
+#[derive(Debug)]
+pub struct RmOptions {
     /// Dependencies to be removed
-    #[clap(value_name = "DEP_ID", required = true)]
     crates: Vec<String>,
-
     /// Remove as development dependency
-    #[clap(long, short = 'D', conflicts_with = "build", help_heading = "SECTION")]
     dev: bool,
-
     /// Remove as build dependency
-    #[clap(long, short = 'B', conflicts_with = "dev", help_heading = "SECTION")]
     build: bool,
-
     /// Remove as dependency from the given target platform
-    #[clap(long, value_parser = clap::builder::NonEmptyStringValueParser::new(), help_heading = "SECTION")]
     target: Option<String>,
-
     /// Path to the manifest to remove a dependency from
-    #[clap(long, value_name = "PATH", action)]
     manifest_path: Option<PathBuf>,
-
     /// Package to remove from
-    #[clap(long = "package", short = 'p', value_name = "PKGID")]
-    pkgid: Option<String>,
-
+    pkg_id: Option<String>,
     /// Don't actually write the manifest
-    #[clap(long)]
     dry_run: bool,
-
     /// Do not print any output in case of success
-    #[clap(long, short)]
     quiet: bool,
 }
 
-impl RmArgs {
-    pub fn exec(&self) -> CargoResult<()> {
-        exec(self)
-    }
-
+impl RmOptions {
     /// Get dependency section
     pub fn get_section(&self) -> Vec<String> {
         let section_name = if self.dev {
@@ -69,9 +49,113 @@ impl RmArgs {
     }
 }
 
-fn exec(args: &RmArgs) -> CargoResult<()> {
-    let manifest_path = if let Some(ref pkgid) = args.pkgid {
-        let pkg = manifest_from_pkgid(args.manifest_path.as_deref(), pkgid)?;
+pub fn cli() -> clap::Command<'static> {
+    clap::Command::new("rm")
+        .setting(clap::AppSettings::DeriveDisplayOrder)
+        .about("Remove a dependency from a Cargo.toml manifest file")
+        .args([
+            clap::Arg::new("dependencies")
+                .action(clap::ArgAction::Append)
+                .required(true)
+                .multiple_values(true)
+                .takes_value(true)
+                .value_name("DEP_ID")
+                .help("Dependencies to be removed"),
+            clap::Arg::new("manifest_path")
+                .long("manifest-path")
+                .takes_value(true)
+                .value_name("PATH")
+                .value_parser(clap::builder::PathBufValueParser::new())
+                .help("Path to the manifest to remove a dependency from"),
+            clap::Arg::new("pkg_id")
+                .short('p')
+                .long("package")
+                .takes_value(true)
+                .value_name("PKGID")
+                .help("Package to remove from"),
+            clap::Arg::new("dry_run")
+                .long("dry-run")
+                .action(clap::ArgAction::SetTrue)
+                .help("Don't actually write the manifest"),
+            clap::Arg::new("quiet")
+                .short('q')
+                .long("quiet")
+                .action(clap::ArgAction::SetTrue)
+                .help("Do not print any output in case of success"),
+        ])
+        .next_help_heading("SECTION")
+        .args([
+            clap::Arg::new("dev")
+                .short('D')
+                .long("dev")
+                .conflicts_with("build")
+                .action(clap::ArgAction::SetTrue)
+                .group("section")
+                .help("Remove as development dependency"),
+            clap::Arg::new("build")
+                .short('B')
+                .long("build")
+                .conflicts_with("dev")
+                .action(clap::ArgAction::SetTrue)
+                .group("section")
+                .help("Remove as build dependency"),
+            clap::Arg::new("target")
+                .long("target")
+                .takes_value(true)
+                .value_name("TARGET")
+                .value_parser(clap::builder::NonEmptyStringValueParser::new())
+                .help("Remove as dependency from the given target platform"),
+        ])
+}
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+enum UnstableOptions {}
+
+pub fn exec(_config: &mut Config, args: &ArgMatches) -> CliResult {
+    let crates = args
+        .get_many("dependencies")
+        .expect("required(true)")
+        .cloned()
+        .collect();
+    let dev = args
+        .get_one::<bool>("dev")
+        .copied()
+        .expect("action(ArgAction::SetTrue)");
+    let build = args
+        .get_one::<bool>("build")
+        .copied()
+        .expect("action(ArgAction::SetTrue)");
+    let target = args.get_one("target").cloned();
+    let manifest_path = args.get_one("manifest_path").cloned();
+    let pkg_id = args.get_one("pkg_id").cloned();
+    let dry_run = args
+        .get_one::<bool>("dry_run")
+        .copied()
+        .expect("action(ArgAction::SetTrue)");
+    let quiet = args
+        .get_one::<bool>("quiet")
+        .copied()
+        .expect("action(ArgAction::SetTrue)");
+
+    let options = RmOptions {
+        crates,
+        dev,
+        build,
+        target,
+        manifest_path,
+        pkg_id,
+        dry_run,
+        quiet,
+    };
+
+    rm(&options)?;
+
+    Ok(())
+}
+
+fn rm(args: &RmOptions) -> CargoResult<()> {
+    let manifest_path = if let Some(ref pkg_id) = args.pkg_id {
+        let pkg = manifest_from_pkgid(args.manifest_path.as_deref(), pkg_id)?;
         Cow::Owned(Some(pkg.manifest_path.into_std_path_buf()))
     } else {
         Cow::Borrowed(&args.manifest_path)

--- a/crates/cargo-rm/src/bin/cargo/commands/rm.rs
+++ b/crates/cargo-rm/src/bin/cargo/commands/rm.rs
@@ -71,7 +71,7 @@ pub fn cli() -> clap::Command<'static> {
                 .short('p')
                 .long("package")
                 .takes_value(true)
-                .value_name("PKGID")
+                .value_name("PKG_ID")
                 .help("Package to remove from"),
             clap::Arg::new("dry_run")
                 .long("dry-run")

--- a/crates/cargo-rm/src/bin/cargo/commands/rm.rs
+++ b/crates/cargo-rm/src/bin/cargo/commands/rm.rs
@@ -35,10 +35,6 @@ pub struct RmArgs {
     #[clap(long = "package", short = 'p', value_name = "PKGID")]
     pkgid: Option<String>,
 
-    /// Unstable (nightly-only) flags
-    #[clap(short = 'Z', value_name = "FLAG", global = true, arg_enum)]
-    unstable_features: Vec<UnstableOptions>,
-
     /// Don't actually write the manifest
     #[clap(long)]
     dry_run: bool,
@@ -72,9 +68,6 @@ impl RmArgs {
         }
     }
 }
-
-#[derive(Copy, Clone, Debug, PartialEq, Eq, clap::ArgEnum)]
-enum UnstableOptions {}
 
 fn exec(args: &RmArgs) -> CargoResult<()> {
     let manifest_path = if let Some(ref pkgid) = args.pkgid {

--- a/crates/cargo-rm/src/bin/cargo/main.rs
+++ b/crates/cargo-rm/src/bin/cargo/main.rs
@@ -19,7 +19,7 @@ use std::process;
 use clap::Parser;
 
 fn main() {
-    let args = cli::Command::parse();
+    let args = cli::Cli::parse();
 
     if let Err(err) = args.exec() {
         eprintln!("Error: {:?}", err);

--- a/crates/cargo-rm/src/bin/cargo/main.rs
+++ b/crates/cargo-rm/src/bin/cargo/main.rs
@@ -14,16 +14,9 @@
 mod cli;
 mod commands;
 
-use std::process;
-
-use clap::Parser;
-
 fn main() {
-    let args = cli::Cli::parse();
-
-    if let Err(err) = args.exec() {
-        eprintln!("Error: {:?}", err);
-
-        process::exit(1);
+    let mut config = cargo::Config::default().unwrap();
+    if let Err(err) = cli::main(&mut config) {
+        cargo::exit_with_error(err, &mut config.shell());
     }
 }

--- a/crates/cargo-rm/tests/testsuite/cargo_rm/invalid_arg/mod.rs
+++ b/crates/cargo-rm/tests/testsuite/cargo_rm/invalid_arg/mod.rs
@@ -17,7 +17,7 @@ fn case() {
         .args(["foo", "--flag"])
         .current_dir(cwd)
         .assert()
-        .code(2)
+        .code(1)
         .stdout_matches_path(curr_dir!().join("stdout.log"))
         .stderr_matches_path(curr_dir!().join("stderr.log"));
 

--- a/crates/cargo-rm/tests/testsuite/cargo_rm/invalid_dep/mod.rs
+++ b/crates/cargo-rm/tests/testsuite/cargo_rm/invalid_dep/mod.rs
@@ -17,7 +17,7 @@ fn case() {
         .args(["invalid_dependency_name"])
         .current_dir(cwd)
         .assert()
-        .code(1)
+        .code(101)
         .stdout_matches_path(curr_dir!().join("stdout.log"))
         .stderr_matches_path(curr_dir!().join("stderr.log"));
 

--- a/crates/cargo-rm/tests/testsuite/cargo_rm/invalid_dep/stderr.log
+++ b/crates/cargo-rm/tests/testsuite/cargo_rm/invalid_dep/stderr.log
@@ -1,2 +1,2 @@
     Removing invalid_dependency_name from dependencies
-Error: The dependency `invalid_dependency_name` could not be found in `dependencies`.
+error: The dependency `invalid_dependency_name` could not be found in `dependencies`.

--- a/crates/cargo-rm/tests/testsuite/cargo_rm/invalid_rm_target/mod.rs
+++ b/crates/cargo-rm/tests/testsuite/cargo_rm/invalid_rm_target/mod.rs
@@ -17,7 +17,7 @@ fn case() {
         .args(["--target", "powerpc-unknown-linux-gnu", "dbus"])
         .current_dir(cwd)
         .assert()
-        .code(1)
+        .code(101)
         .stdout_matches_path(curr_dir!().join("stdout.log"))
         .stderr_matches_path(curr_dir!().join("stderr.log"));
 

--- a/crates/cargo-rm/tests/testsuite/cargo_rm/invalid_rm_target/stderr.log
+++ b/crates/cargo-rm/tests/testsuite/cargo_rm/invalid_rm_target/stderr.log
@@ -1,2 +1,2 @@
     Removing dbus from dependencies for target `powerpc-unknown-linux-gnu`
-Error: The table `powerpc-unknown-linux-gnu` could not be found.
+error: The table `powerpc-unknown-linux-gnu` could not be found.

--- a/crates/cargo-rm/tests/testsuite/cargo_rm/invalid_rm_target_dep/mod.rs
+++ b/crates/cargo-rm/tests/testsuite/cargo_rm/invalid_rm_target_dep/mod.rs
@@ -17,7 +17,7 @@ fn case() {
         .args(["--target", "x86_64-unknown-linux-gnu", "toml"])
         .current_dir(cwd)
         .assert()
-        .code(1)
+        .code(101)
         .stdout_matches_path(curr_dir!().join("stdout.log"))
         .stderr_matches_path(curr_dir!().join("stderr.log"));
 

--- a/crates/cargo-rm/tests/testsuite/cargo_rm/invalid_rm_target_dep/stderr.log
+++ b/crates/cargo-rm/tests/testsuite/cargo_rm/invalid_rm_target_dep/stderr.log
@@ -1,2 +1,2 @@
     Removing toml from dependencies for target `x86_64-unknown-linux-gnu`
-Error: The dependency `toml` could not be found in `target.x86_64-unknown-linux-gnu.dependencies`.
+error: The dependency `toml` could not be found in `target.x86_64-unknown-linux-gnu.dependencies`.

--- a/crates/cargo-rm/tests/testsuite/cargo_rm/invalid_section/mod.rs
+++ b/crates/cargo-rm/tests/testsuite/cargo_rm/invalid_section/mod.rs
@@ -17,7 +17,7 @@ fn case() {
         .args(["--build", "semver"])
         .current_dir(cwd)
         .assert()
-        .code(1)
+        .code(101)
         .stdout_matches_path(curr_dir!().join("stdout.log"))
         .stderr_matches_path(curr_dir!().join("stderr.log"));
 

--- a/crates/cargo-rm/tests/testsuite/cargo_rm/invalid_section/stderr.log
+++ b/crates/cargo-rm/tests/testsuite/cargo_rm/invalid_section/stderr.log
@@ -1,2 +1,2 @@
     Removing semver from build-dependencies
-Error: The table `build-dependencies` could not be found.
+error: The table `build-dependencies` could not be found.

--- a/crates/cargo-rm/tests/testsuite/cargo_rm/invalid_section_dep/mod.rs
+++ b/crates/cargo-rm/tests/testsuite/cargo_rm/invalid_section_dep/mod.rs
@@ -17,7 +17,7 @@ fn case() {
         .args(["--dev", "semver", "regex"])
         .current_dir(cwd)
         .assert()
-        .code(1)
+        .code(101)
         .stdout_matches_path(curr_dir!().join("stdout.log"))
         .stderr_matches_path(curr_dir!().join("stderr.log"));
 

--- a/crates/cargo-rm/tests/testsuite/cargo_rm/invalid_section_dep/stderr.log
+++ b/crates/cargo-rm/tests/testsuite/cargo_rm/invalid_section_dep/stderr.log
@@ -1,2 +1,2 @@
     Removing semver from dev-dependencies
-Error: The dependency `semver` could not be found in `dev-dependencies`.
+error: The dependency `semver` could not be found in `dev-dependencies`.

--- a/crates/cargo-rm/tests/testsuite/cargo_rm/no_arg/mod.rs
+++ b/crates/cargo-rm/tests/testsuite/cargo_rm/no_arg/mod.rs
@@ -16,7 +16,7 @@ fn case() {
         .arg("rm")
         .current_dir(cwd)
         .assert()
-        .code(2)
+        .code(1)
         .stdout_matches_path(curr_dir!().join("stdout.log"))
         .stderr_matches_path(curr_dir!().join("stderr.log"));
 


### PR DESCRIPTION
This PR converts rm's arg parsing to clap builder with minimal changes to functionality. After this is merged, I will start working on using more cargo internals in the argument parsing, which will have more noticeable effects.