### PR TITLE
fix(upgrade): show the next effective verbosity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ The format is based on [Keep a Changelog].
 <!-- next-header -->
 ## Unreleased - ReleaseDate
 
+### Fixes
+
+- *(upgrade)* Point single-`--verbose` users to `--verbose --verbose` when more dependencies are hidden
+
 ## 0.13.12 - 2026-07-14
 
 ### Fixes

--- a/src/bin/upgrade/upgrade.rs
+++ b/src/bin/upgrade/upgrade.rs
@@ -625,7 +625,12 @@ fn exec(args: UpgradeArgs) -> CargoResult<()> {
                 .or_insert_with(BTreeSet::new)
                 .insert(dep.name);
         }
-        let mut note = "Re-run with `--verbose` to show more dependencies".to_owned();
+        let verbose_flags = if args.is_verbose() {
+            "`--verbose --verbose`"
+        } else {
+            "`--verbose`"
+        };
+        let mut note = format!("Re-run with {verbose_flags} to show more dependencies");
         for (reason, deps) in categorize {
             use std::fmt::Write;
             write!(&mut note, "\n  {reason}: ")?;

--- a/tests/cargo-upgrade/main.rs
+++ b/tests/cargo-upgrade/main.rs
@@ -33,6 +33,7 @@ mod upgrade_all;
 mod upgrade_everything;
 mod upgrade_renamed;
 mod upgrade_verbose;
+mod upgrade_verbose_hint;
 mod upgrade_workspace;
 mod virtual_manifest;
 mod workspace_inheritance;

--- a/tests/cargo-upgrade/upgrade_verbose_hint/in/Cargo.toml
+++ b/tests/cargo-upgrade/upgrade_verbose_hint/in/Cargo.toml
@@ -1,0 +1,47 @@
+[package]
+name = "None"
+version = "0.1.0"
+
+[lib]
+path = "dummy.rs"
+
+[dependencies]
+docopt = "0.4"
+pad = "0.1"
+serde_json = "20.0"
+syn = { version = "0.1.1", default-features = false }
+tar = { version = "0.4", default-features = false }
+ftp = "20.0.0"
+te = { package = "toml_edit", version = "0.1.1" }
+
+[dependencies.semver]
+version = "0.2"
+
+[dependencies.rn]
+package = "renamed"
+version = "0.1"
+
+[dev-dependencies]
+assert_cli = "0.2.0"
+tempdir = "0.1"
+
+[build-dependencies]
+serde = { version = "1.0", path = "../serde" }
+
+[target.'cfg(unix)'.dependencies]
+openssl = "0.4"
+
+[target."windows.json"]
+# let's make it an inline table
+dependencies = { rget = "0.4.0" }
+
+[target.'cfg(target_arch = "x86_64")'.dev-dependencies]
+geo = { version = "0.2.0", default-features = false }
+
+[target.foo.build-dependencies]
+ftp = "0.2.0"
+
+[features]
+default = []
+test-external-apis = []
+unstable = []

--- a/tests/cargo-upgrade/upgrade_verbose_hint/mod.rs
+++ b/tests/cargo-upgrade/upgrade_verbose_hint/mod.rs
@@ -1,0 +1,28 @@
+use cargo_test_support::Project;
+use cargo_test_support::compare::assert_ui;
+use cargo_test_support::file;
+use cargo_test_support::prelude::*;
+
+use crate::CargoCommand;
+use cargo_test_support::current_dir;
+
+#[cargo_test]
+fn case() {
+    cargo_test_support::registry::init();
+    crate::add_everything_registry_packages(false);
+    crate::add_git_registry_packages();
+    let project = Project::from_template(current_dir!().join("in"));
+    let project_root = project.root();
+    let cwd = &project_root;
+
+    snapbox::cmd::Command::cargo_ui()
+        .arg("upgrade")
+        .args(["--pinned", "--incompatible", "--verbose"])
+        .current_dir(cwd)
+        .assert()
+        .success()
+        .stdout_eq(file!["stdout.term.svg"])
+        .stderr_eq(file!["stderr.term.svg"]);
+
+    assert_ui().subset_matches(current_dir!().join("out"), &project_root);
+}

--- a/tests/cargo-upgrade/upgrade_verbose_hint/out/Cargo.toml
+++ b/tests/cargo-upgrade/upgrade_verbose_hint/out/Cargo.toml
@@ -1,0 +1,47 @@
+[package]
+name = "None"
+version = "0.1.0"
+
+[lib]
+path = "dummy.rs"
+
+[dependencies]
+docopt = "99999.0"
+pad = "99999.0"
+serde_json = "99999.0"
+syn = { version = "99999.0.0", default-features = false }
+tar = { version = "99999.0", default-features = false }
+ftp = "99999.0.0"
+te = { package = "toml_edit", version = "99999.0.0" }
+
+[dependencies.semver]
+version = "99999.0"
+
+[dependencies.rn]
+package = "renamed"
+version = "99999.0"
+
+[dev-dependencies]
+assert_cli = "99999.0.0"
+tempdir = "99999.0"
+
+[build-dependencies]
+serde = { version = "1.0", path = "../serde" }
+
+[target.'cfg(unix)'.dependencies]
+openssl = "99999.0"
+
+[target."windows.json"]
+# let's make it an inline table
+dependencies = { rget = "99999.0.0" }
+
+[target.'cfg(target_arch = "x86_64")'.dev-dependencies]
+geo = { version = "99999.0.0", default-features = false }
+
+[target.foo.build-dependencies]
+ftp = "99999.0.0"
+
+[features]
+default = []
+test-external-apis = []
+unstable = []

--- a/tests/cargo-upgrade/upgrade_verbose_hint/stderr.term.svg
+++ b/tests/cargo-upgrade/upgrade_verbose_hint/stderr.term.svg
@@ -1,0 +1,33 @@
+<svg width="740px" height="128px" xmlns="http://www.w3.org/2000/svg">
+  <style>
+    .fg { fill: #AAAAAA }
+    .bg { background: #000000 }
+    .container {
+      padding: 0 10px;
+      line-height: 18px;
+    }
+    tspan {
+      font: 14px SFMono-Regular, Consolas, Liberation Mono, Menlo, monospace;
+      white-space: pre;
+      line-height: 18px;
+    }
+  </style>
+
+  <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
+
+  <text xml:space="preserve" class="container fg">
+    <tspan x="10px" y="28px"><tspan>    Checking None's dependencies</tspan>
+</tspan>
+    <tspan x="10px" y="46px"><tspan>   Upgrading recursive dependencies</tspan>
+</tspan>
+    <tspan x="10px" y="64px"><tspan>     Locking 0 packages to latest compatible versions</tspan>
+</tspan>
+    <tspan x="10px" y="82px"><tspan>note: Re-run with `--verbose --verbose` to show more dependencies</tspan>
+</tspan>
+    <tspan x="10px" y="100px"><tspan>  latest: serde</tspan>
+</tspan>
+    <tspan x="10px" y="118px">
+</tspan>
+  </text>
+
+</svg>

--- a/tests/cargo-upgrade/upgrade_verbose_hint/stdout.term.svg
+++ b/tests/cargo-upgrade/upgrade_verbose_hint/stdout.term.svg
@@ -1,0 +1,57 @@
+<svg width="740px" height="344px" xmlns="http://www.w3.org/2000/svg">
+  <style>
+    .fg { fill: #AAAAAA }
+    .bg { background: #000000 }
+    .container {
+      padding: 0 10px;
+      line-height: 18px;
+    }
+    tspan {
+      font: 14px SFMono-Regular, Consolas, Liberation Mono, Menlo, monospace;
+      white-space: pre;
+      line-height: 18px;
+    }
+  </style>
+
+  <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
+
+  <text xml:space="preserve" class="container fg">
+    <tspan x="10px" y="28px"><tspan>name           old req compatible latest    new req  </tspan>
+</tspan>
+    <tspan x="10px" y="46px"><tspan>====           ======= ========== ======    =======  </tspan>
+</tspan>
+    <tspan x="10px" y="64px"><tspan>docopt         0.4     0.4.1      99999.0.0 99999.0  </tspan>
+</tspan>
+    <tspan x="10px" y="82px"><tspan>pad            0.1     0.1.1      99999.0.0 99999.0  </tspan>
+</tspan>
+    <tspan x="10px" y="100px"><tspan>serde_json     20.0    20.0.0     99999.0.0 99999.0  </tspan>
+</tspan>
+    <tspan x="10px" y="118px"><tspan>syn            0.1.1   0.1.1      99999.0.0 99999.0.0</tspan>
+</tspan>
+    <tspan x="10px" y="136px"><tspan>tar            0.4     0.4.1      99999.0.0 99999.0  </tspan>
+</tspan>
+    <tspan x="10px" y="154px"><tspan>ftp            20.0.0  20.0.0     99999.0.0 99999.0.0</tspan>
+</tspan>
+    <tspan x="10px" y="172px"><tspan>toml_edit (te) 0.1.1   0.1.1      99999.0.0 99999.0.0</tspan>
+</tspan>
+    <tspan x="10px" y="190px"><tspan>semver         0.2     0.2.3      99999.0.0 99999.0  </tspan>
+</tspan>
+    <tspan x="10px" y="208px"><tspan>renamed (rn)   0.1     0.1.1      99999.0.0 99999.0  </tspan>
+</tspan>
+    <tspan x="10px" y="226px"><tspan>assert_cli     0.2.0   0.2.3      99999.0.0 99999.0.0</tspan>
+</tspan>
+    <tspan x="10px" y="244px"><tspan>tempdir        0.1     0.1.1      99999.0.0 99999.0  </tspan>
+</tspan>
+    <tspan x="10px" y="262px"><tspan>openssl        0.4     0.4.1      99999.0.0 99999.0  </tspan>
+</tspan>
+    <tspan x="10px" y="280px"><tspan>rget           0.4.0   0.4.1      99999.0.0 99999.0.0</tspan>
+</tspan>
+    <tspan x="10px" y="298px"><tspan>geo            0.2.0   0.2.3      99999.0.0 99999.0.0</tspan>
+</tspan>
+    <tspan x="10px" y="316px"><tspan>ftp            0.2.0   0.2.3      99999.0.0 99999.0.0</tspan>
+</tspan>
+    <tspan x="10px" y="334px">
+</tspan>
+  </text>
+
+</svg>


### PR DESCRIPTION
## Summary

- point single-`--verbose` users to `--verbose --verbose` when dependencies are still hidden
- preserve the existing default hint and three-level filtering behavior
- cover both hint levels with CLI snapshots

## Why

The first `--verbose` level intentionally shows upgradeable dependencies, but the existing hint still told users to rerun with the same flag. The next command now reflects the level needed to show all dependencies.

Closes #867.

## Validation

- `cargo test --locked --test cargo-upgrade upgrade_everything -- --nocapture` — passed
- `cargo test --locked --all-features` — passed
- `cargo fmt --all -- --check` — passed
- `cargo clippy --locked --all-targets --all-features -- -D warnings` — passed
