### PR TITLE
restrict feature-specific deps and remove unused deps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,21 +28,6 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ca84f3628370c59db74ee214b3263d58f9aadd9b4fe7e711fd87dc452b7f163"
-dependencies = [
- "anstyle",
- "anstyle-parse",
- "anstyle-query",
- "anstyle-wincon 1.0.2",
- "colorchoice",
- "is-terminal",
- "utf8parse",
-]
-
-[[package]]
-name = "anstream"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1f58811cfac344940f1a400b6e6231ce35171f614f26439e80f8c1465c5cc0c"
@@ -118,16 +103,6 @@ dependencies = [
 
 [[package]]
 name = "anstyle-wincon"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c677ab05e09154296dd37acecd46420c17b9713e8366facafa8fc0885167cf4c"
-dependencies = [
- "anstyle",
- "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "anstyle-wincon"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "58f54d10c6dfa51283a066ceab3ec1ab78d13fae00aa49243a45e4571fb79dfd"
@@ -151,38 +126,6 @@ name = "anyhow"
 version = "1.0.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "86fdf8605db99b54d3cd748a44c6d04df638eb5dafb219b135d0149bd0db01f6"
-
-[[package]]
-name = "assert_cmd"
-version = "2.0.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88903cb14723e4d4003335bb7f8a14f27691649105346a0f0957466c096adfe6"
-dependencies = [
- "anstream 0.3.2",
- "anstyle",
- "bstr",
- "doc-comment",
- "predicates",
- "predicates-core",
- "predicates-tree",
- "wait-timeout",
-]
-
-[[package]]
-name = "assert_fs"
-version = "1.0.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f070617a68e5c2ed5d06ee8dd620ee18fb72b99f6c094bed34cf8ab07c875b48"
-dependencies = [
- "anstream 0.3.2",
- "anstyle",
- "doc-comment",
- "globwalk",
- "predicates",
- "predicates-core",
- "predicates-tree",
- "tempfile",
-]
 
 [[package]]
 name = "async-compression"
@@ -281,7 +224,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40723b8fb387abc38f4f4a37c09073622e41dd12327033091ef8950659e6dc0c"
 dependencies = [
  "memchr",
- "regex-automata",
  "serde",
 ]
 
@@ -317,8 +259,6 @@ name = "cargo-edit"
 version = "0.13.0"
 dependencies = [
  "anyhow",
- "assert_cmd",
- "assert_fs",
  "cargo-test-macro",
  "cargo-test-support",
  "cargo_metadata",
@@ -326,19 +266,14 @@ dependencies = [
  "clap-cargo",
  "concolor-control",
  "dunce",
- "env_proxy",
  "hex",
  "home",
  "indexmap 1.9.3",
  "pathdiff",
- "predicates",
- "regex",
  "semver",
  "serde",
  "serde_derive",
- "serde_json",
  "snapbox 0.6.17",
- "subprocess",
  "tame-index",
  "termcolor",
  "toml 0.7.6",
@@ -378,7 +313,7 @@ dependencies = [
  "flate2",
  "git2",
  "glob",
- "itertools 0.13.0",
+ "itertools",
  "pasetors",
  "regex",
  "serde",
@@ -705,12 +640,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "difflib"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
-
-[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -721,12 +650,6 @@ dependencies = [
  "crypto-common",
  "subtle",
 ]
-
-[[package]]
-name = "doc-comment"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
 
 [[package]]
 name = "dunce"
@@ -782,16 +705,6 @@ dependencies = [
  "sec1",
  "subtle",
  "zeroize",
-]
-
-[[package]]
-name = "env_proxy"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a5019be18538406a43b5419a5501461f0c8b49ea7dfda0cfc32f4e51fc44be1"
-dependencies = [
- "log",
- "url",
 ]
 
 [[package]]
@@ -853,15 +766,6 @@ dependencies = [
  "crc32fast",
  "libz-sys",
  "miniz_oxide",
-]
-
-[[package]]
-name = "float-cmp"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98de4bbd547a563b716d8dfa9aad1cb19bfab00f4fa09a6a4ed21dbcf44ce9c4"
-dependencies = [
- "num-traits",
 ]
 
 [[package]]
@@ -991,17 +895,6 @@ dependencies = [
  "log",
  "regex-automata",
  "regex-syntax",
-]
-
-[[package]]
-name = "globwalk"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93e3af942408868f6934a7b85134a3230832b9977cf66125df2f9edcfce4ddcc"
-dependencies = [
- "bitflags 1.3.2",
- "ignore",
- "walkdir",
 ]
 
 [[package]]
@@ -1288,30 +1181,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "187674a687eed5fe42285b40c6291f9a01517d415fad1c3cbc6a9f778af7fcd4"
 
 [[package]]
-name = "is-terminal"
-version = "0.4.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb0889898416213fab133e1d33a0e5858a48177452750691bde3666d0fdbaf8b"
-dependencies = [
- "hermit-abi 0.3.9",
- "rustix 0.38.37",
- "windows-sys 0.48.0",
-]
-
-[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
-
-[[package]]
-name = "itertools"
-version = "0.10.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
-dependencies = [
- "either",
-]
 
 [[package]]
 name = "itertools"
@@ -1483,15 +1356,6 @@ name = "num-conv"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
-
-[[package]]
-name = "num-traits"
-version = "0.2.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f30b0abd723be7e2ffca1272140fac1a2f084c77ec3e123c192b66af1ee9e6c2"
-dependencies = [
- "autocfg",
-]
 
 [[package]]
 name = "num_cpus"
@@ -1672,37 +1536,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04"
 dependencies = [
  "zerocopy",
-]
-
-[[package]]
-name = "predicates"
-version = "3.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09963355b9f467184c04017ced4a2ba2d75cbcb4e7462690d388233253d4b1a9"
-dependencies = [
- "anstyle",
- "difflib",
- "float-cmp",
- "itertools 0.10.5",
- "normalize-line-endings",
- "predicates-core",
- "regex",
-]
-
-[[package]]
-name = "predicates-core"
-version = "1.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b794032607612e7abeb4db69adb4e33590fa6cf1149e95fd7cb00e634b92f174"
-
-[[package]]
-name = "predicates-tree"
-version = "1.0.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "368ba315fb8c5052ab692e68a0eefec6ec57b23a36959c14496f0b0df2c0cecf"
-dependencies = [
- "predicates-core",
- "termtree",
 ]
 
 [[package]]
@@ -2336,16 +2169,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
-name = "subprocess"
-version = "0.2.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c2e86926081dda636c546d8c5e641661049d7562a68f5488be4a1f7f66f6086"
-dependencies = [
- "libc",
- "winapi",
-]
-
-[[package]]
 name = "subtle"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2438,12 +2261,6 @@ dependencies = [
  "rustix 0.37.23",
  "windows-sys 0.48.0",
 ]
-
-[[package]]
-name = "termtree"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3369f5ac52d5eb6ab48c6b4ffdc8efbcad6b89c765749064ba298f2c68a16a76"
 
 [[package]]
 name = "thiserror"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,17 +65,13 @@ cargo_metadata = "0.15.4"
 # one they want to be used.
 tame-index = { version = "0.13", features = ["sparse", "native-certs", "local"], optional = true }
 dunce = "1.0"
-env_proxy = "0.4.1"
 anyhow = "1.0"
 hex = "0.4.3"
 home = { version = "0.5.5", optional = true }
-regex = "1.9.4"
 serde = { version = "1.0.188", optional = true }
 serde_derive = { version = "1.0.188", optional = true }
-serde_json = "1.0.105"
 clap = { version = "4.4.2", features = ["derive", "wrap_help"], optional = true }
 clap-cargo = "0.12.0"
-subprocess = "0.2.9"
 termcolor = "1.2.0"
 toml = { version = "0.7.6", optional = true }
 toml_edit = "0.19.14"
@@ -88,14 +84,10 @@ features = ["serde"]
 version = "1.0.18"
 
 [dev-dependencies]
-predicates = { version = "3.0.3", features = ["color"] }
-assert_cmd = { version = "2.0.12", features = ["color-auto"] }
-assert_fs = { version = "1.0.13", features = ["color-auto"] }
 trycmd = "0.14.17"
 snapbox = { version = "0.6.9", features = ["cmd", "path"] }
 cargo-test-macro = "0.3"
 cargo-test-support = "0.3"
-url = "2.4.0"
 
 [profile.release]
 panic = "abort"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,25 +63,25 @@ cargo_metadata = "0.15.4"
 # certificates AND native certificates. We want support for both to be
 # present, and then to let the user _select_ through configuration which
 # one they want to be used.
-tame-index = { version = "0.13", features = ["sparse", "native-certs", "local"] }
+tame-index = { version = "0.13", features = ["sparse", "native-certs", "local"], optional = true }
 dunce = "1.0"
 env_proxy = "0.4.1"
 anyhow = "1.0"
 hex = "0.4.3"
-home = "0.5.5"
+home = { version = "0.5.5", optional = true }
 regex = "1.9.4"
-serde = "1.0.188"
-serde_derive = "1.0.188"
+serde = { version = "1.0.188", optional = true }
+serde_derive = { version = "1.0.188", optional = true }
 serde_json = "1.0.105"
 clap = { version = "4.4.2", features = ["derive", "wrap_help"], optional = true }
 clap-cargo = "0.12.0"
 subprocess = "0.2.9"
 termcolor = "1.2.0"
-toml = "0.7.6"
+toml = { version = "0.7.6", optional = true }
 toml_edit = "0.19.14"
-indexmap = "1"
-url = "2.4.0"
-pathdiff = "0.2"
+indexmap = { version = "1", optional = true }
+url = { version = "2.4.0", optional = true }
+pathdiff = { version = "0.2", optional = true }
 
 [dependencies.semver]
 features = ["serde"]
@@ -111,7 +111,17 @@ default = [
 ]
 add = ["cli"]
 rm = ["cli"]
-upgrade = ["cli"]
+upgrade = [
+    "cli",
+    "dep:home",
+    "dep:indexmap",
+    "dep:pathdiff",
+    "dep:serde",
+    "dep:serde_derive",
+    "dep:tame-index",
+    "dep:toml",
+    "dep:url",
+]
 set-version = ["cli"]
 cli = ["color", "clap"]
 color = ["concolor-control/auto"]

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -66,6 +66,7 @@ impl From<std::io::Error> for CliError {
     }
 }
 
+#[cfg(feature = "upgrade")]
 pub(crate) fn no_crate_err(name: impl Display) -> Error {
     anyhow::format_err!("The crate `{}` could not be found in registry index.", name)
 }
@@ -82,6 +83,7 @@ pub(crate) fn non_existent_dependency_err(name: impl Display, table: impl Displa
     )
 }
 
+#[cfg(feature = "upgrade")]
 pub(crate) fn invalid_cargo_config() -> Error {
     anyhow::format_err!("Invalid cargo config")
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,33 +18,41 @@
     unused_qualifications
 )]
 
-#[macro_use]
+#[cfg_attr(feature = "upgrade", macro_use)]
+#[cfg(feature = "upgrade")]
 extern crate serde_derive;
 
 mod crate_spec;
+#[cfg(feature = "upgrade")]
 mod dependency;
 mod errors;
+#[cfg(feature = "upgrade")]
 mod fetch;
+#[cfg(feature = "upgrade")]
 mod index;
 mod manifest;
 mod metadata;
+#[cfg(feature = "upgrade")]
 mod registry;
 mod util;
 mod version;
 
 pub use crate_spec::CrateSpec;
-pub use dependency::Dependency;
-pub use dependency::PathSource;
-pub use dependency::RegistrySource;
-pub use dependency::Source;
+#[cfg(feature = "upgrade")]
+pub use dependency::{Dependency, PathSource, RegistrySource, Source};
 pub use errors::*;
+#[cfg(feature = "upgrade")]
 pub use fetch::{get_compatible_dependency, get_latest_dependency, RustVersion};
+#[cfg(feature = "upgrade")]
 pub use index::*;
 pub use manifest::{find, get_dep_version, set_dep_version, LocalManifest, Manifest};
 pub use metadata::manifest_from_pkgid;
+#[cfg(feature = "upgrade")]
 pub use registry::registry_url;
+#[cfg(feature = "upgrade")]
 pub use util::{
-    colorize_stderr, shell_note, shell_print, shell_status, shell_warn, shell_write_stderr,
-    shell_write_stdout, Color, ColorChoice,
+    colorize_stderr, shell_note, shell_print, shell_write_stderr, shell_write_stdout, Color,
+    ColorChoice,
 };
+pub use util::{shell_status, shell_warn};
 pub use version::{upgrade_requirement, VersionExt};

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -506,6 +506,7 @@ fn overwrite_value(item: &mut toml_edit::Item, value: impl Into<toml_edit::Value
     *item = toml_edit::Item::Value(value);
 }
 
+#[cfg(feature = "upgrade")]
 pub fn str_or_1_len_table(item: &toml_edit::Item) -> bool {
     item.is_str() || item.as_table_like().map(|t| t.len() == 1).unwrap_or(false)
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -14,6 +14,7 @@ pub fn colorize_stderr() -> ColorChoice {
     }
 }
 
+#[cfg(feature = "upgrade")]
 /// Whether to color logged output
 pub fn colorize_stdout() -> ColorChoice {
     if concolor_control::get(concolor_control::Stream::Stdout).color() {
@@ -53,11 +54,13 @@ pub fn shell_warn(message: &str) -> CargoResult<()> {
     shell_print("warning", message, Color::Yellow, false)
 }
 
+#[cfg(feature = "upgrade")]
 /// Print a styled warning message.
 pub fn shell_note(message: &str) -> CargoResult<()> {
     shell_print("note", message, Color::Cyan, false)
 }
 
+#[cfg(feature = "upgrade")]
 /// Print a part of a line with formatting
 pub fn shell_write_stderr(fragment: impl std::fmt::Display, spec: &ColorSpec) -> CargoResult<()> {
     let color_choice = colorize_stderr();
@@ -69,6 +72,7 @@ pub fn shell_write_stderr(fragment: impl std::fmt::Display, spec: &ColorSpec) ->
     Ok(())
 }
 
+#[cfg(feature = "upgrade")]
 /// Print a part of a line with formatting
 pub fn shell_write_stdout(fragment: impl std::fmt::Display, spec: &ColorSpec) -> CargoResult<()> {
     let color_choice = colorize_stdout();


### PR DESCRIPTION
Problem: 

The `upgrade` command has much heavier dependencies than the `set-version` command. For me personally, this crate seems like the best way of doing what `set-version` does, but I ran into issues with the rust version that were entirely down to the deps of `upgrade`.

Solution:

- Put a bunch of code and dependencies behind the `upgrade` feature.
- While doing this I noticed some deps are entirely unused, so I removed them in the second commit