### PR TITLE
fix(upgrade): Coalesce long summaries

### DIFF
--- a/src/bin/upgrade/upgrade.rs
+++ b/src/bin/upgrade/upgrade.rs
@@ -600,11 +600,17 @@ fn exec(args: UpgradeArgs) -> CargoResult<()> {
         for (reason, deps) in categorize {
             use std::fmt::Write;
             write!(&mut note, "\n  {reason}: ")?;
-            for (i, dep) in deps.into_iter().enumerate() {
-                if 0 < i {
-                    note.push_str(", ");
+            if deps.len() <= 3 {
+                for (i, dep) in deps.into_iter().enumerate() {
+                    if 0 < i {
+                        note.push_str(", ");
+                    }
+                    note.push_str(&dep);
                 }
-                note.push_str(&dep);
+            } else {
+                let number = deps.len();
+                let plural = if number == 1 { "" } else { "s" };
+                write!(&mut note, "{number} package{plural}")?;
             }
         }
         shell_note(&note)?;


### PR DESCRIPTION
This is inspired by talks in how to handle MSRV, see rust-lang/cargo#9930.

For now, I coalesce for "longer" lists but maybe we should do it always?