### PR TITLE
fix: propagate cargo metada errors instead of silent --no-deps fallback

### DIFF
--- a/src/bin/set-version/set_version.rs
+++ b/src/bin/set-version/set_version.rs
@@ -348,10 +348,7 @@ fn resolve_ws(
     }
     cmd.other_options(other);
 
-    let ws = cmd.exec().or_else(|_| {
-        cmd.no_deps();
-        cmd.exec()
-    })?;
+    let ws = cmd.exec()?;
     Ok(ws)
 }
 


### PR DESCRIPTION
`resolve_ws()` silently retries with `--no-deps` when cargo metadata fails. This hides errors and causes set-version to skip lockfile updates without any indication of failure.

Remove the `or_else` fallback so errors propagate to the caller.

Fixes #891