### PR TITLE
fix(upgrade): Hide upgradeable by default 

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ Options:
       --manifest-path <PATH>  Path to the manifest to upgrade
       --offline               Run without accessing the network
       --locked                Require `Cargo.toml` to be up to date
-  -v, --verbose               Use verbose output
+  -v, --verbose...            Use verbose output
   -Z <FLAG>                   Unstable (nightly-only) flags
   -h, --help                  Print help
   -V, --version               Print version

--- a/src/bin/upgrade/upgrade.rs
+++ b/src/bin/upgrade/upgrade.rs
@@ -401,7 +401,7 @@ fn exec(args: UpgradeArgs) -> CargoResult<()> {
                 let new_version_req = new_version_req.unwrap_or_else(|| old_version_req.clone());
 
                 if new_version_req == old_version_req {
-                    reason.get_or_insert(Reason::Unchanged);
+                    reason.get_or_insert(Reason::Latest);
                 } else {
                     set_dep_version(dep_item, &new_version_req)?;
                     crate_modified = true;
@@ -755,7 +755,7 @@ impl Dep {
         if self.req_changed() {
             spec.set_fg(Some(Color::Green));
         }
-        if self.reason.unwrap_or(Reason::Unchanged).is_upgradeable() {
+        if self.reason.unwrap_or(Reason::Latest).is_upgradeable() {
             spec.set_fg(Some(Color::Yellow));
         }
         if let Some(latest_version) = self
@@ -788,7 +788,7 @@ impl Dep {
 
     fn reason_spec(&self) -> ColorSpec {
         let mut spec = ColorSpec::new();
-        if self.reason.unwrap_or(Reason::Unchanged).is_warning() {
+        if self.reason.unwrap_or(Reason::Latest).is_warning() {
             spec.set_fg(Some(Color::Yellow));
         }
         spec
@@ -803,7 +803,7 @@ impl Dep {
             return true;
         }
         if 0 < verbosity {
-            if self.reason.unwrap_or(Reason::Unchanged).is_upgradeable() {
+            if self.reason.unwrap_or(Reason::Latest).is_upgradeable() {
                 return true;
             }
 
@@ -834,7 +834,7 @@ impl Dep {
 
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 enum Reason {
-    Unchanged,
+    Latest,
     Compatible,
     Incompatible,
     Pinned,
@@ -846,7 +846,7 @@ enum Reason {
 impl Reason {
     fn is_upgradeable(&self) -> bool {
         match self {
-            Self::Unchanged => false,
+            Self::Latest => false,
             Self::Compatible => true,
             Self::Incompatible => true,
             Self::Pinned => true,
@@ -858,7 +858,7 @@ impl Reason {
 
     fn is_warning(&self) -> bool {
         match self {
-            Self::Unchanged => false,
+            Self::Latest => false,
             Self::Compatible => false,
             Self::Incompatible => true,
             Self::Pinned => true,
@@ -870,7 +870,7 @@ impl Reason {
 
     fn as_short(&self) -> &'static str {
         match self {
-            Self::Unchanged => "",
+            Self::Latest => "",
             Self::Compatible => "compatible",
             Self::Incompatible => "incompatible",
             Self::Pinned => "pinned",
@@ -882,7 +882,7 @@ impl Reason {
 
     fn as_long(&self) -> &'static str {
         match self {
-            Self::Unchanged => "unchanged",
+            Self::Latest => "latest",
             Self::Compatible => "compatible",
             Self::Incompatible => "incompatible",
             Self::Pinned => "pinned",

--- a/src/bin/upgrade/upgrade.rs
+++ b/src/bin/upgrade/upgrade.rs
@@ -35,8 +35,8 @@ pub struct UpgradeArgs {
     locked: bool,
 
     /// Use verbose output
-    #[arg(short, long)]
-    verbose: bool,
+    #[arg(short, long, action = clap::ArgAction::Count)]
+    verbose: u8,
 
     /// Unstable (nightly-only) flags
     #[arg(short = 'Z', value_name = "FLAG", global = true, value_enum)]
@@ -114,11 +114,15 @@ impl UpgradeArgs {
         exec(self)
     }
 
+    fn is_verbose(&self) -> bool {
+        0 < self.verbose
+    }
+
     fn verbose<F>(&self, mut callback: F) -> CargoResult<()>
     where
         F: FnMut() -> CargoResult<()>,
     {
-        if self.verbose {
+        if self.is_verbose() {
             callback()
         } else {
             Ok(())
@@ -422,7 +426,7 @@ fn exec(args: UpgradeArgs) -> CargoResult<()> {
             }
         }
         if !table.is_empty() {
-            let (interesting, uninteresting) = if args.verbose {
+            let (interesting, uninteresting) = if args.is_verbose() {
                 (table, Vec::new())
             } else {
                 table

--- a/tests/cargo-upgrade/exclude_dep/mod.rs
+++ b/tests/cargo-upgrade/exclude_dep/mod.rs
@@ -20,6 +20,7 @@ fn case() {
             "--exclude",
             "docopt",
             "--verbose",
+            "--verbose",
             "--incompatible",
         ])
         .current_dir(cwd)

--- a/tests/cargo-upgrade/exclude_renamed/mod.rs
+++ b/tests/cargo-upgrade/exclude_renamed/mod.rs
@@ -14,7 +14,13 @@ fn case() {
 
     snapbox::cmd::Command::cargo_ui()
         .arg("upgrade")
-        .args(["--exclude", "regex", "--verbose", "--incompatible"])
+        .args([
+            "--exclude",
+            "regex",
+            "--verbose",
+            "--verbose",
+            "--incompatible",
+        ])
         .current_dir(cwd)
         .assert()
         .success()

--- a/tests/cargo-upgrade/lockfile/mod.rs
+++ b/tests/cargo-upgrade/lockfile/mod.rs
@@ -14,7 +14,7 @@ fn case() {
 
     snapbox::cmd::Command::cargo_ui()
         .arg("upgrade")
-        .args(["--verbose", "--incompatible"])
+        .args(["--verbose", "--verbose", "--incompatible"])
         .current_dir(cwd)
         .assert()
         .success()

--- a/tests/cargo-upgrade/pinned/mod.rs
+++ b/tests/cargo-upgrade/pinned/mod.rs
@@ -14,7 +14,7 @@ fn case() {
 
     snapbox::cmd::Command::cargo_ui()
         .arg("upgrade")
-        .args(["--verbose", "--incompatible"])
+        .args(["--verbose", "--verbose", "--incompatible"])
         .current_dir(cwd)
         .assert()
         .success()

--- a/tests/cargo-upgrade/preserve_op/mod.rs
+++ b/tests/cargo-upgrade/preserve_op/mod.rs
@@ -14,7 +14,7 @@ fn case() {
 
     snapbox::cmd::Command::cargo_ui()
         .arg("upgrade")
-        .args(["--verbose", "--pinned", "--incompatible"])
+        .args(["--verbose", "--verbose", "--pinned", "--incompatible"])
         .current_dir(cwd)
         .assert()
         .success()

--- a/tests/cargo-upgrade/preserve_precision_major/mod.rs
+++ b/tests/cargo-upgrade/preserve_precision_major/mod.rs
@@ -14,7 +14,7 @@ fn case() {
 
     snapbox::cmd::Command::cargo_ui()
         .arg("upgrade")
-        .args(["--verbose", "--pinned", "--incompatible"])
+        .args(["--verbose", "--verbose", "--pinned", "--incompatible"])
         .current_dir(cwd)
         .assert()
         .success()

--- a/tests/cargo-upgrade/preserve_precision_minor/mod.rs
+++ b/tests/cargo-upgrade/preserve_precision_minor/mod.rs
@@ -14,7 +14,7 @@ fn case() {
 
     snapbox::cmd::Command::cargo_ui()
         .arg("upgrade")
-        .args(["--verbose", "--pinned", "--incompatible"])
+        .args(["--verbose", "--verbose", "--pinned", "--incompatible"])
         .current_dir(cwd)
         .assert()
         .success()

--- a/tests/cargo-upgrade/preserve_precision_patch/mod.rs
+++ b/tests/cargo-upgrade/preserve_precision_patch/mod.rs
@@ -14,7 +14,7 @@ fn case() {
 
     snapbox::cmd::Command::cargo_ui()
         .arg("upgrade")
-        .args(["--verbose", "--pinned", "--incompatible"])
+        .args(["--verbose", "--verbose", "--pinned", "--incompatible"])
         .current_dir(cwd)
         .assert()
         .success()

--- a/tests/cargo-upgrade/skip_compatible/mod.rs
+++ b/tests/cargo-upgrade/skip_compatible/mod.rs
@@ -14,7 +14,7 @@ fn case() {
 
     snapbox::cmd::Command::cargo_ui()
         .arg("upgrade")
-        .args(["--verbose"])
+        .args(["--verbose", "--verbose"])
         .current_dir(cwd)
         .assert()
         .success()

--- a/tests/cargo-upgrade/specified/stderr.log
+++ b/tests/cargo-upgrade/specified/stderr.log
@@ -1,3 +1,5 @@
     Updating '[ROOTURL]/registry' index
     Checking cargo-list-test-fixture's dependencies
    Upgrading recursive dependencies
+note: Re-run with `--verbose` to show more dependencies
+  excluded: my-package2

--- a/tests/cargo-upgrade/specified/stdout.log
+++ b/tests/cargo-upgrade/specified/stdout.log
@@ -1,4 +1,3 @@
-name        old req compatible latest    new req note    
-====        ======= ========== ======    ======= ====    
-my-package1 0.1     0.1.1      99999.0.0 99999.0         
-my-package2 0.2     0.2.3      99999.0.0 0.2     excluded
+name        old req compatible latest    new req
+====        ======= ========== ======    =======
+my-package1 0.1     0.1.1      99999.0.0 99999.0

--- a/tests/cargo-upgrade/to_version/mod.rs
+++ b/tests/cargo-upgrade/to_version/mod.rs
@@ -14,7 +14,7 @@ fn case() {
 
     snapbox::cmd::Command::cargo_ui()
         .arg("upgrade")
-        .args(["--package", "docopt@99999.0.0", "--verbose"])
+        .args(["--package", "docopt@99999.0.0", "--verbose", "--verbose"])
         .current_dir(cwd)
         .assert()
         .success()

--- a/tests/cargo-upgrade/upgrade_all/mod.rs
+++ b/tests/cargo-upgrade/upgrade_all/mod.rs
@@ -14,7 +14,7 @@ fn case() {
 
     snapbox::cmd::Command::cargo_ui()
         .arg("upgrade")
-        .args(["--verbose", "--incompatible"])
+        .args(["--verbose", "--verbose", "--incompatible"])
         .current_dir(cwd)
         .assert()
         .success()

--- a/tests/cargo-upgrade/upgrade_everything/stderr.log
+++ b/tests/cargo-upgrade/upgrade_everything/stderr.log
@@ -1,5 +1,5 @@
     Updating '[ROOTURL]/registry' index
     Checking None's dependencies
    Upgrading recursive dependencies
-note: Re-run with `--verbose` to show all dependencies
+note: Re-run with `--verbose` to show more dependencies
   unchanged: serde

--- a/tests/cargo-upgrade/upgrade_everything/stderr.log
+++ b/tests/cargo-upgrade/upgrade_everything/stderr.log
@@ -2,4 +2,4 @@
     Checking None's dependencies
    Upgrading recursive dependencies
 note: Re-run with `--verbose` to show more dependencies
-  unchanged: serde
+  latest: serde

--- a/tests/cargo-upgrade/upgrade_renamed/mod.rs
+++ b/tests/cargo-upgrade/upgrade_renamed/mod.rs
@@ -14,7 +14,7 @@ fn case() {
 
     snapbox::cmd::Command::cargo_ui()
         .arg("upgrade")
-        .args(["--pinned", "--incompatible", "--verbose"])
+        .args(["--pinned", "--incompatible", "--verbose", "--verbose"])
         .current_dir(cwd)
         .assert()
         .success()

--- a/tests/cargo-upgrade/upgrade_verbose/mod.rs
+++ b/tests/cargo-upgrade/upgrade_verbose/mod.rs
@@ -15,7 +15,7 @@ fn case() {
 
     snapbox::cmd::Command::cargo_ui()
         .arg("upgrade")
-        .args(["--pinned", "--incompatible", "--verbose"])
+        .args(["--pinned", "--incompatible", "--verbose", "--verbose"])
         .current_dir(cwd)
         .assert()
         .success()

--- a/tests/cargo-upgrade/upgrade_workspace/mod.rs
+++ b/tests/cargo-upgrade/upgrade_workspace/mod.rs
@@ -14,7 +14,7 @@ fn case() {
 
     snapbox::cmd::Command::cargo_ui()
         .arg("upgrade")
-        .args(["--incompatible", "--verbose"])
+        .args(["--incompatible", "--verbose", "--verbose"])
         .current_dir(cwd)
         .assert()
         .success()

--- a/tests/cargo-upgrade/virtual_manifest/mod.rs
+++ b/tests/cargo-upgrade/virtual_manifest/mod.rs
@@ -18,6 +18,7 @@ fn case() {
             "--manifest-path",
             "Cargo.toml",
             "--verbose",
+            "--verbose",
             "--incompatible",
         ])
         .current_dir(cwd)

--- a/tests/cargo-upgrade/workspace_inheritance/stderr.log
+++ b/tests/cargo-upgrade/workspace_inheritance/stderr.log
@@ -5,5 +5,5 @@
     Checking three's dependencies
     Checking two's dependencies
    Upgrading recursive dependencies
-note: Re-run with `--verbose` to show all dependencies
+note: Re-run with `--verbose` to show more dependencies
   local: three

--- a/tests/cargo-upgrade/workspace_member_cwd/stderr.log
+++ b/tests/cargo-upgrade/workspace_member_cwd/stderr.log
@@ -5,5 +5,5 @@
     Checking three's dependencies
     Checking two's dependencies
    Upgrading recursive dependencies
-note: Re-run with `--verbose` to show all dependencies
+note: Re-run with `--verbose` to show more dependencies
   excluded: three

--- a/tests/cargo-upgrade/workspace_member_manifest_path/stderr.log
+++ b/tests/cargo-upgrade/workspace_member_manifest_path/stderr.log
@@ -5,5 +5,5 @@
     Checking three's dependencies
     Checking two's dependencies
    Upgrading recursive dependencies
-note: Re-run with `--verbose` to show all dependencies
+note: Re-run with `--verbose` to show more dependencies
   excluded: three


### PR DESCRIPTION
`--verbose` is required for these.  The old `--verbose` is now
`--verbose --verbose` (extra verbose).