### PR TITLE
fix(upgrade)!: Exclusively operate on full workspaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,25 +140,20 @@ cargo-upgrade [..]
 Upgrade dependency version requirements in Cargo.toml manifest files
 
 USAGE:
-    cargo upgrade [OPTIONS] [DEP_ID]...
-
-ARGS:
-    <DEP_ID>...    Crates to be upgraded
+    cargo upgrade [OPTIONS]
 
 OPTIONS:
-        --all                     [deprecated in favor of `--workspace`]
         --dry-run                 Print changes to be made without making them
         --exclude <EXCLUDE>       Crates to exclude and not upgrade
     -h, --help                    Print help information
         --locked                  Require `Cargo.toml` to be up to date
         --manifest-path <PATH>    Path to the manifest to upgrade
         --offline                 Run without accessing the network
-    -p, --package <PKGID>         Package id of the crate to add this dependency to
+    -p, --package <PKGID>         Crate to be upgraded
         --pinned                  Upgrade dependencies pinned in the manifest
         --to-lockfile             Upgrade all packages to the version in the lockfile
     -v, --verbose                 Use verbose output
     -V, --version                 Print version information
-        --workspace               Upgrade all packages in the workspace
     -Z <FLAG>                     Unstable (nightly-only) flags
 
 To only update Cargo.lock, see `cargo update`.

--- a/tests/cargo-upgrade/invalid_dep/mod.rs
+++ b/tests/cargo-upgrade/invalid_dep/mod.rs
@@ -14,7 +14,7 @@ fn case() {
 
     snapbox::cmd::Command::cargo_ui()
         .arg("upgrade")
-        .args(["failure"])
+        .args(["--package", "failure"])
         .current_dir(cwd)
         .assert()
         .failure()

--- a/tests/cargo-upgrade/invalid_flag/stderr.log
+++ b/tests/cargo-upgrade/invalid_flag/stderr.log
@@ -3,6 +3,6 @@ error: Found argument '--flag' which wasn't expected, or isn't valid in this con
 	If you tried to supply `--flag` as a value rather than a flag, use `-- --flag`
 
 USAGE:
-    cargo upgrade [OPTIONS] [DEP_ID]...
+    cargo upgrade [OPTIONS]
 
 For more information try --help

--- a/tests/cargo-upgrade/invalid_manifest/stderr.log
+++ b/tests/cargo-upgrade/invalid_manifest/stderr.log
@@ -1,16 +1,13 @@
     Updating '[ROOTURL]/registry' index
-Error: Invalid manifest
+Error: `cargo metadata` exited with an error: error: failed to parse manifest at `[ROOT]/case/Cargo.toml`
 
 Caused by:
-    `cargo metadata` exited with an error: error: failed to parse manifest at `[ROOT]/case/Cargo.toml`
-    
-    Caused by:
-      could not parse input as TOML
-    
-    Caused by:
-      TOML parse error at line 1, column 6
-        |
-      1 | This is clearly not a valid Cargo.toml.
-        |      ^
-      Unexpected `i`
-      Expected `.` or `=`
+  could not parse input as TOML
+
+Caused by:
+  TOML parse error at line 1, column 6
+    |
+  1 | This is clearly not a valid Cargo.toml.
+    |      ^
+  Unexpected `i`
+  Expected `.` or `=`

--- a/tests/cargo-upgrade/invalid_workspace_root_manifest/mod.rs
+++ b/tests/cargo-upgrade/invalid_workspace_root_manifest/mod.rs
@@ -14,7 +14,6 @@ fn case() {
 
     snapbox::cmd::Command::cargo_ui()
         .arg("upgrade")
-        .args(["--workspace"])
         .current_dir(cwd)
         .assert()
         .code(1)

--- a/tests/cargo-upgrade/invalid_workspace_root_manifest/stderr.log
+++ b/tests/cargo-upgrade/invalid_workspace_root_manifest/stderr.log
@@ -1,11 +1,6 @@
     Updating '[ROOTURL]/registry' index
-Error: Invalid manifest
+Error: `cargo metadata` exited with an error: error: failed to parse manifest at `[ROOT]/case/Cargo.toml`
 
 Caused by:
-    `cargo metadata` exited with an error: error: failed to parse manifest at `[ROOT]/case/Cargo.toml`
-    
-    Caused by:
-      could not parse input as TOML
-    
-    Caused by:
+  could not parse input as TOML
 ...

--- a/tests/cargo-upgrade/preserve_precision_major/mod.rs
+++ b/tests/cargo-upgrade/preserve_precision_major/mod.rs
@@ -14,7 +14,7 @@ fn case() {
 
     snapbox::cmd::Command::cargo_ui()
         .arg("upgrade")
-        .args(["--pinned", "--verbose"])
+        .args(["--verbose", "--pinned"])
         .current_dir(cwd)
         .assert()
         .success()

--- a/tests/cargo-upgrade/preserve_precision_minor/mod.rs
+++ b/tests/cargo-upgrade/preserve_precision_minor/mod.rs
@@ -14,7 +14,7 @@ fn case() {
 
     snapbox::cmd::Command::cargo_ui()
         .arg("upgrade")
-        .args(["--pinned", "--verbose"])
+        .args(["--verbose", "--pinned"])
         .current_dir(cwd)
         .assert()
         .success()

--- a/tests/cargo-upgrade/preserve_precision_patch/mod.rs
+++ b/tests/cargo-upgrade/preserve_precision_patch/mod.rs
@@ -14,7 +14,7 @@ fn case() {
 
     snapbox::cmd::Command::cargo_ui()
         .arg("upgrade")
-        .args(["--pinned", "--verbose"])
+        .args(["--verbose", "--pinned"])
         .current_dir(cwd)
         .assert()
         .success()

--- a/tests/cargo-upgrade/specified/mod.rs
+++ b/tests/cargo-upgrade/specified/mod.rs
@@ -14,7 +14,7 @@ fn case() {
 
     snapbox::cmd::Command::cargo_ui()
         .arg("upgrade")
-        .args(["my-package1"])
+        .args(["--package", "my-package1"])
         .current_dir(cwd)
         .assert()
         .success()

--- a/tests/cargo-upgrade/to_lockfile/mod.rs
+++ b/tests/cargo-upgrade/to_lockfile/mod.rs
@@ -14,7 +14,7 @@ fn case() {
 
     snapbox::cmd::Command::cargo_ui()
         .arg("upgrade")
-        .args(["--workspace", "--to-lockfile", "--verbose"])
+        .args(["--to-lockfile", "--verbose"])
         .current_dir(cwd)
         .assert()
         .success()

--- a/tests/cargo-upgrade/to_lockfile/stderr.log
+++ b/tests/cargo-upgrade/to_lockfile/stderr.log
@@ -1,3 +1,7 @@
+    Checking four's dependencies
+name       old req locked latest    new req
+====       ======= ====== ======    =======
+my-package 0.2.0   0.2.3  99999.0.0 0.2.3  
     Checking one's dependencies
 name       old req locked latest    new req
 ====       ======= ====== ======    =======
@@ -8,10 +12,6 @@ name       old req locked latest    new req
 ====       ======= ====== ======    =======
 my-package 0.2.0   0.2.3  99999.0.0 0.2.3  
     Checking two's dependencies
-name       old req locked latest    new req
-====       ======= ====== ======    =======
-my-package 0.2.0   0.2.3  99999.0.0 0.2.3  
-    Checking four's dependencies
 name       old req locked latest    new req
 ====       ======= ====== ======    =======
 my-package 0.2.0   0.2.3  99999.0.0 0.2.3  

--- a/tests/cargo-upgrade/to_version/mod.rs
+++ b/tests/cargo-upgrade/to_version/mod.rs
@@ -14,7 +14,7 @@ fn case() {
 
     snapbox::cmd::Command::cargo_ui()
         .arg("upgrade")
-        .args(["docopt@99999.0.0", "--verbose"])
+        .args(["--package", "docopt@99999.0.0", "--verbose"])
         .current_dir(cwd)
         .assert()
         .success()

--- a/tests/cargo-upgrade/upgrade_all/mod.rs
+++ b/tests/cargo-upgrade/upgrade_all/mod.rs
@@ -14,7 +14,7 @@ fn case() {
 
     snapbox::cmd::Command::cargo_ui()
         .arg("upgrade")
-        .args(["--all", "--verbose"])
+        .args(["--verbose"])
         .current_dir(cwd)
         .assert()
         .success()

--- a/tests/cargo-upgrade/upgrade_all/stderr.log
+++ b/tests/cargo-upgrade/upgrade_all/stderr.log
@@ -1,5 +1,8 @@
-The flag `--all` has been deprecated in favor of `--workspace`
     Updating '[ROOTURL]/registry' index
+    Checking four's dependencies
+name       old req locked latest    new req  
+====       ======= ====== ======    =======  
+my-package 0.2.0   0.2.3  99999.0.0 99999.0.0
     Checking one's dependencies
 name       old req locked latest    new req  
 ====       ======= ====== ======    =======  
@@ -10,10 +13,6 @@ name       old req locked latest    new req
 ====       ======= ====== ======    =======  
 my-package 0.2.0   0.2.3  99999.0.0 99999.0.0
     Checking two's dependencies
-name       old req locked latest    new req  
-====       ======= ====== ======    =======  
-my-package 0.2.0   0.2.3  99999.0.0 99999.0.0
-    Checking four's dependencies
 name       old req locked latest    new req  
 ====       ======= ====== ======    =======  
 my-package 0.2.0   0.2.3  99999.0.0 99999.0.0

--- a/tests/cargo-upgrade/upgrade_workspace/mod.rs
+++ b/tests/cargo-upgrade/upgrade_workspace/mod.rs
@@ -14,7 +14,7 @@ fn case() {
 
     snapbox::cmd::Command::cargo_ui()
         .arg("upgrade")
-        .args(["--workspace", "--verbose"])
+        .args(["--verbose"])
         .current_dir(cwd)
         .assert()
         .success()

--- a/tests/cargo-upgrade/upgrade_workspace/stderr.log
+++ b/tests/cargo-upgrade/upgrade_workspace/stderr.log
@@ -1,4 +1,8 @@
     Updating '[ROOTURL]/registry' index
+    Checking four's dependencies
+name       old req locked latest    new req  
+====       ======= ====== ======    =======  
+my-package 0.2.0   0.2.3  99999.0.0 99999.0.0
     Checking one's dependencies
 name       old req locked latest    new req  
 ====       ======= ====== ======    =======  
@@ -9,10 +13,6 @@ name       old req locked latest    new req
 ====       ======= ====== ======    =======  
 my-package 0.2.0   0.2.3  99999.0.0 99999.0.0
     Checking two's dependencies
-name       old req locked latest    new req  
-====       ======= ====== ======    =======  
-my-package 0.2.0   0.2.3  99999.0.0 99999.0.0
-    Checking four's dependencies
 name       old req locked latest    new req  
 ====       ======= ====== ======    =======  
 my-package 0.2.0   0.2.3  99999.0.0 99999.0.0

--- a/tests/cargo-upgrade/virtual_manifest/stderr.log
+++ b/tests/cargo-upgrade/virtual_manifest/stderr.log
@@ -1,4 +1,8 @@
     Updating '[ROOTURL]/registry' index
+    Checking four's dependencies
+name       old req locked latest    new req  
+====       ======= ====== ======    =======  
+my-package 0.2.0   0.2.3  99999.0.0 99999.0.0
     Checking one's dependencies
 name       old req locked latest    new req  
 ====       ======= ====== ======    =======  
@@ -9,10 +13,6 @@ name       old req locked latest    new req
 ====       ======= ====== ======    =======  
 my-package 0.2.0   0.2.3  99999.0.0 99999.0.0
     Checking two's dependencies
-name       old req locked latest    new req  
-====       ======= ====== ======    =======  
-my-package 0.2.0   0.2.3  99999.0.0 99999.0.0
-    Checking four's dependencies
 name       old req locked latest    new req  
 ====       ======= ====== ======    =======  
 my-package 0.2.0   0.2.3  99999.0.0 99999.0.0

--- a/tests/cargo-upgrade/workspace_member_cwd/mod.rs
+++ b/tests/cargo-upgrade/workspace_member_cwd/mod.rs
@@ -14,7 +14,7 @@ fn case() {
 
     snapbox::cmd::Command::cargo_ui()
         .arg("upgrade")
-        .args(["my-package"])
+        .args(["--package", "my-package"])
         .current_dir(&cwd)
         .assert()
         .success()

--- a/tests/cargo-upgrade/workspace_member_cwd/out/Cargo.lock
+++ b/tests/cargo-upgrade/workspace_member_cwd/out/Cargo.lock
@@ -6,14 +6,8 @@ version = 3
 name = "four"
 version = "0.1.0"
 dependencies = [
- "my-package 0.1.1+my-package",
+ "my-package",
 ]
-
-[[package]]
-name = "my-package"
-version = "0.1.1+my-package"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61758fedb08b81e9c6967f0661a54feb83fb38eb4bde3614119fbc1d03c1cedf"
 
 [[package]]
 name = "my-package"
@@ -25,7 +19,7 @@ checksum = "62c45acf9e11d2f97f5b318143219c0b4102eafef1c22a4b545b47104691d915"
 name = "one"
 version = "0.1.0"
 dependencies = [
- "my-package 99999.0.0+my-package",
+ "my-package",
  "three",
 ]
 
@@ -33,12 +27,12 @@ dependencies = [
 name = "three"
 version = "0.1.0"
 dependencies = [
- "my-package 0.1.1+my-package",
+ "my-package",
 ]
 
 [[package]]
 name = "two"
 version = "0.1.0"
 dependencies = [
- "my-package 0.1.1+my-package",
+ "my-package",
 ]

--- a/tests/cargo-upgrade/workspace_member_cwd/out/explicit/four/Cargo.toml
+++ b/tests/cargo-upgrade/workspace_member_cwd/out/explicit/four/Cargo.toml
@@ -6,4 +6,4 @@ version = "0.1.0"
 path = "../../dummy.rs"
 
 [dependencies]
-my-package = "0.1.1"
+my-package = "99999.0.0"

--- a/tests/cargo-upgrade/workspace_member_cwd/out/implicit/three/Cargo.toml
+++ b/tests/cargo-upgrade/workspace_member_cwd/out/implicit/three/Cargo.toml
@@ -6,4 +6,4 @@ version = "0.1.0"
 path = "../../dummy.rs"
 
 [dependencies]
-my-package = "0.1.1"
+my-package = "99999.0.0"

--- a/tests/cargo-upgrade/workspace_member_cwd/out/two/Cargo.toml
+++ b/tests/cargo-upgrade/workspace_member_cwd/out/two/Cargo.toml
@@ -7,4 +7,4 @@ name = "two"
 path = "../dummy.rs"
 
 [dependencies]
-my-package = "0.1.1"
+my-package = "99999.0.0"

--- a/tests/cargo-upgrade/workspace_member_cwd/stderr.log
+++ b/tests/cargo-upgrade/workspace_member_cwd/stderr.log
@@ -1,5 +1,17 @@
     Updating '[ROOTURL]/registry' index
+    Checking four's dependencies
+name       old req locked latest    new req  
+====       ======= ====== ======    =======  
+my-package 0.1.1   0.1.1  99999.0.0 99999.0.0
     Checking one's dependencies
+name       old req locked latest    new req  
+====       ======= ====== ======    =======  
+my-package 0.1.1   0.1.1  99999.0.0 99999.0.0
+    Checking three's dependencies
+name       old req locked latest    new req  
+====       ======= ====== ======    =======  
+my-package 0.1.1   0.1.1  99999.0.0 99999.0.0
+    Checking two's dependencies
 name       old req locked latest    new req  
 ====       ======= ====== ======    =======  
 my-package 0.1.1   0.1.1  99999.0.0 99999.0.0

--- a/tests/cargo-upgrade/workspace_member_manifest_path/mod.rs
+++ b/tests/cargo-upgrade/workspace_member_manifest_path/mod.rs
@@ -14,7 +14,7 @@ fn case() {
 
     snapbox::cmd::Command::cargo_ui()
         .arg("upgrade")
-        .args(["my-package", "--manifest-path", "Cargo.toml"])
+        .args(["--package", "my-package", "--manifest-path", "Cargo.toml"])
         .current_dir(&cwd)
         .assert()
         .success()

--- a/tests/cargo-upgrade/workspace_member_manifest_path/out/explicit/four/Cargo.toml
+++ b/tests/cargo-upgrade/workspace_member_manifest_path/out/explicit/four/Cargo.toml
@@ -6,4 +6,4 @@ version = "0.1.5"
 path = "../../dummy.rs"
 
 [dependencies]
-my-package = "0.2.0"
+my-package = "99999.0.0"

--- a/tests/cargo-upgrade/workspace_member_manifest_path/out/implicit/three/Cargo.toml
+++ b/tests/cargo-upgrade/workspace_member_manifest_path/out/implicit/three/Cargo.toml
@@ -6,4 +6,4 @@ version = "0.1.5"
 path = "../../dummy.rs"
 
 [dependencies]
-my-package = "0.2.0"
+my-package = "99999.0.0"

--- a/tests/cargo-upgrade/workspace_member_manifest_path/out/two/Cargo.toml
+++ b/tests/cargo-upgrade/workspace_member_manifest_path/out/two/Cargo.toml
@@ -7,4 +7,4 @@ name = "two"
 path = "../dummy.rs"
 
 [dependencies]
-my-package = "0.2.0"
+my-package = "99999.0.0"

--- a/tests/cargo-upgrade/workspace_member_manifest_path/stderr.log
+++ b/tests/cargo-upgrade/workspace_member_manifest_path/stderr.log
@@ -1,5 +1,17 @@
     Updating '[ROOTURL]/registry' index
+    Checking four's dependencies
+name       old req locked latest    new req  
+====       ======= ====== ======    =======  
+my-package 0.2.0   0.2.3  99999.0.0 99999.0.0
     Checking one's dependencies
+name       old req locked latest    new req  
+====       ======= ====== ======    =======  
+my-package 0.2.0   0.2.3  99999.0.0 99999.0.0
+    Checking three's dependencies
+name       old req locked latest    new req  
+====       ======= ====== ======    =======  
+my-package 0.2.0   0.2.3  99999.0.0 99999.0.0
+    Checking two's dependencies
 name       old req locked latest    new req  
 ====       ======= ====== ======    =======  
 my-package 0.2.0   0.2.3  99999.0.0 99999.0.0


### PR DESCRIPTION
This came from the internals discussion on what `cargo upgrade` should look like in cargo.

See https://internals.rust-lang.org/t/feedback-on-cargo-upgrade-to-prepare-it-for-merging/17101

Benefits
- Removes the UI conflict in selecting manifests to edit and selecting dependencies to upgrade
- Will work naturally with `[workspace.dependencies]`
- If we merge `upgrade` into `update` or supersede it, we'll already be aligned on behavior