### PR TITLE
Add metadata without bumping

### DIFF
--- a/src/bin/set-version/set_version.rs
+++ b/src/bin/set-version/set_version.rs
@@ -21,10 +21,6 @@ pub struct VersionArgs {
     #[arg(long, group = "ver")]
     bump: Option<BumpLevel>,
 
-    /// Add build id
-    #[arg(long, group = "ver")]
-    build: Option<String>,
-
     /// Specify the version metadata field (e.g. a wrapped libraries version)
     #[arg(short, long)]
     pub metadata: Option<String>,
@@ -99,7 +95,6 @@ fn exec(args: VersionArgs) -> CargoResult<()> {
     let VersionArgs {
         target,
         bump,
-        build,
         metadata,
         manifest_path,
         pkgid,
@@ -113,12 +108,11 @@ fn exec(args: VersionArgs) -> CargoResult<()> {
         unstable_features: _,
     } = args;
 
-    let target = match (target, bump, build) {
-        (None, None, Some(_)) => TargetVersion::Relative(BumpLevel::Release),
-        (None, None, None) => TargetVersion::Unchanged,
-        (None, Some(level), None) => TargetVersion::Relative(level),
-        (Some(version), None, None) => TargetVersion::Absolute(version),
-        _ => unreachable!("clap groups should prevent this"),
+    let target = match (target, bump) {
+        (None, None) => TargetVersion::Unchanged,
+        (None, Some(level)) => TargetVersion::Relative(level),
+        (Some(version), None) => TargetVersion::Absolute(version),
+        (Some(_), Some(_)) => unreachable!("clap groups should prevent this"),
     };
 
     let ws_metadata = resolve_ws(manifest_path.as_deref(), locked, offline)?;

--- a/src/bin/set-version/set_version.rs
+++ b/src/bin/set-version/set_version.rs
@@ -21,6 +21,10 @@ pub struct VersionArgs {
     #[arg(long, group = "ver")]
     bump: Option<BumpLevel>,
 
+    /// Add build id
+    #[arg(long, group = "ver")]
+    build: Option<String>,
+
     /// Specify the version metadata field (e.g. a wrapped libraries version)
     #[arg(short, long)]
     pub metadata: Option<String>,
@@ -95,6 +99,7 @@ fn exec(args: VersionArgs) -> CargoResult<()> {
     let VersionArgs {
         target,
         bump,
+        build,
         metadata,
         manifest_path,
         pkgid,
@@ -108,11 +113,12 @@ fn exec(args: VersionArgs) -> CargoResult<()> {
         unstable_features: _,
     } = args;
 
-    let target = match (target, bump) {
-        (None, None) => TargetVersion::Relative(BumpLevel::Release),
-        (None, Some(level)) => TargetVersion::Relative(level),
-        (Some(version), None) => TargetVersion::Absolute(version),
-        (Some(_), Some(_)) => unreachable!("clap groups should prevent this"),
+    let target = match (target, bump, build) {
+        (None, None, Some(_)) => TargetVersion::Relative(BumpLevel::Release),
+        (None, None, None) => TargetVersion::Unchanged,
+        (None, Some(level), None) => TargetVersion::Relative(level),
+        (Some(version), None, None) => TargetVersion::Absolute(version),
+        _ => unreachable!("clap groups should prevent this"),
     };
 
     let ws_metadata = resolve_ws(manifest_path.as_deref(), locked, offline)?;

--- a/src/bin/set-version/set_version.rs
+++ b/src/bin/set-version/set_version.rs
@@ -108,11 +108,12 @@ fn exec(args: VersionArgs) -> CargoResult<()> {
         unstable_features: _,
     } = args;
 
-    let target = match (target, bump) {
-        (None, None) => TargetVersion::Unchanged,
-        (None, Some(level)) => TargetVersion::Relative(level),
-        (Some(version), None) => TargetVersion::Absolute(version),
-        (Some(_), Some(_)) => unreachable!("clap groups should prevent this"),
+    let target = match (target, bump, &metadata) {
+        (None, None, Some(_)) => TargetVersion::Unchanged,
+        (None, None, None) => TargetVersion::Relative(BumpLevel::Release),
+        (None, Some(level), _) => TargetVersion::Relative(level),
+        (Some(version), None, _) => TargetVersion::Absolute(version),
+        (Some(_), Some(_), _) => unreachable!("clap groups should prevent this"),
     };
 
     let ws_metadata = resolve_ws(manifest_path.as_deref(), locked, offline)?;

--- a/src/bin/set-version/version.rs
+++ b/src/bin/set-version/version.rs
@@ -24,7 +24,6 @@ impl TargetVersion {
                     potential_version.metadata(metadata)?;
                 };
                 Ok(Some(potential_version))
-
             }
             TargetVersion::Relative(bump_level) => {
                 let mut potential_version = current.to_owned();

--- a/src/bin/set-version/version.rs
+++ b/src/bin/set-version/version.rs
@@ -8,6 +8,7 @@ use crate::errors::*;
 pub enum TargetVersion {
     Relative(BumpLevel),
     Absolute(semver::Version),
+    Unchanged,
 }
 
 impl TargetVersion {
@@ -17,6 +18,14 @@ impl TargetVersion {
         metadata: Option<&str>,
     ) -> CargoResult<Option<semver::Version>> {
         match self {
+            TargetVersion::Unchanged => {
+                let mut potential_version = current.to_owned();
+                if let Some(metadata) = metadata {
+                    potential_version.metadata(metadata)?;
+                };
+                Ok(Some(potential_version))
+
+            }
             TargetVersion::Relative(bump_level) => {
                 let mut potential_version = current.to_owned();
                 bump_level.bump_version(&mut potential_version, metadata)?;

--- a/src/version.rs
+++ b/src/version.rs
@@ -289,6 +289,9 @@ mod test {
             let mut v = semver::Version::parse("1.0.0").unwrap();
             v.metadata("git.123456").unwrap();
             assert_eq!(v, semver::Version::parse("1.0.0+git.123456").unwrap());
+            let mut v = semver::Version::parse("1.0.0-dev10").unwrap();
+            v.metadata("git.123456").unwrap();
+            assert_eq!(v, semver::Version::parse("1.0.0-dev10+git.123456").unwrap());
         }
     }
 

--- a/tests/cargo-set-version/main.rs
+++ b/tests/cargo-set-version/main.rs
@@ -12,6 +12,7 @@ mod relative_absolute_conflict;
 mod set_absolute_version;
 mod set_absolute_workspace_version;
 mod set_metadata;
+mod set_relative_release;
 mod set_relative_version;
 mod set_relative_workspace_version;
 mod upgrade_compatible_dependency;

--- a/tests/cargo-set-version/main.rs
+++ b/tests/cargo-set-version/main.rs
@@ -11,6 +11,7 @@ mod ignore_dependent;
 mod relative_absolute_conflict;
 mod set_absolute_version;
 mod set_absolute_workspace_version;
+mod set_metadata;
 mod set_relative_version;
 mod set_relative_workspace_version;
 mod upgrade_compatible_dependency;


### PR DESCRIPTION
I am using cargo-edit to add metadata tags to my version string. For the moment, I am having trouble with adding metadata to version with pre-release tags (ex. 0.1.0-dev). `cargo set-version -m meta`   will remove the pre-release and replace it with the meta tag (0.1.0+meta). 

This MR will fix this behaviour to respect the dev tag, so the correct version will be 0.1.0-dev+meta.

Let me know what you think! (and thanks for making cargo-edit!)