### PR TITLE
feat(remove): expose and use `DepTable`'s table name

### DIFF
--- a/crates/cargo-remove/src/cargo/ops/cargo_remove/manifest.rs
+++ b/crates/cargo-remove/src/cargo/ops/cargo_remove/manifest.rs
@@ -53,6 +53,14 @@ impl DepTable {
         self.kind
     }
 
+    pub fn kind_table_name(&self) -> &str {
+        match self.kind {
+            DepKind::Normal => "dependencies",
+            DepKind::Development => "dev-dependencies",
+            DepKind::Build => "build-dependencies",
+        }
+    }
+
     /// Platform for the dependency
     pub fn target(&self) -> Option<&str> {
         self.target.as_deref()
@@ -61,17 +69,9 @@ impl DepTable {
     /// Keys to the table
     pub fn to_table(&self) -> Vec<&str> {
         if let Some(target) = &self.target {
-            vec!["target", target, self.kind_table()]
+            vec!["target", target, self.kind_table_name()]
         } else {
-            vec![self.kind_table()]
-        }
-    }
-
-    fn kind_table(&self) -> &str {
-        match self.kind {
-            DepKind::Normal => "dependencies",
-            DepKind::Development => "dev-dependencies",
-            DepKind::Build => "build-dependencies",
+            vec![self.kind_table_name()]
         }
     }
 }
@@ -165,7 +165,7 @@ impl Manifest {
         let mut sections = Vec::new();
 
         for table in DepTable::KINDS {
-            let dependency_type = table.kind_table();
+            let dependency_type = table.kind_table_name();
             // Dependencies can be in the three standard sections...
             if self
                 .data

--- a/crates/cargo-remove/src/cargo/ops/cargo_remove/mod.rs
+++ b/crates/cargo-remove/src/cargo/ops/cargo_remove/mod.rs
@@ -45,10 +45,13 @@ pub fn remove(options: &RemoveOptions<'_>) -> CargoResult<()> {
         .dependencies
         .iter()
         .map(|dep| {
-            let section = if dep_table.len() >= 3 {
-                format!("{} for target `{}`", &dep_table[2], &dep_table[1])
-            } else {
-                dep_table[0].clone()
+            let section = {
+                let table_name = options.section.kind_table_name();
+                if let Some(target) = options.section.target() {
+                    format!("{table_name} for target `{target}`")
+                } else {
+                    table_name.to_owned()
+                }
             };
             options
                 .config


### PR DESCRIPTION
Make the `remove` function more readable by using a newly exposed function instead of hardcoded indices.

This is a longstanding nit I forgot about until now as I was reviewing the final draft :)