### PR TITLE
fix(set-version): reject unmatched package selectors

### DIFF
--- a/src/bin/set-version/set_version.rs
+++ b/src/bin/set-version/set_version.rs
@@ -119,6 +119,23 @@ fn exec(args: VersionArgs) -> CargoResult<()> {
     let root_manifest_path = ws_metadata.workspace_root.as_std_path().join("Cargo.toml");
     let workspace_members = find_ws_members(&ws_metadata);
 
+    let mut missing = Vec::new();
+    for name in &pkgid {
+        let name = name.as_str();
+        if !workspace_members
+            .iter()
+            .any(|package| package.name.as_str() == name)
+            && !missing.contains(&name)
+        {
+            missing.push(name);
+        }
+    }
+    match missing.len() {
+        0 => {}
+        1 => anyhow::bail!("package {} doesn't exist", missing.join(", ")),
+        _ => anyhow::bail!("packages {} don't exist", missing.join(", ")),
+    }
+
     if all {
         shell_warn("The flag `--all` has been deprecated in favor of `--workspace`")?;
     }

--- a/tests/cargo-set-version/main.rs
+++ b/tests/cargo-set-version/main.rs
@@ -5,6 +5,10 @@
 mod downgrade_error;
 mod dry_run;
 mod ignore_dependent;
+mod package_not_found;
+mod package_not_found_mixed;
+mod package_not_found_repeated;
+mod packages_not_found;
 mod relative_absolute_conflict;
 mod set_absolute_version;
 mod set_absolute_workspace_version;

--- a/tests/cargo-set-version/package_not_found/in/Cargo.toml
+++ b/tests/cargo-set-version/package_not_found/in/Cargo.toml
@@ -1,0 +1,9 @@
+[workspace]
+
+[package]
+name = "sample"
+version = "0.1.0"
+edition = "2015"
+
+[lib]
+path = "dummy.rs"

--- a/tests/cargo-set-version/package_not_found/mod.rs
+++ b/tests/cargo-set-version/package_not_found/mod.rs
@@ -16,7 +16,7 @@ fn case() {
         .args(["2.0.0", "--package", "missing"])
         .current_dir(&project_root)
         .assert()
-        .code(0)
+        .code(1)
         .stdout_eq(file!["stdout.term.svg"])
         .stderr_eq(file!["stderr.term.svg"]);
 

--- a/tests/cargo-set-version/package_not_found/mod.rs
+++ b/tests/cargo-set-version/package_not_found/mod.rs
@@ -1,0 +1,24 @@
+use cargo_test_support::Project;
+use cargo_test_support::compare::assert_ui;
+use cargo_test_support::current_dir;
+use cargo_test_support::file;
+use cargo_test_support::prelude::*;
+
+use crate::CargoCommand;
+
+#[cargo_test]
+fn case() {
+    let project = Project::from_template(current_dir!().join("in"));
+    let project_root = project.root();
+
+    snapbox::cmd::Command::cargo_ui()
+        .arg("set-version")
+        .args(["2.0.0", "--package", "missing"])
+        .current_dir(&project_root)
+        .assert()
+        .code(0)
+        .stdout_eq(file!["stdout.term.svg"])
+        .stderr_eq(file!["stderr.term.svg"]);
+
+    assert_ui().subset_matches(current_dir!().join("out"), &project_root);
+}

--- a/tests/cargo-set-version/package_not_found/out/Cargo.toml
+++ b/tests/cargo-set-version/package_not_found/out/Cargo.toml
@@ -1,0 +1,9 @@
+[workspace]
+
+[package]
+name = "sample"
+version = "0.1.0"
+edition = "2015"
+
+[lib]
+path = "dummy.rs"

--- a/tests/cargo-set-version/package_not_found/stderr.term.svg
+++ b/tests/cargo-set-version/package_not_found/stderr.term.svg
@@ -1,0 +1,21 @@
+<svg width="740px" height="20px" xmlns="http://www.w3.org/2000/svg">
+  <style>
+    .fg { fill: #AAAAAA }
+    .bg { fill: #000000 }
+    .container {
+      padding: 0 10px;
+      line-height: 18px;
+    }
+    tspan {
+      font: 14px SFMono-Regular, Consolas, Liberation Mono, Menlo, monospace;
+      white-space: pre;
+      line-height: 18px;
+    }
+  </style>
+
+  <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
+
+  <text xml:space="preserve" class="container fg">
+  </text>
+
+</svg>

--- a/tests/cargo-set-version/package_not_found/stderr.term.svg
+++ b/tests/cargo-set-version/package_not_found/stderr.term.svg
@@ -1,4 +1,4 @@
-<svg width="740px" height="20px" xmlns="http://www.w3.org/2000/svg">
+<svg width="740px" height="56px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
     .bg { fill: #000000 }
@@ -16,6 +16,10 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
+    <tspan x="10px" y="28px"><tspan>Error: package missing doesn't exist</tspan>
+</tspan>
+    <tspan x="10px" y="46px">
+</tspan>
   </text>
 
 </svg>

--- a/tests/cargo-set-version/package_not_found/stdout.term.svg
+++ b/tests/cargo-set-version/package_not_found/stdout.term.svg
@@ -1,0 +1,21 @@
+<svg width="740px" height="20px" xmlns="http://www.w3.org/2000/svg">
+  <style>
+    .fg { fill: #AAAAAA }
+    .bg { fill: #000000 }
+    .container {
+      padding: 0 10px;
+      line-height: 18px;
+    }
+    tspan {
+      font: 14px SFMono-Regular, Consolas, Liberation Mono, Menlo, monospace;
+      white-space: pre;
+      line-height: 18px;
+    }
+  </style>
+
+  <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
+
+  <text xml:space="preserve" class="container fg">
+  </text>
+
+</svg>

--- a/tests/cargo-set-version/package_not_found_mixed/in/Cargo.toml
+++ b/tests/cargo-set-version/package_not_found_mixed/in/Cargo.toml
@@ -1,0 +1,9 @@
+[workspace]
+
+[package]
+name = "sample"
+version = "0.1.0"
+edition = "2015"
+
+[lib]
+path = "dummy.rs"

--- a/tests/cargo-set-version/package_not_found_mixed/mod.rs
+++ b/tests/cargo-set-version/package_not_found_mixed/mod.rs
@@ -1,0 +1,24 @@
+use cargo_test_support::Project;
+use cargo_test_support::compare::assert_ui;
+use cargo_test_support::current_dir;
+use cargo_test_support::file;
+use cargo_test_support::prelude::*;
+
+use crate::CargoCommand;
+
+#[cargo_test]
+fn case() {
+    let project = Project::from_template(current_dir!().join("in"));
+    let project_root = project.root();
+
+    snapbox::cmd::Command::cargo_ui()
+        .arg("set-version")
+        .args(["2.0.0", "--package", "sample", "--package", "missing"])
+        .current_dir(&project_root)
+        .assert()
+        .code(0)
+        .stdout_eq(file!["stdout.term.svg"])
+        .stderr_eq(file!["stderr.term.svg"]);
+
+    assert_ui().subset_matches(current_dir!().join("out"), &project_root);
+}

--- a/tests/cargo-set-version/package_not_found_mixed/mod.rs
+++ b/tests/cargo-set-version/package_not_found_mixed/mod.rs
@@ -16,7 +16,7 @@ fn case() {
         .args(["2.0.0", "--package", "sample", "--package", "missing"])
         .current_dir(&project_root)
         .assert()
-        .code(0)
+        .code(1)
         .stdout_eq(file!["stdout.term.svg"])
         .stderr_eq(file!["stderr.term.svg"]);
 

--- a/tests/cargo-set-version/package_not_found_mixed/out/Cargo.toml
+++ b/tests/cargo-set-version/package_not_found_mixed/out/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "sample"
-version = "2.0.0"
+version = "0.1.0"
 edition = "2015"
 
 [lib]

--- a/tests/cargo-set-version/package_not_found_mixed/out/Cargo.toml
+++ b/tests/cargo-set-version/package_not_found_mixed/out/Cargo.toml
@@ -1,0 +1,9 @@
+[workspace]
+
+[package]
+name = "sample"
+version = "2.0.0"
+edition = "2015"
+
+[lib]
+path = "dummy.rs"

--- a/tests/cargo-set-version/package_not_found_mixed/stderr.term.svg
+++ b/tests/cargo-set-version/package_not_found_mixed/stderr.term.svg
@@ -16,7 +16,7 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan>   Upgrading sample from 0.1.0 to 2.0.0</tspan>
+    <tspan x="10px" y="28px"><tspan>Error: package missing doesn't exist</tspan>
 </tspan>
     <tspan x="10px" y="46px">
 </tspan>

--- a/tests/cargo-set-version/package_not_found_mixed/stderr.term.svg
+++ b/tests/cargo-set-version/package_not_found_mixed/stderr.term.svg
@@ -1,0 +1,25 @@
+<svg width="740px" height="56px" xmlns="http://www.w3.org/2000/svg">
+  <style>
+    .fg { fill: #AAAAAA }
+    .bg { fill: #000000 }
+    .container {
+      padding: 0 10px;
+      line-height: 18px;
+    }
+    tspan {
+      font: 14px SFMono-Regular, Consolas, Liberation Mono, Menlo, monospace;
+      white-space: pre;
+      line-height: 18px;
+    }
+  </style>
+
+  <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
+
+  <text xml:space="preserve" class="container fg">
+    <tspan x="10px" y="28px"><tspan>   Upgrading sample from 0.1.0 to 2.0.0</tspan>
+</tspan>
+    <tspan x="10px" y="46px">
+</tspan>
+  </text>
+
+</svg>

--- a/tests/cargo-set-version/package_not_found_mixed/stdout.term.svg
+++ b/tests/cargo-set-version/package_not_found_mixed/stdout.term.svg
@@ -1,0 +1,21 @@
+<svg width="740px" height="20px" xmlns="http://www.w3.org/2000/svg">
+  <style>
+    .fg { fill: #AAAAAA }
+    .bg { fill: #000000 }
+    .container {
+      padding: 0 10px;
+      line-height: 18px;
+    }
+    tspan {
+      font: 14px SFMono-Regular, Consolas, Liberation Mono, Menlo, monospace;
+      white-space: pre;
+      line-height: 18px;
+    }
+  </style>
+
+  <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
+
+  <text xml:space="preserve" class="container fg">
+  </text>
+
+</svg>

--- a/tests/cargo-set-version/package_not_found_repeated/in/Cargo.toml
+++ b/tests/cargo-set-version/package_not_found_repeated/in/Cargo.toml
@@ -1,0 +1,9 @@
+[workspace]
+
+[package]
+name = "sample"
+version = "0.1.0"
+edition = "2015"
+
+[lib]
+path = "dummy.rs"

--- a/tests/cargo-set-version/package_not_found_repeated/mod.rs
+++ b/tests/cargo-set-version/package_not_found_repeated/mod.rs
@@ -1,0 +1,24 @@
+use cargo_test_support::Project;
+use cargo_test_support::compare::assert_ui;
+use cargo_test_support::current_dir;
+use cargo_test_support::file;
+use cargo_test_support::prelude::*;
+
+use crate::CargoCommand;
+
+#[cargo_test]
+fn case() {
+    let project = Project::from_template(current_dir!().join("in"));
+    let project_root = project.root();
+
+    snapbox::cmd::Command::cargo_ui()
+        .arg("set-version")
+        .args(["2.0.0", "-p", "missing", "-p", "missing"])
+        .current_dir(&project_root)
+        .assert()
+        .code(0)
+        .stdout_eq(file!["stdout.term.svg"])
+        .stderr_eq(file!["stderr.term.svg"]);
+
+    assert_ui().subset_matches(current_dir!().join("out"), &project_root);
+}

--- a/tests/cargo-set-version/package_not_found_repeated/mod.rs
+++ b/tests/cargo-set-version/package_not_found_repeated/mod.rs
@@ -16,7 +16,7 @@ fn case() {
         .args(["2.0.0", "-p", "missing", "-p", "missing"])
         .current_dir(&project_root)
         .assert()
-        .code(0)
+        .code(1)
         .stdout_eq(file!["stdout.term.svg"])
         .stderr_eq(file!["stderr.term.svg"]);
 

--- a/tests/cargo-set-version/package_not_found_repeated/out/Cargo.toml
+++ b/tests/cargo-set-version/package_not_found_repeated/out/Cargo.toml
@@ -1,0 +1,9 @@
+[workspace]
+
+[package]
+name = "sample"
+version = "0.1.0"
+edition = "2015"
+
+[lib]
+path = "dummy.rs"

--- a/tests/cargo-set-version/package_not_found_repeated/stderr.term.svg
+++ b/tests/cargo-set-version/package_not_found_repeated/stderr.term.svg
@@ -1,0 +1,21 @@
+<svg width="740px" height="20px" xmlns="http://www.w3.org/2000/svg">
+  <style>
+    .fg { fill: #AAAAAA }
+    .bg { fill: #000000 }
+    .container {
+      padding: 0 10px;
+      line-height: 18px;
+    }
+    tspan {
+      font: 14px SFMono-Regular, Consolas, Liberation Mono, Menlo, monospace;
+      white-space: pre;
+      line-height: 18px;
+    }
+  </style>
+
+  <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
+
+  <text xml:space="preserve" class="container fg">
+  </text>
+
+</svg>

--- a/tests/cargo-set-version/package_not_found_repeated/stderr.term.svg
+++ b/tests/cargo-set-version/package_not_found_repeated/stderr.term.svg
@@ -1,4 +1,4 @@
-<svg width="740px" height="20px" xmlns="http://www.w3.org/2000/svg">
+<svg width="740px" height="56px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
     .bg { fill: #000000 }
@@ -16,6 +16,10 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
+    <tspan x="10px" y="28px"><tspan>Error: package missing doesn't exist</tspan>
+</tspan>
+    <tspan x="10px" y="46px">
+</tspan>
   </text>
 
 </svg>

--- a/tests/cargo-set-version/package_not_found_repeated/stdout.term.svg
+++ b/tests/cargo-set-version/package_not_found_repeated/stdout.term.svg
@@ -1,0 +1,21 @@
+<svg width="740px" height="20px" xmlns="http://www.w3.org/2000/svg">
+  <style>
+    .fg { fill: #AAAAAA }
+    .bg { fill: #000000 }
+    .container {
+      padding: 0 10px;
+      line-height: 18px;
+    }
+    tspan {
+      font: 14px SFMono-Regular, Consolas, Liberation Mono, Menlo, monospace;
+      white-space: pre;
+      line-height: 18px;
+    }
+  </style>
+
+  <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
+
+  <text xml:space="preserve" class="container fg">
+  </text>
+
+</svg>

--- a/tests/cargo-set-version/packages_not_found/in/Cargo.toml
+++ b/tests/cargo-set-version/packages_not_found/in/Cargo.toml
@@ -1,0 +1,9 @@
+[workspace]
+
+[package]
+name = "sample"
+version = "0.1.0"
+edition = "2015"
+
+[lib]
+path = "dummy.rs"

--- a/tests/cargo-set-version/packages_not_found/mod.rs
+++ b/tests/cargo-set-version/packages_not_found/mod.rs
@@ -1,0 +1,30 @@
+use cargo_test_support::Project;
+use cargo_test_support::compare::assert_ui;
+use cargo_test_support::current_dir;
+use cargo_test_support::file;
+use cargo_test_support::prelude::*;
+
+use crate::CargoCommand;
+
+#[cargo_test]
+fn case() {
+    let project = Project::from_template(current_dir!().join("in"));
+    let project_root = project.root();
+
+    snapbox::cmd::Command::cargo_ui()
+        .arg("set-version")
+        .args([
+            "2.0.0",
+            "--package",
+            "first-missing",
+            "--package",
+            "second-missing",
+        ])
+        .current_dir(&project_root)
+        .assert()
+        .code(0)
+        .stdout_eq(file!["stdout.term.svg"])
+        .stderr_eq(file!["stderr.term.svg"]);
+
+    assert_ui().subset_matches(current_dir!().join("out"), &project_root);
+}

--- a/tests/cargo-set-version/packages_not_found/mod.rs
+++ b/tests/cargo-set-version/packages_not_found/mod.rs
@@ -22,7 +22,7 @@ fn case() {
         ])
         .current_dir(&project_root)
         .assert()
-        .code(0)
+        .code(1)
         .stdout_eq(file!["stdout.term.svg"])
         .stderr_eq(file!["stderr.term.svg"]);
 

--- a/tests/cargo-set-version/packages_not_found/out/Cargo.toml
+++ b/tests/cargo-set-version/packages_not_found/out/Cargo.toml
@@ -1,0 +1,9 @@
+[workspace]
+
+[package]
+name = "sample"
+version = "0.1.0"
+edition = "2015"
+
+[lib]
+path = "dummy.rs"

--- a/tests/cargo-set-version/packages_not_found/stderr.term.svg
+++ b/tests/cargo-set-version/packages_not_found/stderr.term.svg
@@ -1,0 +1,21 @@
+<svg width="740px" height="20px" xmlns="http://www.w3.org/2000/svg">
+  <style>
+    .fg { fill: #AAAAAA }
+    .bg { fill: #000000 }
+    .container {
+      padding: 0 10px;
+      line-height: 18px;
+    }
+    tspan {
+      font: 14px SFMono-Regular, Consolas, Liberation Mono, Menlo, monospace;
+      white-space: pre;
+      line-height: 18px;
+    }
+  </style>
+
+  <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
+
+  <text xml:space="preserve" class="container fg">
+  </text>
+
+</svg>

--- a/tests/cargo-set-version/packages_not_found/stderr.term.svg
+++ b/tests/cargo-set-version/packages_not_found/stderr.term.svg
@@ -1,4 +1,4 @@
-<svg width="740px" height="20px" xmlns="http://www.w3.org/2000/svg">
+<svg width="740px" height="56px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
     .bg { fill: #000000 }
@@ -16,6 +16,10 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
+    <tspan x="10px" y="28px"><tspan>Error: packages first-missing, second-missing don't exist</tspan>
+</tspan>
+    <tspan x="10px" y="46px">
+</tspan>
   </text>
 
 </svg>

--- a/tests/cargo-set-version/packages_not_found/stdout.term.svg
+++ b/tests/cargo-set-version/packages_not_found/stdout.term.svg
@@ -1,0 +1,21 @@
+<svg width="740px" height="20px" xmlns="http://www.w3.org/2000/svg">
+  <style>
+    .fg { fill: #AAAAAA }
+    .bg { fill: #000000 }
+    .container {
+      padding: 0 10px;
+      line-height: 18px;
+    }
+    tspan {
+      font: 14px SFMono-Regular, Consolas, Liberation Mono, Menlo, monospace;
+      white-space: pre;
+      line-height: 18px;
+    }
+  </style>
+
+  <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
+
+  <text xml:space="preserve" class="container fg">
+  </text>
+
+</svg>


### PR DESCRIPTION
## Summary

- reject explicit package selectors that do not match a workspace member
- validate the complete selection before changing any manifests
- cover single, mixed, multiple, and repeated missing selectors

## Why

A nonexistent `--package` currently exits successfully without doing anything. Mixed valid and invalid selectors can also update part of a workspace before the mistake is noticed.

Closes #888.

## Validation

- `cargo test --locked --all-features`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `cargo fmt --all -- --check`
- built `cargo-set-version` CLI smoke tests for missing and valid selectors