### PR TITLE
feat: incompatible prevents compatible upgrades

### DIFF
--- a/src/bin/upgrade/upgrade.rs
+++ b/src/bin/upgrade/upgrade.rs
@@ -413,8 +413,9 @@ fn exec(args: UpgradeArgs) -> CargoResult<()> {
                                 }
                             };
 
+                        // If incompatible upgrades are allowed, don't allow compatible upgrades
                         if req_candidate.is_some() {
-                            if !args.compatible.as_bool() {
+                            if !args.compatible.as_bool() || args.incompatible.as_bool() {
                                 reason.get_or_insert(Reason::Compatible);
                             } else {
                                 new_version_req = req_candidate;


### PR DESCRIPTION
### Features
- `upgrade --incompatible allow` prevents compatible upgrades (implicit `--compatible ignore`)

### Use Case
When you only want to bump Cargo.toml for incompatible upgrades and let `cargo update` update patches in Cargo.lock.

#### Before
```toml
home = "0.4"
serde = "1.0.0"
```
became
```toml
home = "0.5"
serde = "1.0.1" # compatible bumped
```

#### After
```toml
home = "0.4"
serde = "1.0.0"
```
becomes
```toml
home = "0.5"
serde = "1.0.0" # compatible not bumped
```
