### PR TITLE
feat(upgrade): Add --recursive=<bool> flag 

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,17 +143,18 @@ USAGE:
     cargo upgrade [OPTIONS]
 
 OPTIONS:
-        --dry-run                 Print changes to be made without making them
-        --exclude <EXCLUDE>       Crates to exclude and not upgrade
-    -h, --help                    Print help information
-        --locked                  Require `Cargo.toml` to be up to date
-        --manifest-path <PATH>    Path to the manifest to upgrade
-        --offline                 Run without accessing the network
-    -p, --package <PKGID>         Crate to be upgraded
-        --pinned                  Upgrade dependencies pinned in the manifest
-    -v, --verbose                 Use verbose output
-    -V, --version                 Print version information
-    -Z <FLAG>                     Unstable (nightly-only) flags
+        --dry-run                   Print changes to be made without making them
+        --exclude <EXCLUDE>         Crates to exclude and not upgrade
+    -h, --help                      Print help information
+        --locked                    Require `Cargo.toml` to be up to date
+        --manifest-path <PATH>      Path to the manifest to upgrade
+        --offline                   Run without accessing the network
+    -p, --package <PKGID>           Crate to be upgraded
+        --pinned                    Upgrade dependencies pinned in the manifest
+        --recursive <true|false>    Recursively update locked dependencies [default: true]
+    -v, --verbose                   Use verbose output
+    -V, --version                   Print version information
+    -Z <FLAG>                       Unstable (nightly-only) flags
 
 ```
 

--- a/src/bin/upgrade/upgrade.rs
+++ b/src/bin/upgrade/upgrade.rs
@@ -259,7 +259,9 @@ fn exec(args: UpgradeArgs) -> CargoResult<()> {
         if args.locked {
             anyhow::bail!("cannot upgrade due to `--locked`");
         } else {
-            resolve_ws(Some(&manifest_path), args.locked, args.offline)?;
+            // If we're going to request an update, it would have already been done by now
+            let offline = true;
+            resolve_ws(Some(&manifest_path), args.locked, offline)?;
         }
     }
 

--- a/src/bin/upgrade/upgrade.rs
+++ b/src/bin/upgrade/upgrade.rs
@@ -33,6 +33,10 @@ pub struct UpgradeArgs {
     #[clap(long)]
     dry_run: bool,
 
+    /// Recursively update locked dependencies
+    #[clap(long, value_name = "true|false", default_value_t = true, action = clap::ArgAction::Set, hide_possible_values = true)]
+    recursive: bool,
+
     /// Upgrade dependencies pinned in the manifest.
     #[clap(long)]
     pinned: bool,
@@ -258,6 +262,28 @@ fn exec(args: UpgradeArgs) -> CargoResult<()> {
     if any_crate_modified {
         if args.locked {
             anyhow::bail!("cannot upgrade due to `--locked`");
+        } else if args.recursive {
+            let mut cmd = std::process::Command::new("cargo");
+            cmd.arg("update");
+            cmd.arg("--manifest-path").arg(&manifest_path);
+            if args.locked {
+                cmd.arg("--locked");
+            }
+            if !selected_dependencies.is_empty() {
+                cmd.arg("--aggressive"); // without `--package` it already is recursive
+                for dep in selected_dependencies.keys() {
+                    cmd.arg("--package").arg(dep);
+                }
+            }
+            // If we're going to request an update, it would have already been done by now
+            cmd.arg("--offline");
+            let output = cmd.output()?;
+            if !output.status.success() {
+                return Err(
+                    anyhow::format_err!("{}", String::from_utf8_lossy(&output.stdout))
+                        .context("recursive dependency update failed"),
+                );
+            }
         } else {
             // If we're going to request an update, it would have already been done by now
             let offline = true;


### PR DESCRIPTION
In the spirit of seeing how `cargo upgrade` could replace `cargo
update`, this is another take on the `--aggresive` flag, controlling how
we handle indirect dependencies in the lock file.