### PR TITLE
chore: make git2 and crates-index optional dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,11 +58,11 @@ required-features = ["set-version"]
 [dependencies]
 concolor-control = { version = "0.0.7", default-features = false }
 cargo_metadata = "0.15.4"
-crates-index = "0.19.13"
+crates-index = { version = "0.19.13", optional = true }
 dunce = "1.0"
 env_proxy = "0.4.1"
 anyhow = "1.0"
-git2 = "0.17"
+git2 = { version = "0.17", optional = true }
 hex = "0.4.3"
 home = "0.5.5"
 regex = "1.9.4"
@@ -103,10 +103,11 @@ default = [
 ]
 add = ["cli"]
 rm = ["cli"]
-upgrade = ["cli"]
+upgrade = ["cli", "fetch"]
 set-version = ["cli"]
 cli = ["color", "clap"]
 color = ["concolor-control/auto"]
+fetch = ["crates-index", "git2"]
 test-external-apis = []
 vendored-openssl = ["git2/vendored-openssl"]
 vendored-libgit2 = ["git2/vendored-libgit2"]

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -52,6 +52,7 @@ impl From<anyhow::Error> for CliError {
     }
 }
 
+#[cfg(feature = "clap")]
 impl From<clap::Error> for CliError {
     fn from(err: clap::Error) -> CliError {
         #[allow(clippy::bool_to_int_with_if)]

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -67,6 +67,7 @@ impl From<std::io::Error> for CliError {
     }
 }
 
+#[cfg(feature = "fetch")]
 pub(crate) fn no_crate_err(name: impl Display) -> Error {
     anyhow::format_err!("The crate `{}` could not be found in registry index.", name)
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,6 +26,7 @@ extern crate serde_derive;
 mod crate_spec;
 mod dependency;
 mod errors;
+#[cfg(feature = "fetch")]
 mod fetch;
 mod manifest;
 mod metadata;
@@ -39,6 +40,7 @@ pub use dependency::PathSource;
 pub use dependency::RegistrySource;
 pub use dependency::Source;
 pub use errors::*;
+#[cfg(feature = "fetch")]
 pub use fetch::{
     get_compatible_dependency, get_latest_dependency, update_registry_index, RustVersion,
 };


### PR DESCRIPTION
in addition, This fixes compile error if clap feature is disabled

git2 and crates-index crate has many of dependencies and native dependency but only referenced by fetch module so if I don't want to use the fetch module, I want to omit git2 and crates-index from my dependencies so I made this pull request.