### PR TITLE
fix(upgrade): Change the values for --compatible and friends

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ The format is based on [Keep a Changelog].
 <!-- next-header -->
 ## Unreleased - ReleaseDate
 
+### Fixes
+
+- Changed `--compatible`, `--incompatible`, and `--pinned` from accepting `true|false` to `allow|ignore` (with aliases for compatibility
+  - While we are still working out how we want to express these options, this at least removes the confusion over `--compatible false` looking like it is the same as `--incompatible`.
+
 ## 0.11.0 - 2022-09-14
 
 This release is another step in our effort to find the appropriate `cargo

--- a/README.md
+++ b/README.md
@@ -153,14 +153,14 @@ OPTIONS:
     -V, --version                 Print version information
 
 VERSION:
-        --compatible [<true|false>...]
-            Upgrade to latest compatible version [default: true]
+        --compatible [<allow|ignore>...]
+            Upgrade to latest compatible version [default: allow]
 
-    -i, --incompatible [<true|false>...]
-            Upgrade to latest incompatible version [default: false]
+    -i, --incompatible [<allow|ignore>...]
+            Upgrade to latest incompatible version [default: ignore]
 
-        --pinned [<true|false>...]
-            Upgrade pinned to latest incompatible version [default: false]
+        --pinned [<allow|ignore>...]
+            Upgrade pinned to latest incompatible version [default: ignore]
 
 DEPENDENCIES:
     -p, --package <PKGID[@<VERSION>]>    Crate to be upgraded


### PR DESCRIPTION
Changed `--compatible`, `--incompatible`, and `--pinned` from accepting `true|false` to `allow|ignore` (with aliases for compatibility

While we are still working out how we want to express these options, this at least removes the confusion over `--compatible false` looking like it is the same as `--incompatible`.