### PR TITLE
fix(upgrade): Ensure precise updates handled

### DIFF
--- a/src/bin/upgrade/upgrade.rs
+++ b/src/bin/upgrade/upgrade.rs
@@ -442,8 +442,7 @@ fn exec(args: UpgradeArgs) -> CargoResult<()> {
             anyhow::bail!("cannot upgrade due to `--locked`");
         } else {
             // Ensure lock file is updated and collect data for `recursive`
-            let offline = true; // index should already be updated
-            let metadata = resolve_ws(Some(&root_manifest_path), args.locked, offline)?;
+            let metadata = resolve_ws(Some(&root_manifest_path), args.locked, args.offline)?;
             let mut locked = metadata.packages;
 
             let precise_deps = selected_dependencies
@@ -475,11 +474,8 @@ fn exec(args: UpgradeArgs) -> CargoResult<()> {
                         if args.locked {
                             cmd.arg("--locked");
                         }
-                        if args.recursive {
-                            // HACK: Since we'll need to skip this during the official recursive
-                            // check, let's handle it here
-                            cmd.arg("--aggressive");
-                        }
+                        // NOTE: This will skip the official recursive check and we don't
+                        // recursively update its dependencies
                         let dep = format!("{name}@{lock_version}");
                         cmd.arg("--precise").arg(&precise);
                         cmd.arg("--package").arg(dep);

--- a/src/bin/upgrade/upgrade.rs
+++ b/src/bin/upgrade/upgrade.rs
@@ -477,7 +477,7 @@ fn exec(args: UpgradeArgs) -> CargoResult<()> {
                         // NOTE: This will skip the official recursive check and we don't
                         // recursively update its dependencies
                         let dep = format!("{name}@{lock_version}");
-                        cmd.arg("--precise").arg(&precise);
+                        cmd.arg("--precise").arg(precise);
                         cmd.arg("--package").arg(dep);
                         // If we're going to request an update, it would have already been done by now
                         cmd.arg("--offline");

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -54,6 +54,7 @@ impl From<anyhow::Error> for CliError {
 
 impl From<clap::Error> for CliError {
     fn from(err: clap::Error) -> CliError {
+        #[allow(clippy::bool_to_int_with_if)]
         let code = if err.use_stderr() { 1 } else { 0 };
         CliError::new(err.into(), code)
     }

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -146,7 +146,7 @@ impl Manifest {
                     input[&segment].or_insert(toml_edit::table())
                 } else {
                     input
-                        .get_mut(&segment)
+                        .get_mut(segment)
                         .ok_or_else(|| non_existent_table_err(segment))?
                 };
 
@@ -219,7 +219,7 @@ impl LocalManifest {
             anyhow::bail!("can only edit absolute paths, got {}", path.display());
         }
         let data =
-            std::fs::read_to_string(&path).with_context(|| "Failed to read manifest contents")?;
+            std::fs::read_to_string(path).with_context(|| "Failed to read manifest contents")?;
         let manifest = data.parse().context("Unable to parse Cargo.toml")?;
         Ok(LocalManifest {
             manifest,
@@ -449,7 +449,7 @@ fn remove_feature_activation(
 pub fn find(specified: Option<&Path>) -> CargoResult<PathBuf> {
     match specified {
         Some(path)
-            if fs::metadata(&path)
+            if fs::metadata(path)
                 .with_context(|| "Failed to get cargo file metadata")?
                 .is_file() =>
         {


### PR DESCRIPTION
There were two problems
- We can't use `--aggresive` with `--precise`
- We soemtimes need to download new index entries but that failed, causing us our tests to not hit the above bug

Fixes #823