### PR TITLE
fix(upgrade): Don't touch lockfile in dry-run

### DIFF
--- a/src/bin/upgrade/upgrade.rs
+++ b/src/bin/upgrade/upgrade.rs
@@ -275,7 +275,7 @@ fn exec(args: UpgradeArgs) -> CargoResult<()> {
         }
     }
 
-    if !modified_crates.is_empty() {
+    if !modified_crates.is_empty() && !args.dry_run {
         if args.locked {
             anyhow::bail!("cannot upgrade due to `--locked`");
         } else {

--- a/tests/cargo-upgrade/dry_run/stderr.log
+++ b/tests/cargo-upgrade/dry_run/stderr.log
@@ -3,5 +3,4 @@
 name       old req locked latest    new req  
 ====       ======= ====== ======    =======  
 my-package 0.1.1   0.1.1  99999.0.0 99999.0.0
-   Upgrading recursive dependencies
 warning: aborting upgrade due to dry run


### PR DESCRIPTION
Ideally we'd still report messages but keeping things simple for now.