### PR TITLE
Use utils from cargo add

### DIFF
--- a/crates/cargo-remove/src/bin/cargo/commands/remove.rs
+++ b/crates/cargo-remove/src/bin/cargo/commands/remove.rs
@@ -1,7 +1,7 @@
+use cargo::core::dependency::DepKind;
 use cargo::util::command_prelude::*;
 
 use cargo_remove::ops::cargo_remove::remove;
-use cargo_remove::ops::cargo_remove::DepKind;
 use cargo_remove::ops::cargo_remove::DepTable;
 use cargo_remove::ops::cargo_remove::RemoveOptions;
 

--- a/crates/cargo-remove/src/cargo/ops/cargo_remove/manifest.rs
+++ b/crates/cargo-remove/src/cargo/ops/cargo_remove/manifest.rs
@@ -365,6 +365,28 @@ impl LocalManifest {
         Ok(())
     }
 
+    /// Remove entry from a Cargo.toml.
+    pub fn remove_from_table(&mut self, table_path: &[String], name: &str) -> CargoResult<()> {
+        let parent_table = self.get_table_mut(table_path)?;
+
+        {
+            let dep = parent_table
+                .get_mut(name)
+                .filter(|t| !t.is_none())
+                .ok_or_else(|| non_existent_dependency_err(name, table_path.join(".")))?;
+
+            // remove the dependency
+            *dep = toml_edit::Item::None;
+        }
+
+        // remove table if empty
+        if parent_table.as_table_like().unwrap().is_empty() {
+            *parent_table = toml_edit::Item::None;
+        }
+
+        Ok(())
+    }
+
     /// Remove references to `dep_key` if its no longer present
     pub fn gc_dep(&mut self, dep_key: &str) {
         let explicit_dep_activation = self.is_explicit_dep_activation(dep_key);
@@ -513,4 +535,15 @@ fn parse_manifest_err() -> anyhow::Error {
 
 fn non_existent_table_err(table: impl std::fmt::Display) -> anyhow::Error {
     anyhow::format_err!("the table `{table}` could not be found.")
+}
+
+fn non_existent_dependency_err(
+    name: impl std::fmt::Display,
+    table: impl std::fmt::Display,
+) -> anyhow::Error {
+    anyhow::format_err!(
+        "The dependency `{}` could not be found in `{}`.",
+        name,
+        table,
+    )
 }

--- a/crates/cargo-remove/src/cargo/ops/cargo_remove/manifest.rs
+++ b/crates/cargo-remove/src/cargo/ops/cargo_remove/manifest.rs
@@ -1,24 +1,14 @@
-use std::fs;
 use std::ops::{Deref, DerefMut};
 use std::path::{Path, PathBuf};
-use std::{env, str};
+use std::str;
 
-use anyhow::Context;
+use anyhow::Context as _;
+
+use super::dependency::Dependency;
+use cargo::core::dependency::DepKind;
+use cargo::core::FeatureValue;
+use cargo::util::interning::InternedString;
 use cargo::CargoResult;
-use semver::Version;
-
-use super::metadata::find_manifest_path;
-
-/// The kind of dependency, i.e. what section it belongs to
-#[derive(PartialEq, Eq, Hash, Ord, PartialOrd, Clone, Debug, Copy)]
-pub enum DepKind {
-    /// A dependency in the "dependencies" section
-    Normal,
-    /// A dependency in the "dev-dependencies" section
-    Development,
-    /// A dependency in the "build-dependencies" section
-    Build,
-}
 
 /// Dependency table to add dep to
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -52,6 +42,16 @@ impl DepTable {
     pub fn set_target(mut self, target: impl Into<String>) -> Self {
         self.target = Some(target.into());
         self
+    }
+
+    /// Type of dependency
+    pub fn kind(&self) -> DepKind {
+        self.kind
+    }
+
+    /// Platform for the dependency
+    pub fn target(&self) -> Option<&str> {
+        self.target.as_deref()
     }
 
     /// Keys to the table
@@ -92,21 +92,72 @@ pub struct Manifest {
 }
 
 impl Manifest {
+    /// Get the manifest's package name
+    pub fn package_name(&self) -> CargoResult<&str> {
+        self.data
+            .as_table()
+            .get("package")
+            .and_then(|m| m.get("name"))
+            .and_then(|m| m.as_str())
+            .ok_or_else(parse_manifest_err)
+    }
+
     /// Get the specified table from the manifest.
-    ///
-    /// If there is no table at the specified path, then a non-existent table
-    /// error will be returned.
-    pub(crate) fn get_table_mut<'a>(
+    pub fn get_table<'a>(&'a self, table_path: &[String]) -> CargoResult<&'a toml_edit::Item> {
+        /// Descend into a manifest until the required table is found.
+        fn descend<'a>(
+            input: &'a toml_edit::Item,
+            path: &[String],
+        ) -> CargoResult<&'a toml_edit::Item> {
+            if let Some(segment) = path.get(0) {
+                let value = input
+                    .get(&segment)
+                    .ok_or_else(|| non_existent_table_err(segment))?;
+
+                if value.is_table_like() {
+                    descend(value, &path[1..])
+                } else {
+                    Err(non_existent_table_err(segment))
+                }
+            } else {
+                Ok(input)
+            }
+        }
+
+        descend(self.data.as_item(), table_path)
+    }
+
+    /// Get the specified table from the manifest.
+    pub fn get_table_mut<'a>(
         &'a mut self,
         table_path: &[String],
     ) -> CargoResult<&'a mut toml_edit::Item> {
-        self.get_table_mut_internal(table_path, false)
+        /// Descend into a manifest until the required table is found.
+        fn descend<'a>(
+            input: &'a mut toml_edit::Item,
+            path: &[String],
+        ) -> CargoResult<&'a mut toml_edit::Item> {
+            if let Some(segment) = path.get(0) {
+                let mut default_table = toml_edit::Table::new();
+                default_table.set_implicit(true);
+                let value = input[&segment].or_insert(toml_edit::Item::Table(default_table));
+
+                if value.is_table_like() {
+                    descend(value, &path[1..])
+                } else {
+                    Err(non_existent_table_err(segment))
+                }
+            } else {
+                Ok(input)
+            }
+        }
+
+        descend(self.data.as_item_mut(), table_path)
     }
 
-    /// Get all sections in the manifest that exist and might contain
-    /// dependencies. The returned items are always `Table` or
-    /// `InlineTable`.
-    pub(crate) fn get_sections(&self) -> Vec<(DepTable, toml_edit::Item)> {
+    /// Get all sections in the manifest that exist and might contain dependencies.
+    /// The returned items are always `Table` or `InlineTable`.
+    pub fn get_sections(&self) -> Vec<(DepTable, toml_edit::Item)> {
         let mut sections = Vec::new();
 
         for table in DepTable::KINDS {
@@ -145,37 +196,32 @@ impl Manifest {
         sections
     }
 
-    fn get_table_mut_internal<'a>(
-        &'a mut self,
-        table_path: &[String],
-        insert_if_not_exists: bool,
-    ) -> CargoResult<&'a mut toml_edit::Item> {
-        /// Descend into a manifest until the required table is found.
-        fn descend<'a>(
-            input: &'a mut toml_edit::Item,
-            path: &[String],
-            insert_if_not_exists: bool,
-        ) -> CargoResult<&'a mut toml_edit::Item> {
-            if let Some(segment) = path.get(0) {
-                let value = if insert_if_not_exists {
-                    input[&segment].or_insert(toml_edit::table())
-                } else {
-                    input
-                        .get_mut(&segment)
-                        .ok_or_else(|| non_existent_table_err(segment))?
-                };
+    pub fn get_legacy_sections(&self) -> Vec<String> {
+        let mut result = Vec::new();
 
-                if value.is_table_like() {
-                    descend(value, &path[1..], insert_if_not_exists)
-                } else {
-                    Err(non_existent_table_err(segment))
-                }
-            } else {
-                Ok(input)
+        for dependency_type in ["dev_dependencies", "build_dependencies"] {
+            if self.data.contains_key(dependency_type) {
+                result.push(dependency_type.to_owned());
             }
-        }
 
-        descend(self.data.as_item_mut(), table_path, insert_if_not_exists)
+            // ... and in `target.<target>.(build-/dev-)dependencies`.
+            result.extend(
+                self.data
+                    .as_table()
+                    .get("target")
+                    .and_then(toml_edit::Item::as_table_like)
+                    .into_iter()
+                    .flat_map(toml_edit::TableLike::iter)
+                    .filter_map(|(target_name, target_table)| {
+                        if target_table.as_table_like()?.contains_key(dependency_type) {
+                            Some(format!("target.{target_name}.{dependency_type}"))
+                        } else {
+                            None
+                        }
+                    }),
+            );
+        }
+        result
     }
 }
 
@@ -192,8 +238,7 @@ impl str::FromStr for Manifest {
 
 impl std::fmt::Display for Manifest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let s = self.data.to_string();
-        s.fmt(f)
+        self.data.fmt(f)
     }
 }
 
@@ -221,20 +266,12 @@ impl DerefMut for LocalManifest {
 }
 
 impl LocalManifest {
-    /// Construct a `LocalManifest`. If no path is provided, make an educated
-    /// guess as to which one the user means.
-    pub fn find(path: Option<&Path>) -> CargoResult<Self> {
-        let path = dunce::canonicalize(find(path)?)?;
-        Self::try_new(&path)
-    }
-
     /// Construct the `LocalManifest` corresponding to the `Path` provided.
     pub fn try_new(path: &Path) -> CargoResult<Self> {
         if !path.is_absolute() {
             anyhow::bail!("can only edit absolute paths, got {}", path.display());
         }
-        let data =
-            std::fs::read_to_string(&path).with_context(|| "Failed to read manifest contents")?;
+        let data = cargo_util::paths::read(&path)?;
         let manifest = data.parse().context("Unable to parse Cargo.toml")?;
         Ok(LocalManifest {
             manifest,
@@ -249,13 +286,13 @@ impl LocalManifest {
         {
             if self.manifest.data.contains_key("workspace") {
                 anyhow::bail!(
-                    "Found virtual manifest at {}, but this command requires running against an \
+                    "found virtual manifest at {}, but this command requires running against an \
                          actual package in this workspace.",
                     self.path.display()
                 );
             } else {
                 anyhow::bail!(
-                    "Missing expected `package` or `project` fields in {}",
+                    "missing expected `package` or `project` fields in {}",
                     self.path.display()
                 );
             }
@@ -264,119 +301,129 @@ impl LocalManifest {
         let s = self.manifest.data.to_string();
         let new_contents_bytes = s.as_bytes();
 
-        std::fs::write(&self.path, new_contents_bytes).context("Failed to write updated Cargo.toml")
+        cargo_util::paths::write(&self.path, new_contents_bytes)
     }
 
-    /// Remove entry from a Cargo.toml.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    ///   use cargo_remove::ops::cargo_remove::{Dependency, LocalManifest, Manifest, RegistrySource};
-    ///   use toml_edit;
-    ///
-    ///   let root = std::path::PathBuf::from("/").canonicalize().unwrap();
-    ///   let path = root.join("Cargo.toml");
-    ///   let manifest: toml_edit::Document = "
-    ///   [dependencies]
-    ///   cargo-edit = '0.1.0'
-    ///   ".parse().unwrap();
-    ///   let mut manifest = LocalManifest { path, manifest: Manifest { data: manifest } };
-    ///   assert!(manifest.remove_from_table(&["dependencies".to_owned()], "cargo-edit").is_ok());
-    ///   assert!(manifest.remove_from_table(&["dependencies".to_owned()], "cargo-edit").is_err());
-    ///   assert!(!manifest.data.contains_key("dependencies"));
-    /// ```
-    pub fn remove_from_table(&mut self, table_path: &[String], name: &str) -> CargoResult<()> {
-        let parent_table = self.get_table_mut(table_path)?;
+    /// Lookup a dependency
+    pub fn get_dependency_versions<'s>(
+        &'s self,
+        dep_key: &'s str,
+    ) -> impl Iterator<Item = (DepTable, CargoResult<Dependency>)> + 's {
+        let crate_root = self.path.parent().expect("manifest path is absolute");
+        self.get_sections()
+            .into_iter()
+            .filter_map(move |(table_path, table)| {
+                let table = table.into_table().ok()?;
+                Some(
+                    table
+                        .into_iter()
+                        .filter_map(|(key, item)| {
+                            if key.as_str() == dep_key {
+                                Some((table_path.clone(), key, item))
+                            } else {
+                                None
+                            }
+                        })
+                        .collect::<Vec<_>>(),
+                )
+            })
+            .flatten()
+            .map(move |(table_path, dep_key, dep_item)| {
+                let dep = Dependency::from_toml(crate_root, &dep_key, &dep_item);
+                (table_path, dep)
+            })
+    }
 
+    /// Add entry to a Cargo.toml.
+    pub fn insert_into_table(
+        &mut self,
+        table_path: &[String],
+        dep: &Dependency,
+    ) -> CargoResult<()> {
+        let crate_root = self
+            .path
+            .parent()
+            .expect("manifest path is absolute")
+            .to_owned();
+        let dep_key = dep.toml_key();
+
+        let table = self.get_table_mut(table_path)?;
+        if let Some((mut dep_key, dep_item)) = table
+            .as_table_like_mut()
+            .unwrap()
+            .get_key_value_mut(dep_key)
         {
-            let dep = parent_table
-                .get_mut(name)
-                .filter(|t| !t.is_none())
-                .ok_or_else(|| non_existent_dependency_err(name, table_path.join(".")))?;
-            // remove the dependency
-            *dep = toml_edit::Item::None;
+            dep.update_toml(&crate_root, &mut dep_key, dep_item);
+        } else {
+            let new_dependency = dep.to_toml(&crate_root);
+            table[dep_key] = new_dependency;
         }
-
-        // remove table if empty
-        if parent_table.as_table_like().unwrap().is_empty() {
-            *parent_table = toml_edit::Item::None;
+        if let Some(t) = table.as_inline_table_mut() {
+            t.fmt()
         }
 
         Ok(())
     }
 
-    /// Allow mutating depedencies, wherever they live
-    pub fn get_dependency_tables_mut<'r>(
-        &'r mut self,
-    ) -> impl Iterator<Item = &mut dyn toml_edit::TableLike> + 'r {
-        let root = self.data.as_table_mut();
-        root.iter_mut().flat_map(|(k, v)| {
-            if DepTable::KINDS
-                .iter()
-                .any(|kind| kind.kind_table() == k.get())
-            {
-                v.as_table_like_mut().into_iter().collect::<Vec<_>>()
-            } else if k == "target" {
-                v.as_table_like_mut()
-                    .unwrap()
-                    .iter_mut()
-                    .flat_map(|(_, v)| {
-                        v.as_table_like_mut().into_iter().flat_map(|v| {
-                            v.iter_mut().filter_map(|(k, v)| {
-                                if DepTable::KINDS
-                                    .iter()
-                                    .any(|kind| kind.kind_table() == k.get())
-                                {
-                                    v.as_table_like_mut()
-                                } else {
-                                    None
-                                }
-                            })
-                        })
-                    })
-                    .collect::<Vec<_>>()
-            } else {
-                Vec::new()
-            }
-        })
-    }
-
-    /// Override the manifest's version
-    pub fn set_package_version(&mut self, version: &Version) {
-        self.data["package"]["version"] = toml_edit::value(version.to_string());
-    }
-
     /// Remove references to `dep_key` if its no longer present
     pub fn gc_dep(&mut self, dep_key: &str) {
-        let status = self.dep_feature(dep_key);
-        if matches!(status, FeatureStatus::None | FeatureStatus::DepFeature) {
-            if let toml_edit::Item::Table(feature_table) = &mut self.data.as_table_mut()["features"]
-            {
-                for (_feature, mut activated_crates) in feature_table.iter_mut() {
-                    if let toml_edit::Item::Value(toml_edit::Value::Array(feature_activations)) =
-                        &mut activated_crates
-                    {
-                        remove_feature_activation(feature_activations, dep_key, status);
-                    }
+        let explicit_dep_activation = self.is_explicit_dep_activation(dep_key);
+        let status = self.dep_status(dep_key);
+
+        if let Some(toml_edit::Item::Table(feature_table)) =
+            self.data.as_table_mut().get_mut("features")
+        {
+            for (_feature, mut feature_values) in feature_table.iter_mut() {
+                if let toml_edit::Item::Value(toml_edit::Value::Array(feature_values)) =
+                    &mut feature_values
+                {
+                    fix_feature_activations(
+                        feature_values,
+                        dep_key,
+                        status,
+                        explicit_dep_activation,
+                    );
                 }
             }
         }
     }
 
-    fn dep_feature(&self, dep_key: &str) -> FeatureStatus {
-        let mut status = FeatureStatus::None;
+    fn is_explicit_dep_activation(&self, dep_key: &str) -> bool {
+        if let Some(toml_edit::Item::Table(feature_table)) = self.data.as_table().get("features") {
+            for values in feature_table
+                .iter()
+                .map(|(_, a)| a)
+                .filter_map(|i| i.as_value())
+                .filter_map(|v| v.as_array())
+            {
+                for value in values.iter().filter_map(|v| v.as_str()) {
+                    let value = FeatureValue::new(InternedString::new(value));
+                    if let FeatureValue::Dep { dep_name } = &value {
+                        if dep_name.as_str() == dep_key {
+                            return true;
+                        }
+                    }
+                }
+            }
+        }
+
+        false
+    }
+
+    fn dep_status(&self, dep_key: &str) -> DependencyStatus {
+        let mut status = DependencyStatus::None;
         for (_, tbl) in self.get_sections() {
             if let toml_edit::Item::Table(tbl) = tbl {
                 if let Some(dep_item) = tbl.get(dep_key) {
-                    let optional = dep_item.get("optional");
-                    let optional = optional.and_then(|i| i.as_value());
-                    let optional = optional.and_then(|i| i.as_bool());
-                    let optional = optional.unwrap_or(false);
+                    let optional = dep_item
+                        .get("optional")
+                        .and_then(|i| i.as_value())
+                        .and_then(|i| i.as_bool())
+                        .unwrap_or(false);
                     if optional {
-                        return FeatureStatus::Feature;
+                        return DependencyStatus::Optional;
                     } else {
-                        status = FeatureStatus::DepFeature;
+                        status = DependencyStatus::Required;
                     }
                 }
             }
@@ -385,125 +432,85 @@ impl LocalManifest {
     }
 }
 
-#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
-enum FeatureStatus {
-    None,
-    DepFeature,
-    Feature,
+impl std::fmt::Display for LocalManifest {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.manifest.fmt(f)
+    }
 }
 
-fn remove_feature_activation(
-    feature_activations: &mut toml_edit::Array,
-    dep: &str,
-    status: FeatureStatus,
-) {
-    let dep_feature: &str = &format!("{}/", dep);
+#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
+enum DependencyStatus {
+    None,
+    Optional,
+    Required,
+}
 
-    let remove_list: Vec<usize> = feature_activations
+fn fix_feature_activations(
+    feature_values: &mut toml_edit::Array,
+    dep_key: &str,
+    status: DependencyStatus,
+    explicit_dep_activation: bool,
+) {
+    let remove_list: Vec<usize> = feature_values
         .iter()
         .enumerate()
-        .filter_map(|(idx, feature_activation)| {
-            if let toml_edit::Value::String(feature_activation) = feature_activation {
-                let activation = feature_activation.value();
-                match status {
-                    FeatureStatus::None => activation == dep || activation.starts_with(dep_feature),
-                    FeatureStatus::DepFeature => activation == dep,
-                    FeatureStatus::Feature => false,
-                }
-                .then(|| idx)
-            } else {
-                None
+        .filter_map(|(idx, value)| value.as_str().map(|s| (idx, s)))
+        .filter_map(|(idx, value)| {
+            let parsed_value = FeatureValue::new(InternedString::new(value));
+            match status {
+                DependencyStatus::None => match (parsed_value, explicit_dep_activation) {
+                    (FeatureValue::Feature(dep_name), false)
+                    | (FeatureValue::Dep { dep_name }, _)
+                    | (FeatureValue::DepFeature { dep_name, .. }, _) => dep_name == dep_key,
+                    _ => false,
+                },
+                DependencyStatus::Optional => false,
+                DependencyStatus::Required => match (parsed_value, explicit_dep_activation) {
+                    (FeatureValue::Feature(dep_name), false)
+                    | (FeatureValue::Dep { dep_name }, _) => dep_name == dep_key,
+                    (FeatureValue::Feature(_), true) | (FeatureValue::DepFeature { .. }, _) => {
+                        false
+                    }
+                },
             }
+            .then(|| idx)
         })
         .collect();
 
     // Remove found idx in revers order so we don't invalidate the idx.
     for idx in remove_list.iter().rev() {
-        feature_activations.remove(*idx);
+        feature_values.remove(*idx);
     }
-}
 
-/// If a manifest is specified, return that one, otherise perform a manifest
-/// search starting from the current directory.
-/// If a manifest is specified, return that one. If a path is specified, perform
-/// a manifest search starting from there. If nothing is specified, start
-/// searching from the current directory (`cwd`).
-pub fn find(specified: Option<&Path>) -> CargoResult<PathBuf> {
-    match specified {
-        Some(path)
-            if fs::metadata(&path)
-                .with_context(|| "Failed to get cargo file metadata")?
-                .is_file() =>
-        {
-            Ok(path.to_owned())
+    if status == DependencyStatus::Required {
+        for value in feature_values.iter_mut() {
+            let parsed_value = if let Some(value) = value.as_str() {
+                FeatureValue::new(InternedString::new(value))
+            } else {
+                continue;
+            };
+            if let FeatureValue::DepFeature {
+                dep_name,
+                dep_feature,
+                weak,
+            } = parsed_value
+            {
+                if dep_name == dep_key && weak {
+                    *value = format!("{dep_name}/{dep_feature}").into();
+                }
+            }
         }
-        Some(path) => find_manifest_path(path),
-        None => find_manifest_path(
-            &env::current_dir().with_context(|| "Failed to get current directory")?,
-        ),
     }
-}
-
-/// Get a dependency's version from its entry in the dependency table
-pub fn get_dep_version(dep_item: &toml_edit::Item) -> CargoResult<&str> {
-    if let Some(req) = dep_item.as_str() {
-        Ok(req)
-    } else if dep_item.is_table_like() {
-        let version = dep_item
-            .get("version")
-            .ok_or_else(|| anyhow::format_err!("Missing version field"))?;
-        version
-            .as_str()
-            .ok_or_else(|| anyhow::format_err!("Expect version to be a string"))
-    } else {
-        anyhow::bail!("Invalid dependency type");
-    }
-}
-
-/// Set a dependency's version in its entry in the dependency table
-pub fn set_dep_version(dep_item: &mut toml_edit::Item, new_version: &str) -> CargoResult<()> {
-    if dep_item.is_str() {
-        overwrite_value(dep_item, new_version);
-    } else if let Some(table) = dep_item.as_table_like_mut() {
-        let version = table
-            .get_mut("version")
-            .ok_or_else(|| anyhow::format_err!("Missing version field"))?;
-        overwrite_value(version, new_version);
-    } else {
-        anyhow::bail!("Invalid dependency type");
-    }
-    Ok(())
-}
-
-/// Overwrite a value while preserving the original formatting
-fn overwrite_value(item: &mut toml_edit::Item, value: impl Into<toml_edit::Value>) {
-    let mut value = value.into();
-
-    let existing_decor = item
-        .as_value()
-        .map(|v| v.decor().clone())
-        .unwrap_or_default();
-
-    *value.decor_mut() = existing_decor;
-
-    *item = toml_edit::Item::Value(value);
 }
 
 pub fn str_or_1_len_table(item: &toml_edit::Item) -> bool {
     item.is_str() || item.as_table_like().map(|t| t.len() == 1).unwrap_or(false)
 }
 
-fn non_existent_table_err(table: impl std::fmt::Display) -> anyhow::Error {
-    anyhow::format_err!("The table `{}` could not be found.", table)
+fn parse_manifest_err() -> anyhow::Error {
+    anyhow::format_err!("unable to parse external Cargo.toml")
 }
 
-fn non_existent_dependency_err(
-    name: impl std::fmt::Display,
-    table: impl std::fmt::Display,
-) -> anyhow::Error {
-    anyhow::format_err!(
-        "The dependency `{}` could not be found in `{}`.",
-        name,
-        table,
-    )
+fn non_existent_table_err(table: impl std::fmt::Display) -> anyhow::Error {
+    anyhow::format_err!("the table `{table}` could not be found.")
 }

--- a/crates/cargo-remove/src/cargo/ops/cargo_remove/mod.rs
+++ b/crates/cargo-remove/src/cargo/ops/cargo_remove/mod.rs
@@ -10,7 +10,6 @@ use cargo::Config;
 
 pub use self::dependency::Dependency;
 pub use self::dependency::RegistrySource;
-pub use self::manifest::DepKind;
 pub use self::manifest::DepTable;
 pub use self::manifest::LocalManifest;
 pub use self::manifest::Manifest;


### PR DESCRIPTION
This PR adds the changes made to `{dependency,manifest,metadata}.rs` in cargo's cargo add. This is done in two parts: with ec94271 directly copying over the changes and breaking cargo remove with the removal of `remove_from_table` in the process, and with 8fbd033 re-adding that missing function. This is done primarily for the ease of review, so it might be best to squash these two commits.