### PR TITLE
fix(upgrade)!: Default --recursive to --compatible

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ Version:
 Dependencies:
   -p, --package <PKGID[@<VERSION>]>  Crate to be upgraded
       --exclude <PKGID>              Crates to exclude and not upgrade
-      --recursive [<true|false>]     Recursively update locked dependencies [default: true]
+      --recursive [<true|false>]     Recursively update locked dependencies
 
 ```
 

--- a/src/bin/upgrade/upgrade.rs
+++ b/src/bin/upgrade/upgrade.rs
@@ -101,12 +101,11 @@ pub struct UpgradeArgs {
         num_args=0..=1,
         action = clap::ArgAction::Set,
         value_name = "true|false",
-        default_value = "true",
         default_missing_value = "true",
         hide_possible_values = true,
         help_heading = "Dependencies"
     )]
-    recursive: bool,
+    recursive: Option<bool>,
 }
 
 impl UpgradeArgs {
@@ -536,7 +535,7 @@ fn exec(args: UpgradeArgs) -> CargoResult<()> {
             locked = metadata.packages;
         }
 
-        if args.recursive {
+        if args.recursive.unwrap_or_else(|| args.compatible.as_bool()) {
             shell_status("Upgrading", "recursive dependencies")?;
             let mut cmd = std::process::Command::new("cargo");
             cmd.arg("update");

--- a/tests/cargo-upgrade/to_version/stderr.log
+++ b/tests/cargo-upgrade/to_version/stderr.log
@@ -1,3 +1,2 @@
     Updating '[ROOTURL]/registry' index
     Checking cargo-list-test-fixture's dependencies
-   Upgrading recursive dependencies


### PR DESCRIPTION
Recursive dependency updating is compatible dependency updating and we should respect it if users disable compatible upgrades.

See also killercup/cargo-edit#812